### PR TITLE
Epic cosmos data 2025

### DIFF
--- a/data/epic/raw/staging/D01a_OPIOID_EDvisits_CountyAL_KS_Year_Age.csv
+++ b/data/epic/raw/staging/D01a_OPIOID_EDvisits_CountyAL_KS_Year_Age.csv
@@ -1,0 +1,11264 @@
+﻿Session Title,"Opioid Overdoses in ED, AL-KS",,
+Session Description,ED encountersAlabama-Kansas pts with ED diagnosis opioid overdose,,
+Session ID,2731206,,
+Data Model,ED Encounters,,
+Population Base,All ED Encounters,,
+Population Criteria Filters: These criteria are a summary and do not fully reflect the content of the exported session.,ED Diagnoses: EDG ICD-10 OPIOID OVERDOSE,"State of Residence (U.S.): Alaska, Alabama, Arizona, Arkansas, California, Colorado, Connecticut, Delaware, Florida, Georgia, Hawaii, Idaho, Illinois, Indiana, Iowa, Kansas",
+Session Date Range,1/1/2023 - 7/17/2025 (Based On Arrival Date),,
+Measure,Number of ED Encounters,,
+Export User,Stephanie Perniciaro,,
+Date of Export,8/8/2025,,
+,,,
+,,,
+,,,Number of ED Encounters
+Year,County of Residence,Age at Time of Visit,
+Jan 1 – Dec 31 2023,"COOK, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,472
+,,≥ 45 and < 65 Years,518
+,,65 Years or more,186
+,,No value,10 or fewer
+,,Total,1183
+,"MARION, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,563
+,,≥ 45 and < 65 Years,234
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,843
+,"DENVER, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,444
+,,≥ 45 and < 65 Years,128
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,594
+,"NEW HAVEN, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,338
+,,≥ 45 and < 65 Years,265
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,660
+,"SAN DIEGO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,288
+,,≥ 45 and < 65 Years,100
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,437
+,"ORANGE, FL",Less than 18 Years,12
+,,≥ 18 and < 45 Years,350
+,,≥ 45 and < 65 Years,183
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,575
+,"MARICOPA, AZ",Less than 18 Years,11
+,,≥ 18 and < 45 Years,258
+,,≥ 45 and < 65 Years,61
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,355
+,"LEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,373
+,,≥ 45 and < 65 Years,188
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,614
+,"HARTFORD, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,194
+,,≥ 45 and < 65 Years,153
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,373
+,"FRESNO, CA",Less than 18 Years,12
+,,≥ 18 and < 45 Years,233
+,,≥ 45 and < 65 Years,98
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,370
+,"DUVAL, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,244
+,,≥ 45 and < 65 Years,127
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,433
+,"ALAMEDA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,232
+,,≥ 45 and < 65 Years,98
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,351
+,"FAIRFIELD, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,137
+,,≥ 45 and < 65 Years,126
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,294
+,"SAN FRANCISCO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,176
+,,≥ 45 and < 65 Years,97
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,291
+,"HILLSBOROUGH, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,198
+,,≥ 45 and < 65 Years,95
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,325
+,"BROWARD, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,162
+,,≥ 45 and < 65 Years,77
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,273
+,"LAKE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,152
+,,≥ 45 and < 65 Years,86
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,275
+,"KENT, DE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,128
+,,≥ 45 and < 65 Years,45
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,188
+,"NEW CASTLE, DE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,77
+,,≥ 45 and < 65 Years,50
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,136
+,"VOLUSIA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,129
+,,≥ 45 and < 65 Years,93
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,252
+,"NEW LONDON, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,124
+,,≥ 45 and < 65 Years,65
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,202
+,"WINNEBAGO, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,108
+,,≥ 45 and < 65 Years,85
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,214
+,"OSCEOLA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,129
+,,≥ 45 and < 65 Years,43
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,188
+,"SAN BERNARDINO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,142
+,,≥ 45 and < 65 Years,37
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,200
+,"MARION, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,114
+,,≥ 45 and < 65 Years,61
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,188
+,"EL PASO, CO",Less than 18 Years,12
+,,≥ 18 and < 45 Years,107
+,,≥ 45 and < 65 Years,25
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,158
+,"FULTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,81
+,,≥ 45 and < 65 Years,55
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,169
+,"PINELLAS, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,113
+,,≥ 45 and < 65 Years,60
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,195
+,"COBB, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,103
+,,≥ 45 and < 65 Years,46
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,168
+,"ARAPAHOE, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,81
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,108
+,"RIVERSIDE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,130
+,,≥ 45 and < 65 Years,33
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,183
+,"HONOLULU, HI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,78
+,,≥ 45 and < 65 Years,42
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,140
+,"PASCO, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,91
+,,≥ 45 and < 65 Years,44
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,152
+,"ADA, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,120
+,,≥ 45 and < 65 Years,25
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,160
+,"SUSSEX, DE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,80
+,,≥ 45 and < 65 Years,48
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,137
+,"DEKALB, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,71
+,,≥ 45 and < 65 Years,29
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,120
+,"ADAMS, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,73
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,93
+,"LAKE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,74
+,,≥ 45 and < 65 Years,45
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,138
+,"PULASKI, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,90
+,,≥ 45 and < 65 Years,35
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,140
+,"SEMINOLE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,72
+,,≥ 45 and < 65 Years,44
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,130
+,"MIDDLESEX, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,52
+,,≥ 45 and < 65 Years,47
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,109
+,"ORANGE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,45
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,63
+,"PUEBLO, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,65
+,,≥ 45 and < 65 Years,32
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,117
+,"HALL, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,78
+,,≥ 45 and < 65 Years,22
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,114
+,"POLK, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,95
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,126
+,"JEFFERSON, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,63
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,83
+,"DUPAGE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,47
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,74
+,"CHAMPAIGN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,39
+,,≥ 45 and < 65 Years,33
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,82
+,"LARIMER, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,58
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,71
+,"WYANDOTTE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,54
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,78
+,"POLK, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,48
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,74
+,"PEORIA, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,30
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,79
+,"LAKE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,60
+,,≥ 45 and < 65 Years,25
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,93
+,"LINN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,33
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,62
+,"WAYNE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,46
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,69
+,"BOULDER, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,42
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,58
+,"BARTHOLOMEW, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,53
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,72
+,"GWINNETT, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,51
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,70
+,"JOHNSON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,45
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,61
+,"PAULDING, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,44
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,70
+,"INDIAN RIVER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,43
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,68
+,"BARROW, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,40
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,64
+,"CANYON, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,44
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,60
+,"COLLIER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,72
+,"ALACHUA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"JOHNSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,33
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,50
+,"NASSAU, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,34
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,62
+,"ST JOSEPH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,35
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"DOUGLAS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,33
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,56
+,"CONTRA COSTA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,44
+,"SHAWNEE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,52
+,"SAINT LUCIE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,41
+,"SUMTER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,46
+,"SANGAMON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,47
+,"VANDERBURGH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,35
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,55
+,"WINDHAM, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,52
+,"CLARKE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,46
+,"MADISON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"KANE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"SANTA CLARA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"WELD, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"LITCHFIELD, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,35
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,49
+,"VERMILION, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,54
+,"SEBASTIAN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"TAZEWELL, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"WILL, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"LA SALLE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"FLOYD, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"LOS ANGELES, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"CLARK, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"MOBILE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,36
+,"FLAGLER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"WHITFIELD, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"ROCK ISLAND, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"KAUAI, HI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"LOWNDES, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"SPALDING, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"PINAL, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"PALM BEACH, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"BANNOCK, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"CLAY, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"HABERSHAM, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"HAWAII, HI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"MADERA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"DOUGLAS, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"FAYETTE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"HIGHLANDS, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"MCLEAN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"HANCOCK, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"MADISON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"MIAMI-DADE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"SAN MATEO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"TOLLAND, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"TWIN FALLS, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"ALLEN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CHEROKEE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"PORTER, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"MACON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"SAINT CLAIR, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"TROUP, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"BALDWIN, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"BOONE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"SAINT JOHNS, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"HERNANDO, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"MURRAY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"CRAWFORD, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"HOWARD, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"MCHENRY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CITRUS, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BREVARD, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CRITTENDEN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"JACKSON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"KNOX, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"GORDON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDRICKS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"RICHMOND, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAULKNER, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"MARSHALL, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"KENDALL, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"WOODBURY, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"LONOKE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"FORSYTH, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WALKER, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"FLOYD, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BARTOW, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CATOOSA, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLACK HAWK, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CHARLOTTE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BUTTS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"LUMPKIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEVY, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MESA, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"SALINE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARRICK, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"HOUSTON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"HARRISON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HENRY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIVINGSTON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SARASOTA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BANKS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"BOND, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUREAU, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CARROLL, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAYTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUBUQUE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"GREENE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SACRAMENTO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELKHART, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JOAQUIN, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELMORE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HART, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAYETTE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YAVAPAI, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MANATEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COWETA, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAIGHEAD, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEARBORN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEARY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOLANO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELAWARE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KOSCIUSKO, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGLE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODFORD, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GIBSON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEPHENS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BINGHAM, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEAVENWORTH, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKDALE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STANISLAUS, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEPHENSON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TULARE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BERRIEN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRADFORD, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWSON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EFFINGHAM, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOT SPRING, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCED, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MUSCATINE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSAGE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POINSETT, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMBOLDT, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KERN, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MISSISSIPPI, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OCONEE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROUTT, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANTA CRUZ, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEDGWICK, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOMFIELD, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COCHISE, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLES, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DONIPHAN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREMONT, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEM, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILA, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRUNDY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TELLER, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIPTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VIGO, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITLEY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAKER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAY, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COCONINO, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELBERT, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARALSON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KANKAKEE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA PORTE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LATAH, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIMA, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLUMAS, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POSEY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTAWATTAMIE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARKANSAS, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOKS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAMBERS, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHATHAM, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHOCTAW, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINCH, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOK, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARLAND, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GENEVA, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILCHRIST, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDRY, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUNTINGTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IROQUOIS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEROME, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINGS, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMAR, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOBLE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKEECHOBEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PICKENS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIPLEY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SONOMA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STARKE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIBB, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASSIA, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHATTOOGA, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALLAS, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DES MOINES, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DIXIE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGHERTY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EFFINGHAM, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRADY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HEARD, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMAR, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANIER, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACOUPIN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARIN, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAUI, HI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MUSCOGEE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGLETHORPE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIATT, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLYMOUTH, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POWER, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RABUN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHLAND, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YUMA, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALAMOSA, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANCHORAGE, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APACHE, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARTON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMDEN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEBURNE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DADE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DESOTO, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EL DORADO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELBERT, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GUTHRIE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JAY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JERSEY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LASSEN, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARIPOSA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASSAC, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIAMI, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIAMI, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOFFAT, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OHIO, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANTA BARBARA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STARK, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLIVAN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIPPECANOE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VALLEY, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN BUREN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VENTURA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAPELLO, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDERSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BALDWIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARBOUR, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAXTER, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOISE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BONNEVILLE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOUNDARY, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRADLEY, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BREMER, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRYAN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURKE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALAVERAS, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHRISTIAN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONWAY, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUBOIS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EARLY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESCAMBIA, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESCAMBIA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FANNIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILMER, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOODING, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAHAM, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRIS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDERSON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JENNINGS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JO DAVIESS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNEAU, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENAI PENINSULA, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KOOTENAI, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAHASKA, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLS, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINIDOKA, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOHAVE, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTEREY, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NAVAJO, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEVADA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEZ PERCE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTH SLOPE, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKALOOSA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTERO, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWEN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARK, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PITKIN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLACER, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POPE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POWESHIEK, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RILEY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIO GRANDE, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALINE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANTA ROSA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIOUX, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPENCER, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THOMAS, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIFT, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUOLUMNE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WABASH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WABAUNSEE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITESIDE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALEXANDER, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APPANOOSE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APPLING, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATCHISON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BACON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOURBON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTTE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARIBOU, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CEDAR, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CERRO GORDO, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAYTON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEBURNE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLBERT, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONEJOS, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COVINGTON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRISP, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROSS, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROWLEY, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CULLMAN, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEL NORTE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELTA, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DESHA, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKINSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOOLY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAGLE, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAIRBANKS NORTH STAR, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FINNEY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FORD, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOUNTAIN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GADSDEN, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARFIELD, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILPIN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLADES, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLYNN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAND, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENWOOD, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRUNDY, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GUNNISON, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOLMES, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMBOLDT, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IMPERIAL, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRWIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEOKUK, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIT CARSON, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA PAZ, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA PLATA, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAS ANIMAS, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIMESTONE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDONOUGH, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENARD, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MODOC, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTROSE, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRIS, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NAPA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OBRIEN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONEIDA, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OUACHITA, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARKE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHILLIPS, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PICKENS, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTAWATOMIE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRAIRIE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRATT, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSH, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSSELL, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CLAIR, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT FRANCIS, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALINE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN LUIS OBISPO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN MIGUEL, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHARP, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHASTA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEUBEN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUTTER, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUWANNEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWITZERLAND, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAMA, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TATTNALL, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TEHAMA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUSCALOOSA, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VERMILLION, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALKER, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WELLS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKES, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WRIGHT, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YELL, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,13
+,,≥ 18 and < 45 Years,527
+,,≥ 45 and < 65 Years,311
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,943
+,Total,Less than 18 Years,321
+,,≥ 18 and < 45 Years,11004
+,,≥ 45 and < 65 Years,5315
+,,65 Years or more,1601
+,,No value,10 or fewer
+,,Total,18241
+Jan 1 – Dec 31 2024,"COOK, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,365
+,,≥ 45 and < 65 Years,479
+,,65 Years or more,226
+,,No value,10 or fewer
+,,Total,1075
+,"MARION, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,444
+,,≥ 45 and < 65 Years,163
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,653
+,"DENVER, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,389
+,,≥ 45 and < 65 Years,95
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,509
+,"NEW HAVEN, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,215
+,,≥ 45 and < 65 Years,233
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,500
+,"SAN DIEGO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,330
+,,≥ 45 and < 65 Years,133
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,524
+,"ORANGE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,208
+,,≥ 45 and < 65 Years,137
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,390
+,"MARICOPA, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,237
+,,≥ 45 and < 65 Years,84
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,354
+,"LEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,183
+,,≥ 45 and < 65 Years,127
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,351
+,"HARTFORD, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,154
+,,≥ 45 and < 65 Years,105
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,291
+,"FRESNO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,240
+,,≥ 45 and < 65 Years,83
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,352
+,"DUVAL, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,158
+,,≥ 45 and < 65 Years,90
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,296
+,"ALAMEDA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,160
+,,≥ 45 and < 65 Years,91
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,271
+,"FAIRFIELD, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,125
+,,≥ 45 and < 65 Years,105
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,267
+,"SAN FRANCISCO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,133
+,,≥ 45 and < 65 Years,86
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,244
+,"HILLSBOROUGH, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,100
+,,≥ 45 and < 65 Years,65
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,184
+,"BROWARD, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,118
+,,≥ 45 and < 65 Years,64
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,215
+,"LAKE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,110
+,,≥ 45 and < 65 Years,54
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,185
+,"KENT, DE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,91
+,,≥ 45 and < 65 Years,53
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,155
+,"NEW CASTLE, DE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,135
+,,≥ 45 and < 65 Years,72
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,221
+,"VOLUSIA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,75
+,,≥ 45 and < 65 Years,54
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,150
+,"NEW LONDON, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,94
+,,≥ 45 and < 65 Years,43
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,154
+,"WINNEBAGO, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,63
+,,≥ 45 and < 65 Years,45
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,130
+,"OSCEOLA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,97
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,124
+,"SAN BERNARDINO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,81
+,,≥ 45 and < 65 Years,29
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,125
+,"MARION, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,77
+,,≥ 45 and < 65 Years,47
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,135
+,"EL PASO, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,78
+,,≥ 45 and < 65 Years,26
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,127
+,"FULTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,70
+,,≥ 45 and < 65 Years,32
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,122
+,"PINELLAS, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,62
+,,≥ 45 and < 65 Years,35
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,111
+,"COBB, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,73
+,,≥ 45 and < 65 Years,29
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,119
+,"ARAPAHOE, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,84
+,,≥ 45 and < 65 Years,25
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,118
+,"RIVERSIDE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,65
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,95
+,"HONOLULU, HI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,47
+,,≥ 45 and < 65 Years,37
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,122
+,"PASCO, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,53
+,,≥ 45 and < 65 Years,41
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,106
+,"ADA, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,62
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,104
+,"SUSSEX, DE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,76
+,,≥ 45 and < 65 Years,29
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,108
+,"DEKALB, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,56
+,,≥ 45 and < 65 Years,34
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,114
+,"ADAMS, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,79
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,98
+,"LAKE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,47
+,,≥ 45 and < 65 Years,27
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,81
+,"PULASKI, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,55
+,"SEMINOLE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,37
+,,≥ 45 and < 65 Years,28
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,75
+,"MIDDLESEX, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,48
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,79
+,"ORANGE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,73
+,,≥ 45 and < 65 Years,27
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,117
+,"PUEBLO, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,65
+,"HALL, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,39
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,72
+,"POLK, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,43
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,55
+,"JEFFERSON, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,53
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,68
+,"DUPAGE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,46
+,,≥ 45 and < 65 Years,25
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,75
+,"CHAMPAIGN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,34
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,76
+,"LARIMER, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,42
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,65
+,"WYANDOTTE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,40
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,69
+,"POLK, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,62
+,"PEORIA, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,50
+,"LAKE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,42
+,"LINN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,35
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,57
+,"WAYNE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,54
+,"BOULDER, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,34
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,55
+,"BARTHOLOMEW, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,42
+,"GWINNETT, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,34
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,51
+,"JOHNSON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,41
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,50
+,"PAULDING, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"INDIAN RIVER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,43
+,"BARROW, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"CANYON, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"COLLIER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"ALACHUA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,51
+,"JOHNSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"NASSAU, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,36
+,"ST JOSEPH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,38
+,"DOUGLAS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,41
+,"CONTRA COSTA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,46
+,"SHAWNEE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"SAINT LUCIE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,51
+,"SUMTER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,39
+,"SANGAMON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,22
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,44
+,"VANDERBURGH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"WINDHAM, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"CLARKE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,41
+,"MADISON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"KANE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"SANTA CLARA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,36
+,"WELD, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"LITCHFIELD, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"VERMILION, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"SEBASTIAN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"TAZEWELL, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"WILL, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"LA SALLE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"FLOYD, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"LOS ANGELES, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"CLARK, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"MOBILE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"FLAGLER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"WHITFIELD, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"HAMILTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"ROCK ISLAND, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"KAUAI, HI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"LOWNDES, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"SPALDING, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"PINAL, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"PALM BEACH, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"BANNOCK, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"CLAY, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"HABERSHAM, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"HAWAII, HI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"MADERA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"DOUGLAS, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"FAYETTE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"HIGHLANDS, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"MCLEAN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"HANCOCK, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MADISON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIAMI-DADE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"SAN MATEO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"TOLLAND, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"TWIN FALLS, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"ALLEN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"CHEROKEE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"PORTER, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"MACON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"SAINT CLAIR, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"TROUP, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"BALDWIN, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"BOONE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"SAINT JOHNS, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"HERNANDO, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MURRAY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"WHITE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"HOWARD, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MCHENRY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"CITRUS, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BREVARD, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CRITTENDEN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"KNOX, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"GORDON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"HENDRICKS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"RICHMOND, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAULKNER, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENDALL, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODBURY, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"LONOKE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"FORSYTH, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"WALKER, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"BARTOW, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CATOOSA, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLACK HAWK, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLOTTE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTTS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUMPKIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEVY, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MESA, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALINE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARRICK, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIVINGSTON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SARASOTA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BANKS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOND, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUREAU, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAYTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUBUQUE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SACRAMENTO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELKHART, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JOAQUIN, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELMORE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HART, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAYETTE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YAVAPAI, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MANATEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COWETA, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAIGHEAD, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEARBORN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEARY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOLANO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELAWARE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KOSCIUSKO, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGLE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODFORD, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GIBSON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEPHENS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BINGHAM, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEAVENWORTH, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKDALE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STANISLAUS, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEPHENSON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TULARE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BERRIEN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRADFORD, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWSON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EFFINGHAM, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOT SPRING, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCED, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MUSCATINE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSAGE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POINSETT, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMBOLDT, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KERN, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MISSISSIPPI, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OCONEE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROUTT, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANTA CRUZ, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEDGWICK, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOMFIELD, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COCHISE, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLES, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DONIPHAN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREMONT, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEM, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILA, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRUNDY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TELLER, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIPTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VIGO, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITLEY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAKER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAY, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COCONINO, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELBERT, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARALSON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KANKAKEE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA PORTE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LATAH, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIMA, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLUMAS, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POSEY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTAWATTAMIE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARKANSAS, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOKS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAMBERS, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHATHAM, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHOCTAW, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINCH, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOK, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARLAND, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GENEVA, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILCHRIST, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDRY, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUNTINGTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IROQUOIS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEROME, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINGS, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMAR, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOBLE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKEECHOBEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PICKENS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIPLEY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SONOMA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STARKE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIBB, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASSIA, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHATTOOGA, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALLAS, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DES MOINES, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DIXIE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGHERTY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EFFINGHAM, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRADY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HEARD, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMAR, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANIER, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACOUPIN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARIN, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAUI, HI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MUSCOGEE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGLETHORPE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIATT, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLYMOUTH, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POWER, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RABUN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHLAND, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YUMA, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALAMOSA, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANCHORAGE, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APACHE, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARTON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMDEN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEBURNE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DADE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DESOTO, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EL DORADO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELBERT, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GUTHRIE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JAY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JERSEY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LASSEN, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARIPOSA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASSAC, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIAMI, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIAMI, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOFFAT, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OHIO, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANTA BARBARA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STARK, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLIVAN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIPPECANOE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VALLEY, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN BUREN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VENTURA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAPELLO, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDERSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BALDWIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARBOUR, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAXTER, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOISE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BONNEVILLE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOUNDARY, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRADLEY, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BREMER, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRYAN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURKE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALAVERAS, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHRISTIAN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONWAY, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUBOIS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EARLY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESCAMBIA, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESCAMBIA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FANNIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILMER, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOODING, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAHAM, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRIS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDERSON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JENNINGS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JO DAVIESS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNEAU, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENAI PENINSULA, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KOOTENAI, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAHASKA, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLS, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINIDOKA, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOHAVE, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTEREY, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NAVAJO, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEVADA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEZ PERCE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTH SLOPE, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKALOOSA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTERO, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWEN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARK, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PITKIN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLACER, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POPE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POWESHIEK, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RILEY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIO GRANDE, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALINE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANTA ROSA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIOUX, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPENCER, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THOMAS, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIFT, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUOLUMNE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WABASH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WABAUNSEE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITESIDE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALEXANDER, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APPANOOSE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APPLING, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATCHISON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BACON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOURBON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTTE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARIBOU, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CEDAR, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CERRO GORDO, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAYTON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEBURNE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLBERT, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONEJOS, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COVINGTON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRISP, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROSS, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROWLEY, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CULLMAN, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEL NORTE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELTA, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DESHA, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKINSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOOLY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAGLE, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAIRBANKS NORTH STAR, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FINNEY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FORD, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOUNTAIN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GADSDEN, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARFIELD, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILPIN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLADES, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLYNN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAND, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENWOOD, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRUNDY, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GUNNISON, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOLMES, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMBOLDT, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IMPERIAL, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRWIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEOKUK, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIT CARSON, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA PAZ, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA PLATA, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAS ANIMAS, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIMESTONE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDONOUGH, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENARD, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MODOC, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTROSE, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRIS, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NAPA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OBRIEN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONEIDA, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OUACHITA, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARKE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHILLIPS, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PICKENS, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTAWATOMIE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRAIRIE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRATT, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSH, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSSELL, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CLAIR, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT FRANCIS, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALINE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN LUIS OBISPO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN MIGUEL, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHARP, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHASTA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEUBEN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUTTER, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUWANNEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWITZERLAND, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAMA, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TATTNALL, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TEHAMA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUSCALOOSA, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VERMILLION, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALKER, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WELLS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKES, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WRIGHT, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YELL, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,347
+,,≥ 45 and < 65 Years,228
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,635
+,Total,Less than 18 Years,217
+,,≥ 18 and < 45 Years,8138
+,,≥ 45 and < 65 Years,4260
+,,65 Years or more,1534
+,,No value,10 or fewer
+,,Total,14149
+Jan 1 – Jul 17 2025,"COOK, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,179
+,,≥ 45 and < 65 Years,256
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,508
+,"MARION, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,215
+,,≥ 45 and < 65 Years,82
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,314
+,"DENVER, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,352
+,,≥ 45 and < 65 Years,97
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,472
+,"NEW HAVEN, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,145
+,,≥ 45 and < 65 Years,130
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,307
+,"SAN DIEGO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,180
+,,≥ 45 and < 65 Years,73
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,293
+,"ORANGE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,84
+,,≥ 45 and < 65 Years,58
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,171
+,"MARICOPA, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,281
+,,≥ 45 and < 65 Years,86
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,387
+,"LEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,55
+,,≥ 45 and < 65 Years,27
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,96
+,"HARTFORD, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,127
+,,≥ 45 and < 65 Years,163
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,325
+,"FRESNO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,116
+,,≥ 45 and < 65 Years,53
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,186
+,"DUVAL, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,58
+,,≥ 45 and < 65 Years,34
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,112
+,"ALAMEDA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,76
+,,≥ 45 and < 65 Years,44
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,137
+,"FAIRFIELD, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,48
+,,≥ 45 and < 65 Years,51
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,114
+,"SAN FRANCISCO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,66
+,,≥ 45 and < 65 Years,48
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,126
+,"HILLSBOROUGH, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,67
+,,≥ 45 and < 65 Years,28
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,104
+,"BROWARD, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,54
+,,≥ 45 and < 65 Years,27
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,93
+,"LAKE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,65
+,"KENT, DE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,91
+,,≥ 45 and < 65 Years,47
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,145
+,"NEW CASTLE, DE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,66
+,,≥ 45 and < 65 Years,50
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,124
+,"VOLUSIA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,34
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,66
+,"NEW LONDON, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,63
+,,≥ 45 and < 65 Years,34
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,105
+,"WINNEBAGO, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,46
+,"OSCEOLA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,31
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,54
+,"SAN BERNARDINO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,38
+,"MARION, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"EL PASO, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,45
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,74
+,"FULTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,35
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,64
+,"PINELLAS, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,42
+,"COBB, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,56
+,"ARAPAHOE, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,83
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,106
+,"RIVERSIDE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"HONOLULU, HI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,56
+,"PASCO, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"ADA, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,41
+,"SUSSEX, DE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,41
+,"DEKALB, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"ADAMS, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,51
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,65
+,"LAKE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"PULASKI, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"SEMINOLE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"MIDDLESEX, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,44
+,"ORANGE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"PUEBLO, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,36
+,"HALL, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"POLK, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"JEFFERSON, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,50
+,"DUPAGE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"CHAMPAIGN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"LARIMER, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,44
+,"WYANDOTTE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"POLK, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"PEORIA, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"LAKE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LINN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"WAYNE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"BOULDER, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"BARTHOLOMEW, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"GWINNETT, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"JOHNSON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"PAULDING, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"INDIAN RIVER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"BARROW, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CANYON, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"COLLIER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALACHUA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"JOHNSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"NASSAU, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"ST JOSEPH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"DOUGLAS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CONTRA COSTA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"SHAWNEE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"SAINT LUCIE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"SUMTER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"SANGAMON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"VANDERBURGH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"WINDHAM, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"CLARKE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MADISON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"KANE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"SANTA CLARA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WELD, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"LITCHFIELD, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"VERMILION, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEBASTIAN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"TAZEWELL, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"WILL, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"LA SALLE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"FLOYD, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"LOS ANGELES, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CLARK, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"MOBILE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"FLAGLER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"WHITFIELD, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"HAMILTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCK ISLAND, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"KAUAI, HI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOWNDES, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"SPALDING, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"PINAL, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,37
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"MARTIN, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PALM BEACH, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"BANNOCK, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HABERSHAM, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"HAWAII, HI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADERA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"DOUGLAS, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"FAYETTE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HIGHLANDS, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCLEAN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MIAMI-DADE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN MATEO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOLLAND, CT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TWIN FALLS, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PORTER, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CLAIR, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TROUP, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BALDWIN, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT JOHNS, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HERNANDO, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MURRAY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCHENRY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CITRUS, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BREVARD, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRITTENDEN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"JACKSON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GORDON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDRICKS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHMOND, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"FAULKNER, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENDALL, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODBURY, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LONOKE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FORSYTH, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALKER, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARTOW, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CATOOSA, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLACK HAWK, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLOTTE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTTS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUMPKIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEVY, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MESA, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALINE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARRICK, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIVINGSTON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SARASOTA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BANKS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOND, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUREAU, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAYTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUBUQUE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SACRAMENTO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELKHART, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JOAQUIN, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELMORE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HART, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAYETTE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YAVAPAI, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MANATEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COWETA, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAIGHEAD, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEARBORN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEARY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOLANO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELAWARE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KOSCIUSKO, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGLE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODFORD, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GIBSON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEPHENS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BINGHAM, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEAVENWORTH, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKDALE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STANISLAUS, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEPHENSON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TULARE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BERRIEN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRADFORD, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWSON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EFFINGHAM, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOT SPRING, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCED, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MUSCATINE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSAGE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POINSETT, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMBOLDT, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KERN, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MISSISSIPPI, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OCONEE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROUTT, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANTA CRUZ, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEDGWICK, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOMFIELD, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COCHISE, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLES, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DONIPHAN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREMONT, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEM, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILA, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRUNDY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TELLER, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIPTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VIGO, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITLEY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAKER, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAY, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COCONINO, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELBERT, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARALSON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KANKAKEE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA PORTE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LATAH, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIMA, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLUMAS, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POSEY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTAWATTAMIE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARKANSAS, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOKS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAMBERS, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHATHAM, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHOCTAW, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINCH, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOK, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARLAND, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GENEVA, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILCHRIST, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDRY, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUNTINGTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IROQUOIS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEROME, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINGS, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMAR, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOBLE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKEECHOBEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PICKENS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIPLEY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SONOMA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STARKE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIBB, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASSIA, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHATTOOGA, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALLAS, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DES MOINES, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DIXIE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGHERTY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EFFINGHAM, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRADY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HEARD, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMAR, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANIER, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACOUPIN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARIN, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAUI, HI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MUSCOGEE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGLETHORPE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIATT, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLYMOUTH, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POWER, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RABUN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHLAND, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YUMA, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALAMOSA, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANCHORAGE, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APACHE, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARTON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMDEN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEBURNE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DADE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DESOTO, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EL DORADO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELBERT, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GUTHRIE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JAY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JERSEY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LASSEN, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARIPOSA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASSAC, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIAMI, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIAMI, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOFFAT, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OHIO, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANTA BARBARA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STARK, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLIVAN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIPPECANOE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VALLEY, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN BUREN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VENTURA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAPELLO, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDERSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BALDWIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARBOUR, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAXTER, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOISE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BONNEVILLE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOUNDARY, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRADLEY, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BREMER, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRYAN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURKE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALAVERAS, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLTON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHRISTIAN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONWAY, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUBOIS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EARLY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESCAMBIA, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESCAMBIA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FANNIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILMER, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOODING, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAHAM, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRIS, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDERSON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JENNINGS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JO DAVIESS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNEAU, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENAI PENINSULA, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KOOTENAI, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAHASKA, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLS, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINIDOKA, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOHAVE, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTEREY, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NAVAJO, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEVADA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEZ PERCE, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTH SLOPE, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKALOOSA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTERO, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWEN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARK, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PITKIN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLACER, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POPE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POWESHIEK, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RILEY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIO GRANDE, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALINE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANTA ROSA, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIOUX, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPENCER, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THOMAS, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIFT, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUOLUMNE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WABASH, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WABAUNSEE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARE, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITESIDE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALEXANDER, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APPANOOSE, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APPLING, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATCHISON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BACON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOURBON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTTE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARIBOU, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CEDAR, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CERRO GORDO, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAYTON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEBURNE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLBERT, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONEJOS, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COVINGTON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRISP, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROSS, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROWLEY, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CULLMAN, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEL NORTE, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELTA, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DESHA, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKINSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOOLY, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAGLE, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAIRBANKS NORTH STAR, AK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FINNEY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FORD, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOUNTAIN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GADSDEN, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARFIELD, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILPIN, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLADES, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLYNN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAND, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENWOOD, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRUNDY, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GUNNISON, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOLMES, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMBOLDT, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IMPERIAL, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRWIN, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEOKUK, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIT CARSON, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA PAZ, AZ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA PLATA, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAS ANIMAS, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIMESTONE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDONOUGH, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENARD, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MODOC, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTROSE, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRIS, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NAPA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OBRIEN, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONEIDA, ID",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OUACHITA, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARKE, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHILLIPS, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PICKENS, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTAWATOMIE, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRAIRIE, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRATT, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSH, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSSELL, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CLAIR, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT FRANCIS, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALINE, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN LUIS OBISPO, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN MIGUEL, CO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHARP, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHASTA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, KS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEUBEN, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUTTER, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUWANNEE, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWITZERLAND, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAMA, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TATTNALL, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TEHAMA, CA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUSCALOOSA, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VERMILLION, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALKER, AL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, IL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, FL",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WELLS, IN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKES, GA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WRIGHT, IA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YELL, AR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,231
+,,≥ 45 and < 65 Years,158
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,469
+,Total,Less than 18 Years,100
+,,≥ 18 and < 45 Years,4367
+,,≥ 45 and < 65 Years,2413
+,,65 Years or more,841
+,,No value,10 or fewer
+,,Total,7721

--- a/data/epic/raw/staging/D01b_OPIOID_EDvisits_CountyKY_NC_Year_Age.csv
+++ b/data/epic/raw/staging/D01b_OPIOID_EDvisits_CountyKY_NC_Year_Age.csv
@@ -1,0 +1,12848 @@
+﻿Session Title,"Opioid Overdoses in ED, KY-NC",,
+Session Description,ED encountersKY-NC by county pts with ED diagnosis opioid overdose,,
+Session ID,2748527,,
+Data Model,ED Encounters,,
+Population Base,All ED Encounters,,
+Population Criteria Filters: These criteria are a summary and do not fully reflect the content of the exported session.,ED Diagnoses: EDG ICD-10 OPIOID OVERDOSE,State of Residence (U.S.): KY_NC,
+Session Date Range,1/1/2023 - 7/17/2025 (Based On Arrival Date),,
+Measure,Number of ED Encounters,,
+Export User,Stephanie Perniciaro,,
+Date of Export,8/8/2025,,
+,,,
+,,,
+,,,Number of ED Encounters
+Year,County of Residence,Age at Time of Visit,
+Jan 1 – Dec 31 2023,"HENNEPIN, MN",Less than 18 Years,14
+,,≥ 18 and < 45 Years,659
+,,≥ 45 and < 65 Years,236
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,952
+,"MONROE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,320
+,,≥ 45 and < 65 Years,234
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,592
+,"WAYNE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,131
+,,≥ 45 and < 65 Years,132
+,,65 Years or more,105
+,,No value,10 or fewer
+,,Total,369
+,"CAMDEN, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,165
+,,≥ 45 and < 65 Years,159
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,370
+,"BALTIMORE CITY, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,133
+,,≥ 45 and < 65 Years,200
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,389
+,"KINGS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,102
+,,≥ 45 and < 65 Years,179
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,336
+,"MIDDLESEX, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,221
+,,≥ 45 and < 65 Years,127
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,375
+,"WAKE, NC",Less than 18 Years,24
+,,≥ 18 and < 45 Years,268
+,,≥ 45 and < 65 Years,82
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,384
+,"JEFFERSON, KY",Less than 18 Years,15
+,,≥ 18 and < 45 Years,222
+,,≥ 45 and < 65 Years,103
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,362
+,"ESSEX, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,56
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,105
+,"SUFFOLK, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,149
+,,≥ 45 and < 65 Years,112
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,290
+,"HUDSON, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,53
+,,≥ 45 and < 65 Years,128
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,197
+,"MECKLENBURG, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,153
+,,≥ 45 and < 65 Years,83
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,254
+,"WORCESTER, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,150
+,,≥ 45 and < 65 Years,69
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,235
+,"CUMBERLAND, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,130
+,,≥ 45 and < 65 Years,67
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,207
+,"SUFFOLK, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,167
+,,≥ 45 and < 65 Years,66
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,251
+,"GUILFORD, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,112
+,,≥ 45 and < 65 Years,63
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,190
+,"CLARK, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,83
+,,≥ 45 and < 65 Years,39
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,134
+,"BRISTOL, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,135
+,,≥ 45 and < 65 Years,82
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,228
+,"EAST BATON ROUGE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,126
+,,≥ 45 and < 65 Years,53
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,195
+,"KENT, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,103
+,,≥ 45 and < 65 Years,56
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,191
+,"WASHINGTON, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,140
+,,≥ 45 and < 65 Years,66
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,227
+,"RAMSEY, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,136
+,,≥ 45 and < 65 Years,41
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,183
+,"CUMBERLAND, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,96
+,,≥ 45 and < 65 Years,37
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,139
+,"MUSKEGON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,102
+,,≥ 45 and < 65 Years,47
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,174
+,"FAYETTE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,103
+,,≥ 45 and < 65 Years,52
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,169
+,"MIDDLESEX, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,57
+,,≥ 45 and < 65 Years,55
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,141
+,"JEFFERSON, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,99
+,,≥ 45 and < 65 Years,49
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,156
+,"WASHOE, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,73
+,,≥ 45 and < 65 Years,34
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,121
+,"JACKSON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,86
+,,≥ 45 and < 65 Years,25
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,126
+,"QUEENS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,46
+,,≥ 45 and < 65 Years,45
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,105
+,"ORLEANS, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,59
+,,≥ 45 and < 65 Years,57
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,121
+,"BURLINGTON, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,62
+,,≥ 45 and < 65 Years,35
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,107
+,"LIVINGSTON, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,82
+,,≥ 45 and < 65 Years,39
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,130
+,"ALBANY, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,44
+,,≥ 45 and < 65 Years,40
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,98
+,"FORSYTH, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,65
+,,≥ 45 and < 65 Years,31
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,113
+,"ERIE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,63
+,,≥ 45 and < 65 Years,46
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,117
+,"GENESEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,73
+,,≥ 45 and < 65 Years,53
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,136
+,"SAINT LOUIS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,107
+,,≥ 45 and < 65 Years,31
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,145
+,"LAFAYETTE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,105
+,,≥ 45 and < 65 Years,32
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,143
+,"ROBESON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,86
+,,≥ 45 and < 65 Years,31
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,124
+,"UNION, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,41
+,"OCEAN, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,60
+,,≥ 45 and < 65 Years,26
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,90
+,"MONTGOMERY, MD",Less than 18 Years,15
+,,≥ 18 and < 45 Years,86
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,131
+,"BALTIMORE, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,66
+,,≥ 45 and < 65 Years,46
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,121
+,"BROOME, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,68
+,,≥ 45 and < 65 Years,33
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,113
+,"BURKE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,90
+,,≥ 45 and < 65 Years,26
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,120
+,"CALDWELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,77
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,108
+,"HARFORD, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,55
+,,≥ 45 and < 65 Years,28
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,91
+,"PITT, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,69
+,,≥ 45 and < 65 Years,50
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,129
+,"ESSEX, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,50
+,,≥ 45 and < 65 Years,31
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,88
+,"TANGIPAHOA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,59
+,,≥ 45 and < 65 Years,37
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,102
+,"ANNE ARUNDEL, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,57
+,,≥ 45 and < 65 Years,42
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,106
+,"OAKLAND, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,34
+,,≥ 45 and < 65 Years,27
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,82
+,"HARNETT, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,71
+,,≥ 45 and < 65 Years,27
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,106
+,"JOHNSTON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,53
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,91
+,"BERNALILLO, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,60
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,92
+,"DAKOTA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,78
+,,≥ 45 and < 65 Years,22
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,106
+,"ONONDAGA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,49
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,68
+,"ROWAN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,59
+,,≥ 45 and < 65 Years,30
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,105
+,"GLOUCESTER, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,55
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,78
+,"ALAMANCE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,56
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,89
+,"NEW YORK, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,37
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,72
+,"WICOMICO, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,58
+,,≥ 45 and < 65 Years,31
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,96
+,"WASHTENAW, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,57
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,86
+,"YORK, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,49
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,74
+,"NASSAU, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,37
+,,≥ 45 and < 65 Years,25
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,69
+,"BUCHANAN, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,58
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,77
+,"WAYNE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,41
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,71
+,"NASH, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,40
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,62
+,"HARRISON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,53
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,71
+,"JACKSON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,40
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,71
+,"ASCENSION, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,54
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,70
+,"ROCKINGHAM, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,51
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,68
+,"RENSSELAER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,41
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,59
+,"HENDERSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,64
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,81
+,"PRINCE GEORGES, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,59
+,"KALAMAZOO, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,66
+,"ORANGE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,34
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,54
+,"DESOTO, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,42
+,"MADISON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,43
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,64
+,"SOMERSET, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,31
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,49
+,"EDGECOMBE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,44
+,"PENOBSCOT, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,34
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,64
+,"JACKSON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,46
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,62
+,"BEAUFORT, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,34
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,50
+,"SULLIVAN, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,49
+,"MONMOUTH, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,42
+,"ONEIDA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,37
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,61
+,"STEARNS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"ANDROSCOGGIN, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"MERCER, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"ANOKA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,43
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,53
+,"CALHOUN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,31
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"DAVIDSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,39
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,50
+,"MONROE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"PLYMOUTH, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"HILLSBOROUGH, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,36
+,"BRUNSWICK, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,38
+,"HALIFAX, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,43
+,"BERRIEN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,31
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,50
+,"CHARLES, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"NORFOLK, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"NIAGARA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"WASHINGTON, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"MACOMB, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,33
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"BELTRAMI, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,46
+,"LANCASTER, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,38
+,"HAMPDEN, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"NEW HANOVER, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"WASHINGTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"HARDIN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"HINDS, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"CLAY, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"WAYNE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"DURHAM, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,38
+,"DORCHESTER, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"KNOX, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"SAINT TAMMANY, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,42
+,"DOUGLAS, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"SAINT MARY, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"OUACHITA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"BRONX, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"ONTARIO, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"BLADEN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"CECIL, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"LENOIR, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,31
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,43
+,"ACADIA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"CORTLAND, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"GENESEE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"ORANGE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"SARATOGA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"CHESHIRE, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"DUPLIN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"IBERVILLE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"LENAWEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"OTSEGO, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"CLINTON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"LOWNDES, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"RANKIN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"ST JOHN THE BAPTIST, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"GALLATIN, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"OXFORD, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"STEUBEN, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"WARREN, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"CAROLINE, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"LIVINGSTON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"SAINT LAWRENCE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"ESTILL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"SOMERSET, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"JEFFERSON DAVIS, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"RANDOLPH, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"BULLITT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CLAY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"KENTON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"BENTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"LINCOLN, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"PEARL RIVER, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"ATLANTIC, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"OTTAWA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"RICHMOND, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"COLUMBUS, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"JESSAMINE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"WESTCHESTER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"KENT, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"MCCRACKEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"SHERBURNE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CHATHAM, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"SCOTT, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"HANCOCK, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"HENDERSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"TALBOT, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"BUNCOMBE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"QUEEN ANNES, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"BARNSTABLE, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"CABARRUS, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CASCADE, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHOWAN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"LEE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PASQUOTANK, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"WORCESTER, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"WRIGHT, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"FRANKLIN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"HERKIMER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"LIVINGSTON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"PHELPS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"PLATTE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"UNION, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WILSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BERGEN, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHENANGO, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"DARE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"IREDELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"STOKES, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"VERMILION, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"BERTIE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CAPE MAY, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FORREST, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"LAFOURCHE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"LAUDERDALE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MILLE LACS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"NEWAYGO, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CHARLES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"UNION, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CROW WING, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELAWARE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BECKER, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"FRANKLIN, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"FRANKLIN, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAMPSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WHITLEY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CLAY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREDERICK, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"HOKE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CARSON CITY, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CASS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"KENNEBEC, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"MONTCALM, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"OCEANA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"SAINT MARTIN, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALEM, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"OLDHAM, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PASSAIC, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"PIKE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN BUREN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"WEST BATON ROUGE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALCASIEU, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARLTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MARION, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"PERQUIMANS, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"ALLEGANY, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CATAWBA, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"OSWEGO, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTTER TAIL, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALDO, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"HUNTERDON, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHAMPTON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"PULASKI, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SAINT FRANCOIS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TERREBONNE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"YADKIN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"HERTFORD, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MADISON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"PENDER, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SARPY, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHOHARIE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VALENCIA, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAUTAUQUA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEARWATER, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"GREENE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KANDIYOHI, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEGAN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARVER, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"PLAQUEMINES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARRY, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHISAGO, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CURRITUCK, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESSEX, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAHNOMEN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MECOSTA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRIS, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUTHERFORD, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT LANDRY, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTLAND, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"YELLOWSTONE, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CASWELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAYUGA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAVEN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GASTON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASSUMPTION, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEVELAND, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELTA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IBERIA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ITASCA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS AND CLARK, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDOWELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORLEANS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAGADAHOC, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHENECTADY, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLIVAN, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIOGA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ULSTER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARRETT, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GATES, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONSLOW, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STANLY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TATE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEGANY, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAFTON, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IONIA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOORE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NELSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT LOUIS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANDOVAL, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDREW, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HALL, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HILLSDALE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ISANTI, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAPEER, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PINE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT BERNARD, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKES, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOPKINS, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HYDE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEAKE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT JAMES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOMERSET, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOURBON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRANCH, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAPE GIRARDEAU, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARRARD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANVILLE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRENADA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT MARYS, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STONE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SURRY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOMPKINS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WATAUGA, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEST FELICIANA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALVERT, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAST FELICIANA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAUREL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NODAWAY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OLMSTED, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSCEOLA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PONTOTOC, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRENTISS, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKINGHAM, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SENECA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SILVER BOW, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODFORD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AVOYELLES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMDEN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEORGE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"INGHAM, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEADE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRISON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT HELENA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AITKIN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATTALA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRECKINRIDGE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEMUNG, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHURCHILL, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COPIAH, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COVINGTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EATON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELKO, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHMOND, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAGINAW, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTTS BLUFF, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIPPAH, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TODD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRIMBLE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TYRRELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YAZOO, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDERSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLUE EARTH, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAVES, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAKOTA, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LARUE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIVINGSTON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARIES, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERRIMACK, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PANOLA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHLAND, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKCASTLE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKLAND, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROWAN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRANSYLVANIA, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AROOSTOOK, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AVERY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARTERET, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHICKASAW, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHRISTIAN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HILL, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ITAWAMBA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMAR, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LE SUEUR, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIVINGSTON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NESHOBA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POINTE COUPEE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PULASKI, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RAPIDES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REDWOOD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHIAWASSEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPENCER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUSSEX, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TORRANCE, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALTHALL, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYOMING, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALEXANDER, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AMITE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BALLARD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOLIVAR, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOLLINGER, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOSSIER, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CADDO, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALDWELL, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CATTARAUGUS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHOUTEAU, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COTTONWOOD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAST CARROLL, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAVES, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARLAN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HART, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOLMES, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LESLIE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LETCHER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MANISTEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCLEOD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENOMINEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIDLAND, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MISSISSIPPI, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORMAN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWSLEY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARK, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PENNINGTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RENVILLE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHLAND, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROSEAU, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CHARLES, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CLAIR, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHUYLER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STRAFFORD, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TENSAS, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUNICA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUSCOLA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKIN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YALOBUSHA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALCORN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEN, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARREN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BATH, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAY, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BELKNAP, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BERKSHIRE, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BREATHITT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROADWATER, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASEY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHIPPEWA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CIBOLA, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOK, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOS, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CURRY, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIESS, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWSON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKINSON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DIXON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DODGE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DONA ANA, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EVANGELINE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FARIBAULT, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAND TRAVERSE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMBOLDT, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ISABELLA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON DAVIS, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KALKASKA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KANABEC, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEMPER, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MISSOULA, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NANTUCKET, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NATCHITOCHES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOBLES, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKTIBBEHA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"QUAY, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCK, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROOSEVELT, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN MIGUEL, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOCORRO, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUNFLOWER, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WADENA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINONA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YATES, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YELLOW MEDICINE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALGER, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANTRIM, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARENAC, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASHE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARAGA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARRY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BATES, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVERHEAD, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BELL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENZIE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOYD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOYLE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRACKEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUFFALO, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALDWELL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALDWELL, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMDEN, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARLISLE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARTER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CEDAR, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CEDAR, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLEVOIX, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHOCTAW, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARKE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COAHOMA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRITTENDEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIESS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DENT, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUTCHESS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDMONSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLIOTT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FILLMORE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLEMING, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREEBORN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALLATIN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GASCONADE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GENTRY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLADWIN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOODHUE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRUNDY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMPSHIRE, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAYWOOD, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HICKMAN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOLT, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWELL, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUBBARD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KOOCHICHING, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAC QUI PARLE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINN, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARQUETTE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCCREARY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDONALD, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCKINLEY, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENIFEE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERRICK, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLER, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINERAL, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOWER, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MUHLENBERG, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MURRAY, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NANCE, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NICOLLET, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NYE, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGEMAW, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTERO, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTOE, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAMLICO, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEMISCOT, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIPESTONE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PISCATAQUIS, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PONDERA, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POWELL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHARDSON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROSCOMMON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SABINE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT LOUIS CITY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANILAC, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANTA FE, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAUNDERS, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEWARD, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIBLEY, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIMPSON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALLAHATCHIE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAOS, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THURSTON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TISHOMINGO, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRAVERSE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRIGG, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VANCE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WABASHA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEST CARROLL, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKINSON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINSTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOLFE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WORTH, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,313
+,,≥ 45 and < 65 Years,179
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,539
+,Total,Less than 18 Years,283
+,,≥ 18 and < 45 Years,10951
+,,≥ 45 and < 65 Years,5549
+,,65 Years or more,1476
+,,No value,10 or fewer
+,,Total,18259
+Jan 1 – Dec 31 2024,"HENNEPIN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,422
+,,≥ 45 and < 65 Years,126
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,589
+,"MONROE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,158
+,,≥ 45 and < 65 Years,105
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,286
+,"WAYNE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,137
+,,≥ 45 and < 65 Years,117
+,,65 Years or more,99
+,,No value,10 or fewer
+,,Total,355
+,"CAMDEN, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,154
+,,≥ 45 and < 65 Years,118
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,319
+,"BALTIMORE CITY, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,92
+,,≥ 45 and < 65 Years,195
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,324
+,"KINGS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,110
+,,≥ 45 and < 65 Years,174
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,330
+,"MIDDLESEX, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,163
+,,≥ 45 and < 65 Years,93
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,278
+,"WAKE, NC",Less than 18 Years,15
+,,≥ 18 and < 45 Years,191
+,,≥ 45 and < 65 Years,41
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,266
+,"JEFFERSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,166
+,,≥ 45 and < 65 Years,71
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,250
+,"ESSEX, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,86
+,,≥ 45 and < 65 Years,249
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,406
+,"SUFFOLK, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,123
+,,≥ 45 and < 65 Years,76
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,227
+,"HUDSON, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,56
+,,≥ 45 and < 65 Years,150
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,230
+,"MECKLENBURG, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,109
+,,≥ 45 and < 65 Years,45
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,171
+,"WORCESTER, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,99
+,,≥ 45 and < 65 Years,67
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,181
+,"CUMBERLAND, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,102
+,,≥ 45 and < 65 Years,40
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,161
+,"SUFFOLK, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,68
+,,≥ 45 and < 65 Years,39
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,119
+,"GUILFORD, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,103
+,,≥ 45 and < 65 Years,42
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,153
+,"CLARK, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,108
+,,≥ 45 and < 65 Years,47
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,179
+,"BRISTOL, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,73
+,,≥ 45 and < 65 Years,36
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,115
+,"EAST BATON ROUGE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,82
+,,≥ 45 and < 65 Years,36
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,128
+,"KENT, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,71
+,,≥ 45 and < 65 Years,40
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,133
+,"WASHINGTON, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,63
+,,≥ 45 and < 65 Years,42
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,113
+,"RAMSEY, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,103
+,,≥ 45 and < 65 Years,32
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,140
+,"CUMBERLAND, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,87
+,,≥ 45 and < 65 Years,38
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,131
+,"MUSKEGON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,65
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,110
+,"FAYETTE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,58
+,,≥ 45 and < 65 Years,36
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,101
+,"MIDDLESEX, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,56
+,,≥ 45 and < 65 Years,49
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,120
+,"JEFFERSON, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,51
+,,≥ 45 and < 65 Years,32
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,92
+,"WASHOE, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,53
+,,≥ 45 and < 65 Years,31
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,93
+,"JACKSON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,58
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,91
+,"QUEENS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,41
+,,≥ 45 and < 65 Years,51
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,109
+,"ORLEANS, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,50
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,95
+,"BURLINGTON, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,62
+,,≥ 45 and < 65 Years,37
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,106
+,"LIVINGSTON, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,62
+,,≥ 45 and < 65 Years,22
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,92
+,"ALBANY, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,55
+,,≥ 45 and < 65 Years,36
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,105
+,"FORSYTH, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,52
+,,≥ 45 and < 65 Years,22
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,90
+,"ERIE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,66
+,,≥ 45 and < 65 Years,29
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,100
+,"GENESEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,46
+,,≥ 45 and < 65 Years,22
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,78
+,"SAINT LOUIS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,57
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,75
+,"LAFAYETTE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,49
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,68
+,"ROBESON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,54
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,78
+,"UNION, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,33
+,,≥ 45 and < 65 Years,57
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,107
+,"OCEAN, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,64
+,,≥ 45 and < 65 Years,26
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,94
+,"MONTGOMERY, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,53
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,68
+,"BALTIMORE, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,35
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,65
+,"BROOME, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,48
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,75
+,"BURKE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,48
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,68
+,"CALDWELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,46
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,73
+,"HARFORD, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,47
+,,≥ 45 and < 65 Years,28
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,93
+,"PITT, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,39
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,59
+,"ESSEX, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,48
+,,≥ 45 and < 65 Years,35
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,87
+,"TANGIPAHOA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,34
+,,≥ 45 and < 65 Years,29
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,71
+,"ANNE ARUNDEL, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,40
+,,≥ 45 and < 65 Years,27
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,76
+,"OAKLAND, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,68
+,"HARNETT, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,39
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,64
+,"JOHNSTON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,41
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,64
+,"BERNALILLO, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,40
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,64
+,"DAKOTA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,59
+,"ONONDAGA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,52
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,76
+,"ROWAN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,56
+,"GLOUCESTER, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,59
+,"ALAMANCE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,46
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,60
+,"NEW YORK, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,32
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,62
+,"WICOMICO, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,53
+,"WASHTENAW, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,60
+,"YORK, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,57
+,"NASSAU, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,69
+,"BUCHANAN, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,46
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,57
+,"WAYNE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,55
+,"NASH, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,53
+,"HARRISON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,42
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,59
+,"JACKSON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"ASCENSION, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"ROCKINGHAM, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,44
+,"RENSSELAER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,50
+,"HENDERSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"PRINCE GEORGES, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,49
+,"KALAMAZOO, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"ORANGE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"DESOTO, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"MADISON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"SOMERSET, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"EDGECOMBE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"PENOBSCOT, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"JACKSON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"BEAUFORT, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,38
+,"SULLIVAN, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"MONMOUTH, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"ONEIDA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"STEARNS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,47
+,"ANDROSCOGGIN, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"MERCER, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"ANOKA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"CALHOUN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,41
+,"DAVIDSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"MONROE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"PLYMOUTH, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,41
+,"HILLSBOROUGH, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,43
+,"BRUNSWICK, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"HALIFAX, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"BERRIEN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"CHARLES, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,36
+,"NORFOLK, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"NIAGARA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"WASHINGTON, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"MACOMB, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BELTRAMI, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"LANCASTER, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"HAMPDEN, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"NEW HANOVER, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,36
+,"WASHINGTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"HARDIN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"HINDS, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"CLAY, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"WAYNE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"DURHAM, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"DORCHESTER, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"KNOX, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"SAINT TAMMANY, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"DOUGLAS, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"SAINT MARY, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"OUACHITA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"BRONX, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"ONTARIO, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"BLADEN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"CECIL, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"LENOIR, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"ACADIA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CORTLAND, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"GENESEE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"ORANGE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"SARATOGA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CHESHIRE, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"DUPLIN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"IBERVILLE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"LENAWEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"OTSEGO, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CLINTON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"LOWNDES, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"RANKIN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ST JOHN THE BAPTIST, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"GALLATIN, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"OXFORD, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"STEUBEN, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"CAROLINE, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"LIVINGSTON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"SAINT LAWRENCE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"ESTILL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"SOMERSET, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"JEFFERSON DAVIS, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"RANDOLPH, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"BULLITT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CLAY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"KENTON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BENTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"LINCOLN, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"PEARL RIVER, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATLANTIC, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"OTTAWA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"RICHMOND, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"COLUMBUS, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"JESSAMINE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WESTCHESTER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"KENT, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCCRACKEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERBURNE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHATHAM, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"SCOTT, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HANCOCK, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDERSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALBOT, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BUNCOMBE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"QUEEN ANNES, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARNSTABLE, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CABARRUS, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"CASCADE, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CHOWAN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"LEE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"PASQUOTANK, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WORCESTER, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WRIGHT, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"FRANKLIN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"HERKIMER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIVINGSTON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHELPS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLATTE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WILSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"BERGEN, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CHENANGO, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DARE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"IREDELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"STOKES, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VERMILION, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BERTIE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAPE MAY, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"FORREST, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFOURCHE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAUDERDALE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MILLE LACS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWAYGO, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SAINT CHARLES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROW WING, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"DELAWARE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"BECKER, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"SAMPSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITLEY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"FREDERICK, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOKE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"PIKE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARSON CITY, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENNEBEC, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTCALM, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OCEANA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT MARTIN, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALEM, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OLDHAM, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PASSAIC, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN BUREN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEST BATON ROUGE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALCASIEU, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARLTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERQUIMANS, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEGANY, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CATAWBA, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSWEGO, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"OTTER TAIL, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WALDO, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUNTERDON, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MASON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHAMPTON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PULASKI, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT FRANCOIS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TERREBONNE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YADKIN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HERTFORD, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PENDER, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SARPY, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHOHARIE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VALENCIA, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAUTAUQUA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEARWATER, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KANDIYOHI, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEGAN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARVER, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLAQUEMINES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARRY, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHISAGO, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CURRITUCK, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESSEX, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAHNOMEN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MECOSTA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRIS, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUTHERFORD, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT LANDRY, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTLAND, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YELLOWSTONE, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASWELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAYUGA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAVEN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GASTON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASSUMPTION, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEVELAND, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELTA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IBERIA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ITASCA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS AND CLARK, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDOWELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORLEANS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAGADAHOC, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHENECTADY, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLIVAN, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIOGA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ULSTER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARRETT, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GATES, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONSLOW, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STANLY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TATE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEGANY, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAFTON, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IONIA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOORE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NELSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT LOUIS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANDOVAL, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDREW, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HALL, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HILLSDALE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ISANTI, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAPEER, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PINE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT BERNARD, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKES, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOPKINS, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HYDE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEAKE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT JAMES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOMERSET, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOURBON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRANCH, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAPE GIRARDEAU, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARRARD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANVILLE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRENADA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT MARYS, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STONE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SURRY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOMPKINS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WATAUGA, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEST FELICIANA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALVERT, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAST FELICIANA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAUREL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NODAWAY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OLMSTED, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSCEOLA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PONTOTOC, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRENTISS, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKINGHAM, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SENECA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SILVER BOW, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODFORD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AVOYELLES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMDEN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEORGE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"INGHAM, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEADE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRISON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT HELENA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AITKIN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATTALA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRECKINRIDGE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEMUNG, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHURCHILL, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COPIAH, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COVINGTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EATON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELKO, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHMOND, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAGINAW, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTTS BLUFF, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIPPAH, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TODD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRIMBLE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TYRRELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YAZOO, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDERSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLUE EARTH, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAVES, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAKOTA, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LARUE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIVINGSTON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARIES, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERRIMACK, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PANOLA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHLAND, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKCASTLE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKLAND, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROWAN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRANSYLVANIA, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AROOSTOOK, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AVERY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARTERET, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHICKASAW, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHRISTIAN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HILL, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ITAWAMBA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMAR, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LE SUEUR, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIVINGSTON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NESHOBA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POINTE COUPEE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PULASKI, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RAPIDES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REDWOOD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHIAWASSEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPENCER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUSSEX, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TORRANCE, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALTHALL, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYOMING, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALEXANDER, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AMITE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BALLARD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOLIVAR, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOLLINGER, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOSSIER, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CADDO, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALDWELL, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CATTARAUGUS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHOUTEAU, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COTTONWOOD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAST CARROLL, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAVES, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARLAN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HART, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOLMES, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LESLIE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LETCHER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MANISTEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCLEOD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENOMINEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIDLAND, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MISSISSIPPI, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORMAN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWSLEY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARK, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PENNINGTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RENVILLE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHLAND, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROSEAU, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CHARLES, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CLAIR, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHUYLER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STRAFFORD, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TENSAS, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUNICA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUSCOLA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKIN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YALOBUSHA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALCORN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEN, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARREN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BATH, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAY, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BELKNAP, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BERKSHIRE, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BREATHITT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROADWATER, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASEY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHIPPEWA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CIBOLA, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOK, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOS, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CURRY, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIESS, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWSON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKINSON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DIXON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DODGE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DONA ANA, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EVANGELINE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FARIBAULT, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAND TRAVERSE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMBOLDT, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ISABELLA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON DAVIS, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KALKASKA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KANABEC, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEMPER, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MISSOULA, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NANTUCKET, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NATCHITOCHES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOBLES, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKTIBBEHA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"QUAY, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCK, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROOSEVELT, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN MIGUEL, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOCORRO, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUNFLOWER, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WADENA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINONA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YATES, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YELLOW MEDICINE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALGER, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANTRIM, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARENAC, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASHE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARAGA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARRY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BATES, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVERHEAD, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BELL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENZIE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOYD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOYLE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRACKEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUFFALO, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALDWELL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALDWELL, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMDEN, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARLISLE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARTER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CEDAR, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CEDAR, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLEVOIX, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHOCTAW, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARKE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COAHOMA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRITTENDEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIESS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DENT, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUTCHESS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDMONSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLIOTT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FILLMORE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLEMING, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREEBORN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALLATIN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GASCONADE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GENTRY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLADWIN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOODHUE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRUNDY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMPSHIRE, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAYWOOD, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HICKMAN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOLT, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWELL, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUBBARD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KOOCHICHING, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAC QUI PARLE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINN, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARQUETTE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCCREARY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDONALD, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCKINLEY, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENIFEE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERRICK, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLER, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINERAL, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOWER, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MUHLENBERG, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MURRAY, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NANCE, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NICOLLET, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NYE, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGEMAW, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTERO, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTOE, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAMLICO, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEMISCOT, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIPESTONE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PISCATAQUIS, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PONDERA, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POWELL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHARDSON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROSCOMMON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SABINE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT LOUIS CITY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANILAC, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANTA FE, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAUNDERS, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEWARD, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIBLEY, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIMPSON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALLAHATCHIE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAOS, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THURSTON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TISHOMINGO, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRAVERSE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRIGG, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VANCE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WABASHA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEST CARROLL, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKINSON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINSTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOLFE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WORTH, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,284
+,,≥ 45 and < 65 Years,172
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,517
+,Total,Less than 18 Years,193
+,,≥ 18 and < 45 Years,7757
+,,≥ 45 and < 65 Years,4376
+,,65 Years or more,1385
+,,No value,10 or fewer
+,,Total,13711
+Jan 1 – Jul 17 2025,"HENNEPIN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,261
+,,≥ 45 and < 65 Years,81
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,366
+,"MONROE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,90
+,,≥ 45 and < 65 Years,46
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,151
+,"WAYNE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,99
+,,≥ 45 and < 65 Years,68
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,225
+,"CAMDEN, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,87
+,,≥ 45 and < 65 Years,89
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,214
+,"BALTIMORE CITY, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,44
+,,≥ 45 and < 65 Years,85
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,149
+,"KINGS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,56
+,,≥ 45 and < 65 Years,101
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,191
+,"MIDDLESEX, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,87
+,,≥ 45 and < 65 Years,50
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,150
+,"WAKE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,109
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,145
+,"JEFFERSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,83
+,,≥ 45 and < 65 Years,36
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,129
+,"ESSEX, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,44
+,,≥ 45 and < 65 Years,127
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,210
+,"SUFFOLK, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,68
+,,≥ 45 and < 65 Years,38
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,118
+,"HUDSON, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,83
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,125
+,"MECKLENBURG, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,54
+,,≥ 45 and < 65 Years,28
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,89
+,"WORCESTER, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,52
+,,≥ 45 and < 65 Years,34
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,90
+,"CUMBERLAND, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,51
+,,≥ 45 and < 65 Years,27
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,88
+,"SUFFOLK, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,46
+,"GUILFORD, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,66
+,"CLARK, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,65
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,92
+,"BRISTOL, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,52
+,"EAST BATON ROUGE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,34
+,,≥ 45 and < 65 Years,22
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,67
+,"KENT, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,35
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,66
+,"WASHINGTON, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,42
+,"RAMSEY, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,37
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,52
+,"CUMBERLAND, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,62
+,"MUSKEGON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"FAYETTE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"MIDDLESEX, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,25
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,57
+,"JEFFERSON, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,44
+,"WASHOE, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,45
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,67
+,"JACKSON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,25
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,56
+,"QUEENS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,25
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,58
+,"ORLEANS, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"BURLINGTON, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"LIVINGSTON, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"ALBANY, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,50
+,"FORSYTH, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,50
+,"ERIE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"GENESEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"SAINT LOUIS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"LAFAYETTE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"ROBESON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"UNION, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,46
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,93
+,"OCEAN, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,52
+,"MONTGOMERY, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"BALTIMORE, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,41
+,"BROOME, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"BURKE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"CALDWELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"HARFORD, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"PITT, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"ESSEX, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"TANGIPAHOA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"ANNE ARUNDEL, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"OAKLAND, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,51
+,"HARNETT, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"JOHNSTON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,41
+,"BERNALILLO, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"DAKOTA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"ONONDAGA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,43
+,"ROWAN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"GLOUCESTER, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"ALAMANCE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"NEW YORK, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"WICOMICO, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"WASHTENAW, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"YORK, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"NASSAU, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"BUCHANAN, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"WAYNE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"NASH, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"HARRISON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"JACKSON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"ASCENSION, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"ROCKINGHAM, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"RENSSELAER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"HENDERSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"PRINCE GEORGES, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"KALAMAZOO, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ORANGE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"DESOTO, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"MADISON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"SOMERSET, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"EDGECOMBE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"PENOBSCOT, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"JACKSON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"BEAUFORT, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"SULLIVAN, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"MONMOUTH, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"ONEIDA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"STEARNS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"ANDROSCOGGIN, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MERCER, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"ANOKA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CALHOUN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"DAVIDSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"PLYMOUTH, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"HILLSBOROUGH, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"BRUNSWICK, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"HALIFAX, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BERRIEN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CHARLES, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"NORFOLK, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"NIAGARA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"WASHINGTON, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACOMB, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"BELTRAMI, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"LANCASTER, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMPDEN, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,46
+,"NEW HANOVER, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"WASHINGTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"HARDIN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"HINDS, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"CLAY, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DURHAM, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DORCHESTER, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SAINT TAMMANY, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"SAINT MARY, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OUACHITA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRONX, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONTARIO, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLADEN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CECIL, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"LENOIR, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ACADIA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CORTLAND, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GENESEE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORANGE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SARATOGA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"CHESHIRE, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUPLIN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IBERVILLE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LENAWEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTSEGO, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOWNDES, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"RANKIN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ST JOHN THE BAPTIST, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALLATIN, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"OXFORD, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"STEUBEN, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAROLINE, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIVINGSTON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT LAWRENCE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESTILL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOMERSET, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON DAVIS, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BULLITT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENTON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEARL RIVER, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATLANTIC, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTTAWA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHMOND, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBUS, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JESSAMINE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WESTCHESTER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENT, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCCRACKEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERBURNE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHATHAM, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDERSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALBOT, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUNCOMBE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"QUEEN ANNES, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARNSTABLE, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CABARRUS, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASCADE, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"CHOWAN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"PASQUOTANK, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WORCESTER, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WRIGHT, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HERKIMER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIVINGSTON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHELPS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLATTE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BERGEN, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHENANGO, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DARE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IREDELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STOKES, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VERMILION, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BERTIE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAPE MAY, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FORREST, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFOURCHE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAUDERDALE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLE LACS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWAYGO, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CHARLES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROW WING, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELAWARE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BECKER, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAMPSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITLEY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREDERICK, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOKE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARSON CITY, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENNEBEC, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTCALM, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OCEANA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT MARTIN, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALEM, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OLDHAM, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PASSAIC, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"VAN BUREN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEST BATON ROUGE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALCASIEU, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CARLTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERQUIMANS, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEGANY, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CATAWBA, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSWEGO, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTTER TAIL, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALDO, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUNTERDON, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHAMPTON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PULASKI, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT FRANCOIS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TERREBONNE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YADKIN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HERTFORD, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PENDER, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SARPY, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHOHARIE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VALENCIA, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAUTAUQUA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEARWATER, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KANDIYOHI, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEGAN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARVER, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLAQUEMINES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARRY, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHISAGO, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CURRITUCK, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESSEX, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAHNOMEN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MECOSTA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRIS, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUTHERFORD, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT LANDRY, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTLAND, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YELLOWSTONE, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASWELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAYUGA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAVEN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GASTON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASSUMPTION, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEVELAND, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELTA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IBERIA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ITASCA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS AND CLARK, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDOWELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORLEANS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAGADAHOC, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHENECTADY, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLIVAN, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIOGA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ULSTER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARRETT, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GATES, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONSLOW, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STANLY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TATE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEGANY, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAFTON, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IONIA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOORE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NELSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT LOUIS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANDOVAL, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDREW, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HALL, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HILLSDALE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ISANTI, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAPEER, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PINE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT BERNARD, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKES, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOPKINS, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HYDE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEAKE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT JAMES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOMERSET, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOURBON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRANCH, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAPE GIRARDEAU, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARRARD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANVILLE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRENADA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT MARYS, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STONE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SURRY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOMPKINS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WATAUGA, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEST FELICIANA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALVERT, MD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAST FELICIANA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAUREL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NODAWAY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OLMSTED, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSCEOLA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PONTOTOC, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRENTISS, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKINGHAM, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SENECA, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SILVER BOW, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODFORD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AVOYELLES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMDEN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEORGE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"INGHAM, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEADE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRISON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT HELENA, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AITKIN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATTALA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRECKINRIDGE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEMUNG, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHURCHILL, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COPIAH, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COVINGTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EATON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELKO, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHMOND, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAGINAW, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTTS BLUFF, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIPPAH, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TODD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRIMBLE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TYRRELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YAZOO, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDERSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLUE EARTH, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAVES, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAKOTA, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LARUE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIVINGSTON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARIES, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERRIMACK, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PANOLA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHLAND, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKCASTLE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKLAND, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROWAN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRANSYLVANIA, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AROOSTOOK, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AVERY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARTERET, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHICKASAW, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHRISTIAN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HILL, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ITAWAMBA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMAR, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LE SUEUR, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIVINGSTON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NESHOBA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POINTE COUPEE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PULASKI, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RAPIDES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REDWOOD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHIAWASSEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPENCER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUSSEX, NJ",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TORRANCE, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALTHALL, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYOMING, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALEXANDER, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AMITE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BALLARD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOLIVAR, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOLLINGER, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOSSIER, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CADDO, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALDWELL, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CATTARAUGUS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHOUTEAU, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COTTONWOOD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAST CARROLL, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAVES, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARLAN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HART, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOLMES, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LESLIE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LETCHER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MANISTEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCLEOD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENOMINEE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIDLAND, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MISSISSIPPI, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORMAN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWSLEY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARK, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PENNINGTON, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RENVILLE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHLAND, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROSEAU, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CHARLES, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CLAIR, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHUYLER, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STRAFFORD, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TENSAS, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUNICA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUSCOLA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKIN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YALOBUSHA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALCORN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEN, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARREN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BATH, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAY, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BELKNAP, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BERKSHIRE, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BREATHITT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROADWATER, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASEY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHIPPEWA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CIBOLA, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOK, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOS, NH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CURRY, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIESS, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWSON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKINSON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DIXON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DODGE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DONA ANA, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EVANGELINE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FARIBAULT, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAND TRAVERSE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMBOLDT, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ISABELLA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON DAVIS, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KALKASKA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KANABEC, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEMPER, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MISSOULA, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NANTUCKET, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NATCHITOCHES, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOBLES, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKTIBBEHA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"QUAY, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCK, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROOSEVELT, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN MIGUEL, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOCORRO, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUNFLOWER, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WADENA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINONA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YATES, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YELLOW MEDICINE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALGER, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANTRIM, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARENAC, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASHE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARAGA, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARRY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BATES, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVERHEAD, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BELL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENZIE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOYD, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOYLE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRACKEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUFFALO, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALDWELL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALDWELL, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMDEN, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARLISLE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARTER, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CEDAR, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CEDAR, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLEVOIX, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHOCTAW, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARKE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COAHOMA, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRITTENDEN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIESS, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DENT, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUTCHESS, NY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDMONSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLIOTT, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FILLMORE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLEMING, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREEBORN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALLATIN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GASCONADE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GENTRY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLADWIN, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOODHUE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRUNDY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMPSHIRE, MA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAYWOOD, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HICKMAN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOLT, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWELL, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUBBARD, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KOOCHICHING, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAC QUI PARLE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINN, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARQUETTE, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCCREARY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDONALD, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCKINLEY, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENIFEE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERRICK, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLER, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINERAL, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOWER, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MUHLENBERG, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MURRAY, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NANCE, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NICOLLET, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NYE, NV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGEMAW, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTERO, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTOE, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAMLICO, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEMISCOT, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIPESTONE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PISCATAQUIS, ME",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PONDERA, MT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POWELL, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHARDSON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROSCOMMON, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SABINE, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT LOUIS CITY, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANILAC, MI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANTA FE, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAUNDERS, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEWARD, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIBLEY, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIMPSON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALLAHATCHIE, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAOS, NM",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THURSTON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TISHOMINGO, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRAVERSE, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRIGG, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VANCE, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WABASHA, MN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, NC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, NE",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEST CARROLL, LA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKINSON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINSTON, MS",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOLFE, KY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WORTH, MO",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,150
+,,≥ 45 and < 65 Years,110
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,295
+,Total,Less than 18 Years,84
+,,≥ 18 and < 45 Years,3836
+,,≥ 45 and < 65 Years,2301
+,,65 Years or more,806
+,,No value,10 or fewer
+,,Total,7027

--- a/data/epic/raw/staging/D01c_OPIOID_EDvisits_CountyND_VA_Year_Age.csv
+++ b/data/epic/raw/staging/D01c_OPIOID_EDvisits_CountyND_VA_Year_Age.csv
@@ -1,0 +1,11516 @@
+﻿Session Title,"Opioid Overdoses in ED, ND-VA",,
+Session Description,ED encountersND-VA by countycount pts with ED diagnosis opioid overdose,,
+Session ID,2748528,,
+Data Model,ED Encounters,,
+Population Base,All ED Encounters,,
+Population Criteria Filters: These criteria are a summary and do not fully reflect the content of the exported session.,ED Diagnoses: EDG ICD-10 OPIOID OVERDOSE,State of Residence (U.S.): ND-VA,
+Session Date Range,1/1/2023 - 7/17/2025 (Based On Arrival Date),,
+Measure,Number of ED Encounters,,
+Export User,Stephanie Perniciaro,,
+Date of Export,8/8/2025,,
+,,,
+,,,
+,,,Number of ED Encounters
+Year,County of Residence,Age at Time of Visit,
+Jan 1 – Dec 31 2023,"PHILADELPHIA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,500
+,,≥ 45 and < 65 Years,348
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,934
+,"FRANKLIN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,577
+,,≥ 45 and < 65 Years,228
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,860
+,"MULTNOMAH, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,408
+,,≥ 45 and < 65 Years,136
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,581
+,"CUYAHOGA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,301
+,,≥ 45 and < 65 Years,164
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,514
+,"TARRANT, TX",Less than 18 Years,34
+,,≥ 18 and < 45 Years,277
+,,≥ 45 and < 65 Years,103
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,463
+,"DALLAS, TX",Less than 18 Years,30
+,,≥ 18 and < 45 Years,303
+,,≥ 45 and < 65 Years,78
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,453
+,"HAMILTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,301
+,,≥ 45 and < 65 Years,155
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,496
+,"TULSA, OK",Less than 18 Years,11
+,,≥ 18 and < 45 Years,290
+,,≥ 45 and < 65 Years,80
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,405
+,"MONTGOMERY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,227
+,,≥ 45 and < 65 Years,110
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,360
+,"ALLEGHENY, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,130
+,,≥ 45 and < 65 Years,78
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,229
+,"SHELBY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,149
+,,≥ 45 and < 65 Years,40
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,198
+,"NORFOLK CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,121
+,,≥ 45 and < 65 Years,132
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,301
+,"PORTSMOUTH CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,96
+,,≥ 45 and < 65 Years,139
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,266
+,"SPARTANBURG, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,183
+,,≥ 45 and < 65 Years,98
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,299
+,"LUCAS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,191
+,,≥ 45 and < 65 Years,66
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,270
+,"BUTLER, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,157
+,,≥ 45 and < 65 Years,57
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,228
+,"HARRIS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,123
+,,≥ 45 and < 65 Years,33
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,184
+,"RICHMOND CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,111
+,,≥ 45 and < 65 Years,99
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,249
+,"GREENVILLE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,154
+,,≥ 45 and < 65 Years,70
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,249
+,"CHARLESTON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,112
+,,≥ 45 and < 65 Years,77
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,212
+,"YORK, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,130
+,,≥ 45 and < 65 Years,54
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,198
+,"MAHONING, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,139
+,,≥ 45 and < 65 Years,47
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,204
+,"LEHIGH, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,94
+,,≥ 45 and < 65 Years,83
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,194
+,"HENRICO, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,90
+,,≥ 45 and < 65 Years,83
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,189
+,"VIRGINIA BEACH CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,124
+,,≥ 45 and < 65 Years,53
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,198
+,"FAIRFAX, VA",Less than 18 Years,27
+,,≥ 18 and < 45 Years,88
+,,≥ 45 and < 65 Years,28
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,162
+,"DAUPHIN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,98
+,,≥ 45 and < 65 Years,65
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,178
+,"DELAWARE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,74
+,,≥ 45 and < 65 Years,37
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,115
+,"RICHLAND, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,93
+,,≥ 45 and < 65 Years,49
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,156
+,"LANCASTER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,95
+,,≥ 45 and < 65 Years,31
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,138
+,"NEWPORT NEWS CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,78
+,,≥ 45 and < 65 Years,71
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,177
+,"CHESAPEAKE CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,70
+,,≥ 45 and < 65 Years,62
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,147
+,"HAMILTON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,95
+,,≥ 45 and < 65 Years,39
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,144
+,"LORAIN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,83
+,,≥ 45 and < 65 Years,36
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,125
+,"TRUMBULL, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,98
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,130
+,"BELL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,77
+,,≥ 45 and < 65 Years,30
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,122
+,"MONTGOMERY, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,58
+,,≥ 45 and < 65 Years,25
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,93
+,"ANDERSON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,85
+,,≥ 45 and < 65 Years,31
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,118
+,"BUCKS, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,47
+,,≥ 45 and < 65 Years,26
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,81
+,"DESCHUTES, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,71
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,105
+,"NORTHAMPTON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,71
+,,≥ 45 and < 65 Years,39
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,118
+,"CHITTENDEN, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,81
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,100
+,"HAMPTON CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,57
+,,≥ 45 and < 65 Years,42
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,116
+,"PRINCE WILLIAM, VA",Less than 18 Years,14
+,,≥ 18 and < 45 Years,58
+,,≥ 45 and < 65 Years,22
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,101
+,"CLARK, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,61
+,,≥ 45 and < 65 Years,29
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,98
+,"FLORENCE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,50
+,,≥ 45 and < 65 Years,22
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,77
+,"CLERMONT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,50
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,75
+,"SUMMIT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,46
+,,≥ 45 and < 65 Years,22
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,78
+,"COLLIN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,47
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,70
+,"RICHLAND, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,56
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,81
+,"CHESTER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,39
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,62
+,"CASS, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,52
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,68
+,"ERIE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,49
+,,≥ 45 and < 65 Years,32
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,87
+,"HORRY, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,37
+,,≥ 45 and < 65 Years,25
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,70
+,"LEBANON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,48
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,74
+,"GREENWOOD, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,59
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,86
+,"CHEROKEE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,49
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,61
+,"LICKING, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,59
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,83
+,"BERKELEY, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,37
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,61
+,"DENTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,47
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,74
+,"SULLIVAN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,51
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,73
+,"STARK, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,48
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,77
+,"MARION, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,57
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,77
+,"CHESTERFIELD, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,42
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,61
+,"GREENE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,68
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,83
+,"WARREN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,59
+,"CLACKAMAS, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,44
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,59
+,"LINN, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,43
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,65
+,"LANCASTER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"SUFFOLK CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,28
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,64
+,"CUMBERLAND, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,47
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,70
+,"BEXAR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,52
+,"WASHINGTON, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,44
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,53
+,"FRANKLIN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,54
+,"ALLEN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,46
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,64
+,"PICKENS, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,51
+,"LEXINGTON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,31
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,53
+,"MONROE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,39
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,56
+,"OKLAHOMA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"UNION, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,56
+,"WESTMORELAND, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,31
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,44
+,"BURLEIGH, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,42
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,50
+,"SUMTER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"JOHNSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,41
+,"WASHINGTON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,35
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,54
+,"BERKS, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"UMATILLA, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"COOS, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,30
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,49
+,"KERSHAW, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"LUZERNE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,31
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"MUSKOGEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"PETERSBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,47
+,"SCHUYLKILL, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,31
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,38
+,"FAYETTE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,49
+,"DILLON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,42
+,"ARLINGTON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"CARBON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"CHARLOTTESVILLE CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"MARION, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"LOUDOUN, VA",Less than 18 Years,14
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,43
+,"JEFFERSON, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"OCONEE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,43
+,"TRAVIS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"PICKAWAY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"ATHENS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"DELAWARE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"ORANGEBURG, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SALT LAKE, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"DORCHESTER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"MARION, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"HANOVER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"ELLIS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"LAURENS, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"MIAMI, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"ALEXANDRIA CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"CHESTER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"FAIRFIELD, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"TOM GREEN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"LAKE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CREEK, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"MEDINA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"MONTGOMERY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MALHEUR, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"BENTON, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"CROOK, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"GREENE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"LINCOLN, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"ADAMS, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"SANDUSKY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"DARLINGTON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"HENDERSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"ALBEMARLE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"BROWN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"MCLENNAN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"WASHINGTON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"WOOD, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"KAUFMAN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"WAGONER, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"ROGERS, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"YORK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CHESTERFIELD, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"FORT BEND, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SENECA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"GLOUCESTER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"WASHINGTON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"FREDERICK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMSBURG, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"COLUMBIA, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"JAMES CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BELMONT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"COLONIAL HEIGHTS CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"GRAND FORKS, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"HALIFAX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"TIPTON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"HARDIN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"PARKER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"ORANGE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"PREBLE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"WASHINGTON, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CARTER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"LOUISA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"MADISON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARENDON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"HAWKINS, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"OKMULGEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"PORTAGE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"YORK, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"ACCOMACK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"CRAWFORD, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"FLUVANNA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MANASSAS CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MARLBORO, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"ISLE OF WIGHT, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"CULPEPER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"ROCKINGHAM, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"MAYES, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DARKE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRINCE GEORGE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"ERIE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"FAIRFIELD, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HURON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"MADISON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MECKLENBURG, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"DINWIDDIE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MINNEHAHA, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADDISON, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAMPAIGN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"GEORGETOWN, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HOPEWELL CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MORTON, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEQUOYAH, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALVESTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISONBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PROVIDENCE, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKWALL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"SMYTH, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"TAZEWELL, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WILLIAMSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WISE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARMSTRONG, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAKER, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CORYELL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEW KENT, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDALL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUSCARAWAS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"AIKEN, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRADFORD, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"BRADLEY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEAUGA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LACKAWANNA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAYNE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CARROLL, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SEQUATCHIE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUSSEX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASHLAND, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASHTABULA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIANA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DYER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIBERTY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHENANDOAH, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDEMAN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARNEY, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OBION, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ABBEVILLE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRISTOL CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSSELL, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YAMHILL, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRAZORIA, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRAZOS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIDSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"FAIRFAX CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENSVILLE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LE FLORE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LLANO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN ZANDT, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEVELAND, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOSEPHINE, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANCASTER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"LANE, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAWNEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROSS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINDSOR, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOOD, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAMBERS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GIBSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HIGHLAND, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUNT, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORANGE, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINCHESTER CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAMBERG, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRUNSWICK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURNET, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARKE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KLAMATH, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STAFFORD, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STUTSMAN, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WISE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYANDOT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKENSON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GUERNSEY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KING WILLIAM, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCINTOSH, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORROW, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWBERRY, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTTAWA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOUTHAMPTON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPOTSYLVANIA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CANADIAN, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEFIANCE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESSEX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAUQUIER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRUNDY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAUDERDALE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MATHEWS, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCKENZIE, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NELSON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWPORT, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAGE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POWHATAN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHMOND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTS, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN WERT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUCKINGHAM, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAIG, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOCKING, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOOD, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIDDLESEX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORROW, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MUSKINGUM, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCIOTO, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNICOI, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEAKLEY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMSBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUGLAIZE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLEDSOE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAROLINE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLLETON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROCKETT, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ERATH, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOOCHLAND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAYS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KING AND QUEEN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYCOMING, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCCORMICK, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCMINN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOUNTRAIL, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSAGE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANOKE CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSK, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UPSHUR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASCO, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUGUSTA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARNWELL, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAUFORT, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAIR, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMBRIA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMERON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIS, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDGEFIELD, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREDERICKSBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREGG, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOOD RIVER, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCNAIRY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHAMPTON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POQUOSON CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RHEA, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHLAND, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUTLAND, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STAUNTON CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UTAH, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VINTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALLER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WESTMORELAND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLOTTE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLATSOP, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELAWARE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAND ISLE, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENT, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMPASAS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MANASSAS PARK CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEIGS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEIGS, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILAM, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTTAWA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PITTSYLVANIA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PONTOTOC, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUSQUEHANNA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIOGA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALKER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDERSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BASTROP, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENNINGTON, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLANCO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOSQUE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUCHANAN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALEDONIA, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMP, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CENTRE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COMANCHE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DANVILLE CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EASTLAND, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ECTOR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EL PASO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FALLS CHURCH CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GUADALUPE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HASKELL, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HILL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUNENBURG, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHUMBERLAND, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOWATA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PANOLA, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAULDING, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTAWATOMIE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRINCE EDWARD, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOMERSET, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMNER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TILLAMOOK, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VENANGO, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYOMING, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YANKTON, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLENDALE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUSTIN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BATH, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRISTOL, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARTER, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLES CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLEMAN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOKE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEAF SMITH, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMPORIA CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALLIA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILES, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAYWOOD, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDERSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HIDALGO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMPHREYS, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUNTINGDON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"INDIANA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRION, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JIM WELLS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIMBLE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KING GEORGE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMAR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMOILLE, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LATIMER, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYNCHBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIDLAND, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTOUR, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NACOGDOCHES, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOBLE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHUMBERLAND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTON CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOTTOWAY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PALO PINTO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEMBINA, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PITTSBURG, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUTHERFORD, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JACINTO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN PATRICIO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SARGENT, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIOUX, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STARK, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLIVAN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SURRY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRINITY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TURNER, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALSH, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARD, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHITA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNESBORO CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBER, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHARTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHEELER, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMS, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINDHAM, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODS, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDERSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARMSTRONG, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BECKHAM, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLOUNT, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOWIE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOKS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CADDO, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALLAHAN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASTRO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHESTER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEARFIELD, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COCKE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COMAL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONCHO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COSHOCTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRANE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CURRY, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEWEY, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DONLEY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FALLS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOSTER, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREESTONE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALAX CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARFIELD, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARVIN, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILLESPIE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAINGER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYSON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRIMES, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMBLEN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HICKMAN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSTON, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNIATA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KAY, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIDDER, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIMESTONE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOUDON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUBBOCK, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MATAGORDA, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAURY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAVERICK, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCKEAN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCLEAN, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEADE, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENARD, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIFFLIN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTAGUE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRIS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NAVARRO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NELSON, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKFUSKEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORANGE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PECOS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUSHMATAHA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANSOM, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RAPPAHANNOCK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REEVES, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANOKE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROLETTE, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUNNELS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALUDA, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEMINOLE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEVIER, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STARR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEPHENS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEWART, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWISHER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TITUS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TODD, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOOELE, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOWNER, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UVALDE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBB, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILBARGER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLACY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODWARD, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYTHE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YOUNG, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ZAVALA, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,338
+,,≥ 45 and < 65 Years,138
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,527
+,Total,Less than 18 Years,366
+,,≥ 18 and < 45 Years,11116
+,,≥ 45 and < 65 Years,4926
+,,65 Years or more,1406
+,,No value,10 or fewer
+,,Total,17814
+Jan 1 – Dec 31 2024,"PHILADELPHIA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,799
+,,≥ 45 and < 65 Years,558
+,,65 Years or more,140
+,,No value,10 or fewer
+,,Total,1500
+,"FRANKLIN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,395
+,,≥ 45 and < 65 Years,218
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,656
+,"MULTNOMAH, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,300
+,,≥ 45 and < 65 Years,101
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,433
+,"CUYAHOGA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,247
+,,≥ 45 and < 65 Years,96
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,396
+,"TARRANT, TX",Less than 18 Years,15
+,,≥ 18 and < 45 Years,217
+,,≥ 45 and < 65 Years,88
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,353
+,"DALLAS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,256
+,,≥ 45 and < 65 Years,64
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,367
+,"HAMILTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,194
+,,≥ 45 and < 65 Years,135
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,365
+,"TULSA, OK",Less than 18 Years,11
+,,≥ 18 and < 45 Years,220
+,,≥ 45 and < 65 Years,56
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,307
+,"MONTGOMERY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,156
+,,≥ 45 and < 65 Years,68
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,239
+,"ALLEGHENY, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,134
+,,≥ 45 and < 65 Years,99
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,264
+,"SHELBY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,112
+,,≥ 45 and < 65 Years,42
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,175
+,"NORFOLK CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,88
+,,≥ 45 and < 65 Years,74
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,187
+,"PORTSMOUTH CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,61
+,,≥ 45 and < 65 Years,121
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,213
+,"SPARTANBURG, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,73
+,,≥ 45 and < 65 Years,57
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,151
+,"LUCAS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,108
+,,≥ 45 and < 65 Years,43
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,165
+,"BUTLER, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,101
+,,≥ 45 and < 65 Years,47
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,154
+,"HARRIS, TX",Less than 18 Years,12
+,,≥ 18 and < 45 Years,95
+,,≥ 45 and < 65 Years,42
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,175
+,"RICHMOND CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,63
+,,≥ 45 and < 65 Years,65
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,142
+,"GREENVILLE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,87
+,,≥ 45 and < 65 Years,37
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,137
+,"CHARLESTON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,70
+,,≥ 45 and < 65 Years,40
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,122
+,"YORK, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,100
+,,≥ 45 and < 65 Years,38
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,151
+,"MAHONING, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,79
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,110
+,"LEHIGH, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,62
+,,≥ 45 and < 65 Years,46
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,128
+,"HENRICO, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,43
+,,≥ 45 and < 65 Years,53
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,108
+,"VIRGINIA BEACH CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,61
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,91
+,"FAIRFAX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,61
+,,≥ 45 and < 65 Years,27
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,106
+,"DAUPHIN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,61
+,,≥ 45 and < 65 Years,39
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,105
+,"DELAWARE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,66
+,,≥ 45 and < 65 Years,30
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,101
+,"RICHLAND, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,52
+,,≥ 45 and < 65 Years,48
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,105
+,"LANCASTER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,71
+,,≥ 45 and < 65 Years,29
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,108
+,"NEWPORT NEWS CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,48
+,,≥ 45 and < 65 Years,33
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,88
+,"CHESAPEAKE CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,47
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,95
+,"HAMILTON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,73
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,101
+,"LORAIN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,67
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,99
+,"TRUMBULL, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,52
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,76
+,"BELL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,47
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,80
+,"MONTGOMERY, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,59
+,,≥ 45 and < 65 Years,22
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,86
+,"ANDERSON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,44
+,,≥ 45 and < 65 Years,27
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,77
+,"BUCKS, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,47
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,79
+,"DESCHUTES, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,56
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,80
+,"NORTHAMPTON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,47
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,68
+,"CHITTENDEN, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,41
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,64
+,"HAMPTON CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,62
+,"PRINCE WILLIAM, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,44
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,65
+,"CLARK, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,41
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,68
+,"FLORENCE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,60
+,"CLERMONT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,42
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,63
+,"SUMMIT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,34
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,53
+,"COLLIN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,37
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,56
+,"RICHLAND, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,58
+,"CHESTER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,44
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,70
+,"CASS, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,35
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"ERIE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,62
+,"HORRY, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,58
+,"LEBANON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,32
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,54
+,"GREENWOOD, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,33
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,47
+,"CHEROKEE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,46
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,64
+,"LICKING, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,43
+,"BERKELEY, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,57
+,"DENTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,42
+,"SULLIVAN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,46
+,"STARK, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"MARION, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"CHESTERFIELD, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"GREENE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"WARREN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,33
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,56
+,"CLACKAMAS, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,34
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,48
+,"LINN, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,47
+,"LANCASTER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,50
+,"SUFFOLK CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,42
+,"CUMBERLAND, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"BEXAR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"WASHINGTON, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"FRANKLIN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"ALLEN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"PICKENS, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"LEXINGTON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"MONROE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"OKLAHOMA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,42
+,"UNION, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"WESTMORELAND, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"BURLEIGH, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"SUMTER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"JOHNSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"WASHINGTON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"BERKS, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"UMATILLA, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,41
+,"COOS, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"KERSHAW, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,38
+,"LUZERNE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"MUSKOGEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"PETERSBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"SCHUYLKILL, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"FAYETTE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"DILLON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"ARLINGTON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"CARBON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"CHARLOTTESVILLE CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"MARION, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"LOUDOUN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"JEFFERSON, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"OCONEE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"TRAVIS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"PICKAWAY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"ATHENS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"DELAWARE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"ORANGEBURG, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,36
+,"SALT LAKE, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"DORCHESTER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"MARION, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"HANOVER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"ELLIS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"LAURENS, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"MIAMI, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"ALEXANDRIA CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CHESTER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"FAIRFIELD, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"TOM GREEN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"LAKE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"CREEK, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MEDINA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"MONTGOMERY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MALHEUR, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"BENTON, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"CROOK, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"GREENE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LINCOLN, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"ADAMS, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"SANDUSKY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"DARLINGTON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"HENDERSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"ALBEMARLE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"BROWN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCLENNAN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WASHINGTON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOOD, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"KAUFMAN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"WAGONER, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"ROGERS, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"YORK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CHESTERFIELD, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"FORT BEND, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SENECA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"GLOUCESTER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREDERICK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"WILLIAMSBURG, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"COLUMBIA, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JAMES CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"SMITH, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"BELMONT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLONIAL HEIGHTS CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"GRAND FORKS, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"HALIFAX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"TIPTON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"PARKER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"ORANGE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"PREBLE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CARTER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOUISA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARENDON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAWKINS, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"OKMULGEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PORTAGE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"POTTER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YORK, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ACCOMACK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"FLUVANNA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MANASSAS CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARLBORO, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ISLE OF WIGHT, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CULPEPER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ROCKINGHAM, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAYES, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DARKE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"PRINCE GEORGE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ERIE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAIRFIELD, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"FAYETTE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"HURON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MECKLENBURG, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DINWIDDIE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINNEHAHA, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"ADDISON, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CHAMPAIGN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEORGETOWN, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOPEWELL CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORTON, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEQUOYAH, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"GALVESTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISONBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PROVIDENCE, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKWALL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMYTH, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAZEWELL, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WISE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARMSTRONG, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BAKER, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CORYELL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEW KENT, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDALL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUSCARAWAS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AIKEN, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRADFORD, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRADLEY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEAUGA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LACKAWANNA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAYNE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEQUATCHIE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUSSEX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASHLAND, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASHTABULA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIANA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DYER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIBERTY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHENANDOAH, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDEMAN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARNEY, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OBION, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ABBEVILLE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRISTOL CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSSELL, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YAMHILL, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRAZORIA, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRAZOS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIDSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAIRFAX CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENSVILLE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LE FLORE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LLANO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN ZANDT, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEVELAND, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOSEPHINE, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANCASTER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANE, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAWNEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROSS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINDSOR, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOOD, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAMBERS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GIBSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HIGHLAND, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUNT, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORANGE, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINCHESTER CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAMBERG, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRUNSWICK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURNET, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARKE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KLAMATH, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STAFFORD, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STUTSMAN, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WISE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYANDOT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKENSON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GUERNSEY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KING WILLIAM, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCINTOSH, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORROW, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWBERRY, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTTAWA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOUTHAMPTON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPOTSYLVANIA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CANADIAN, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEFIANCE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESSEX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAUQUIER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRUNDY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAUDERDALE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MATHEWS, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCKENZIE, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NELSON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWPORT, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAGE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POWHATAN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHMOND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTS, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN WERT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUCKINGHAM, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAIG, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOCKING, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOOD, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIDDLESEX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORROW, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MUSKINGUM, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCIOTO, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNICOI, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEAKLEY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMSBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUGLAIZE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLEDSOE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAROLINE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLLETON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROCKETT, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ERATH, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOOCHLAND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAYS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KING AND QUEEN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYCOMING, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCCORMICK, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCMINN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOUNTRAIL, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSAGE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANOKE CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSK, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UPSHUR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASCO, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUGUSTA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARNWELL, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAUFORT, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAIR, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMBRIA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMERON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIS, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDGEFIELD, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREDERICKSBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREGG, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOOD RIVER, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCNAIRY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHAMPTON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POQUOSON CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RHEA, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHLAND, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUTLAND, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STAUNTON CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UTAH, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VINTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALLER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WESTMORELAND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLOTTE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLATSOP, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELAWARE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAND ISLE, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENT, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMPASAS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MANASSAS PARK CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEIGS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEIGS, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILAM, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTTAWA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PITTSYLVANIA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PONTOTOC, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUSQUEHANNA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIOGA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALKER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDERSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BASTROP, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENNINGTON, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLANCO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOSQUE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUCHANAN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALEDONIA, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMP, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CENTRE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COMANCHE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DANVILLE CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EASTLAND, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ECTOR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EL PASO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FALLS CHURCH CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GUADALUPE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HASKELL, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HILL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUNENBURG, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHUMBERLAND, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOWATA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PANOLA, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAULDING, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTAWATOMIE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRINCE EDWARD, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOMERSET, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMNER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TILLAMOOK, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VENANGO, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYOMING, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YANKTON, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLENDALE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUSTIN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BATH, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRISTOL, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARTER, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLES CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLEMAN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOKE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEAF SMITH, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMPORIA CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALLIA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILES, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAYWOOD, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDERSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HIDALGO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMPHREYS, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUNTINGDON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"INDIANA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRION, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JIM WELLS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIMBLE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KING GEORGE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMAR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMOILLE, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LATIMER, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYNCHBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIDLAND, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTOUR, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NACOGDOCHES, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOBLE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHUMBERLAND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTON CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOTTOWAY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PALO PINTO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEMBINA, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PITTSBURG, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUTHERFORD, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JACINTO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN PATRICIO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SARGENT, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIOUX, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STARK, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLIVAN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SURRY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRINITY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TURNER, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALSH, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARD, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHITA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNESBORO CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBER, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHARTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHEELER, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMS, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINDHAM, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODS, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDERSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARMSTRONG, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BECKHAM, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLOUNT, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOWIE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOKS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CADDO, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALLAHAN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASTRO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHESTER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEARFIELD, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COCKE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COMAL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONCHO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COSHOCTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRANE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CURRY, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEWEY, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DONLEY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FALLS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOSTER, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREESTONE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALAX CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARFIELD, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARVIN, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILLESPIE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAINGER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYSON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRIMES, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMBLEN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HICKMAN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSTON, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNIATA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KAY, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIDDER, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIMESTONE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOUDON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUBBOCK, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MATAGORDA, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAURY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAVERICK, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCKEAN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCLEAN, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEADE, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENARD, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIFFLIN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTAGUE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRIS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NAVARRO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NELSON, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKFUSKEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORANGE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PECOS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUSHMATAHA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANSOM, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RAPPAHANNOCK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REEVES, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANOKE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROLETTE, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUNNELS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALUDA, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEMINOLE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEVIER, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STARR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEPHENS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEWART, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWISHER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TITUS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TODD, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOOELE, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOWNER, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UVALDE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBB, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILBARGER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLACY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODWARD, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYTHE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YOUNG, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ZAVALA, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,11
+,,≥ 18 and < 45 Years,254
+,,≥ 45 and < 65 Years,132
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,434
+,Total,Less than 18 Years,230
+,,≥ 18 and < 45 Years,8061
+,,≥ 45 and < 65 Years,3987
+,,65 Years or more,1323
+,,No value,10 or fewer
+,,Total,13601
+Jan 1 – Jul 17 2025,"PHILADELPHIA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,602
+,,≥ 45 and < 65 Years,421
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,1115
+,"FRANKLIN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,161
+,,≥ 45 and < 65 Years,89
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,267
+,"MULTNOMAH, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,203
+,,≥ 45 and < 65 Years,65
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,281
+,"CUYAHOGA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,129
+,,≥ 45 and < 65 Years,80
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,241
+,"TARRANT, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,208
+,,≥ 45 and < 65 Years,78
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,317
+,"DALLAS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,185
+,,≥ 45 and < 65 Years,56
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,264
+,"HAMILTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,111
+,,≥ 45 and < 65 Years,78
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,213
+,"TULSA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,113
+,,≥ 45 and < 65 Years,31
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,163
+,"MONTGOMERY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,76
+,,≥ 45 and < 65 Years,38
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,123
+,"ALLEGHENY, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,77
+,,≥ 45 and < 65 Years,50
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,146
+,"SHELBY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,174
+,,≥ 45 and < 65 Years,56
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,248
+,"NORFOLK CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,39
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,72
+,"PORTSMOUTH CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,37
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,64
+,"SPARTANBURG, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,51
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,81
+,"LUCAS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,43
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,58
+,"BUTLER, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,60
+,,≥ 45 and < 65 Years,35
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,99
+,"HARRIS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,72
+,,≥ 45 and < 65 Years,25
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,121
+,"RICHMOND CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,42
+,,≥ 45 and < 65 Years,27
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,84
+,"GREENVILLE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,42
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,72
+,"CHARLESTON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,37
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,64
+,"YORK, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"MAHONING, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,33
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,58
+,"LEHIGH, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"HENRICO, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,54
+,"VIRGINIA BEACH CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,50
+,"FAIRFAX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,35
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,51
+,"DAUPHIN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"DELAWARE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,57
+,,≥ 45 and < 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,91
+,"RICHLAND, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"LANCASTER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,31
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,51
+,"NEWPORT NEWS CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"CHESAPEAKE CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,41
+,"HAMILTON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,36
+,"LORAIN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"TRUMBULL, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"BELL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"MONTGOMERY, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,37
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,54
+,"ANDERSON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"BUCKS, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,40
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,61
+,"DESCHUTES, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,26
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"NORTHAMPTON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"CHITTENDEN, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,44
+,"HAMPTON CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"PRINCE WILLIAM, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"CLARK, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"FLORENCE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,45
+,"CLERMONT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"SUMMIT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,36
+,"COLLIN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"RICHLAND, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"CHESTER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"CASS, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,38
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,49
+,"ERIE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HORRY, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"LEBANON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"GREENWOOD, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"CHEROKEE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"LICKING, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"BERKELEY, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"DENTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"SULLIVAN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"STARK, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"MARION, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"CHESTERFIELD, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"GREENE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"WARREN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CLACKAMAS, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"LINN, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LANCASTER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"SUFFOLK CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CUMBERLAND, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"BEXAR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"WASHINGTON, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"FRANKLIN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"ALLEN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PICKENS, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"LEXINGTON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"MONROE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"OKLAHOMA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"UNION, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"WESTMORELAND, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"BURLEIGH, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"SUMTER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"JOHNSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"WASHINGTON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BERKS, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"UMATILLA, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"COOS, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"KERSHAW, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"LUZERNE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MUSKOGEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"PETERSBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SCHUYLKILL, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"FAYETTE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DILLON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"ARLINGTON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CARBON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CHARLOTTESVILLE CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOUDOUN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"OCONEE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRAVIS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PICKAWAY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATHENS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELAWARE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORANGEBURG, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"SALT LAKE, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"DORCHESTER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANOVER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"ELLIS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"LAURENS, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIAMI, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ALEXANDRIA CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CHESTER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAIRFIELD, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"TOM GREEN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CREEK, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEDINA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"MALHEUR, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROOK, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANDUSKY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DARLINGTON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDERSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALBEMARLE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCLENNAN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"WOOD, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KAUFMAN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAGONER, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROGERS, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YORK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHESTERFIELD, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FORT BEND, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"SENECA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLOUCESTER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREDERICK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMSBURG, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JAMES CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BELMONT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLONIAL HEIGHTS CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAND FORKS, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HALIFAX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIPTON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"HARDIN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARKER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORANGE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PREBLE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARTER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOUISA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"CLARENDON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAWKINS, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKMULGEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PORTAGE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YORK, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ACCOMACK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLUVANNA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MANASSAS CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARLBORO, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ISLE OF WIGHT, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CULPEPER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKINGHAM, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAYES, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"DARKE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRINCE GEORGE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ERIE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAIRFIELD, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HURON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MECKLENBURG, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DINWIDDIE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINNEHAHA, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADDISON, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAMPAIGN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEORGETOWN, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOPEWELL CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORTON, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEQUOYAH, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALVESTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISONBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PROVIDENCE, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKWALL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMYTH, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAZEWELL, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WISE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARMSTRONG, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAKER, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CORYELL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEW KENT, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDALL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUSCARAWAS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AIKEN, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRADFORD, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRADLEY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GEAUGA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LACKAWANNA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAYNE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEQUATCHIE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUSSEX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASHLAND, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASHTABULA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIANA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DYER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LIBERTY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHENANDOAH, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDEMAN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARNEY, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OBION, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ABBEVILLE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRISTOL CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSSELL, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YAMHILL, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRAZORIA, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRAZOS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIDSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAIRFAX CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENSVILLE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LE FLORE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LLANO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN ZANDT, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEVELAND, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOSEPHINE, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANCASTER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANE, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAWNEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROSS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINDSOR, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOOD, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAMBERS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GIBSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HIGHLAND, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUNT, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORANGE, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINCHESTER CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAMBERG, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRUNSWICK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURNET, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARKE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KLAMATH, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STAFFORD, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STUTSMAN, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WISE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYANDOT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKENSON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GUERNSEY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KING WILLIAM, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCINTOSH, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORROW, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWBERRY, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTTAWA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOUTHAMPTON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPOTSYLVANIA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CANADIAN, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEFIANCE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESSEX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAUQUIER, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRUNDY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAUDERDALE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MATHEWS, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCKENZIE, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NELSON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWPORT, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAGE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POWHATAN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHMOND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTS, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN WERT, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUCKINGHAM, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAIG, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOCKING, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOOD, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIDDLESEX, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORROW, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MUSKINGUM, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCIOTO, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNICOI, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEAKLEY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMSBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUGLAIZE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLEDSOE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAROLINE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLLETON, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROCKETT, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ERATH, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOOCHLAND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAYS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KING AND QUEEN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYCOMING, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCCORMICK, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCMINN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOUNTRAIL, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSAGE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANOKE CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSK, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UPSHUR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASCO, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUGUSTA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARNWELL, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAUFORT, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAIR, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMBRIA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMERON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIS, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDGEFIELD, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREDERICKSBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREGG, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOOD RIVER, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCNAIRY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHAMPTON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POQUOSON CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RHEA, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHLAND, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUTLAND, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STAUNTON CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UTAH, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VINTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALLER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WESTMORELAND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLOTTE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLATSOP, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELAWARE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAND ISLE, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENT, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMPASAS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MANASSAS PARK CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEIGS, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEIGS, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILAM, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTTAWA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PITTSYLVANIA, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PONTOTOC, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUSQUEHANNA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TIOGA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALKER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDERSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BASTROP, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENNINGTON, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLANCO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOSQUE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUCHANAN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALEDONIA, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMP, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CENTRE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COMANCHE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DANVILLE CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EASTLAND, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ECTOR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EL PASO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FALLS CHURCH CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GUADALUPE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HASKELL, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HILL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUNENBURG, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHUMBERLAND, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOWATA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PANOLA, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAULDING, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTAWATOMIE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRINCE EDWARD, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOMERSET, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMNER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TILLAMOOK, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VENANGO, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYOMING, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YANKTON, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLENDALE, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUSTIN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BATH, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRISTOL, RI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARTER, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLES CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLEMAN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOKE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMBERLAND, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEAF SMITH, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMPORIA CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALLIA, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILES, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAYWOOD, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENDERSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HIDALGO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMPHREYS, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUNTINGDON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"INDIANA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRION, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JIM WELLS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIMBLE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KING GEORGE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMAR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMOILLE, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LATIMER, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYNCHBURG CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIDLAND, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTOUR, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NACOGDOCHES, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOBLE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHUMBERLAND, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTON CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOTTOWAY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PALO PINTO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEMBINA, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PITTSBURG, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUTHERFORD, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JACINTO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN PATRICIO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SARGENT, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIOUX, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STARK, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLIVAN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SURRY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRINITY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TURNER, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALSH, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARD, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHITA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNESBORO CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBER, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHARTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHEELER, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMS, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINDHAM, VT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODS, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDERSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARMSTRONG, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BECKHAM, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLOUNT, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOWIE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOKS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CADDO, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALLAHAN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASTRO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHESTER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEARFIELD, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COCKE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COMAL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONCHO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COSHOCTON, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRANE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CURRY, OR",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEWEY, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DONLEY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FALLS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOSTER, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREESTONE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALAX CITY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARFIELD, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARVIN, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILLESPIE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAINGER, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYSON, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRIMES, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMBLEN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HICKMAN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSTON, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNIATA, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KAY, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIDDER, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIMESTONE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOUDON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUBBOCK, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MATAGORDA, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAURY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAVERICK, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCKEAN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCLEAN, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEADE, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENARD, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIFFLIN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTAGUE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, OH",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRIS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NAVARRO, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NELSON, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKFUSKEE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORANGE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PECOS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUSHMATAHA, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANSOM, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RAPPAHANNOCK, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REEVES, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANOKE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROLETTE, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUNNELS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALUDA, SC",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEMINOLE, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEVIER, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STARR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEPHENS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEWART, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWISHER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TITUS, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TODD, SD",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOOELE, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOWNER, ND",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UVALDE, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, PA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, UT",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBB, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILBARGER, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLACY, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLIAMSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILSON, TN",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODWARD, OK",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYTHE, VA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YOUNG, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ZAVALA, TX",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,200
+,,≥ 45 and < 65 Years,91
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,327
+,Total,Less than 18 Years,83
+,,≥ 18 and < 45 Years,4682
+,,≥ 45 and < 65 Years,2306
+,,65 Years or more,772
+,,No value,10 or fewer
+,,Total,7843

--- a/data/epic/raw/staging/D01d_OPIOID_EDvisits_County_WA_WY_Year_Age.csv
+++ b/data/epic/raw/staging/D01d_OPIOID_EDvisits_County_WA_WY_Year_Age.csv
@@ -1,0 +1,2750 @@
+﻿Session Title,"Opioid Overdoses in ED, WA-WY",,
+Session Description,ED encountersND-VA by countycount pts with ED diagnosis opioid overdose,,
+Session ID,2748530,,
+Data Model,ED Encounters,,
+Population Base,All ED Encounters,,
+Population Criteria Filters: These criteria are a summary and do not fully reflect the content of the exported session.,ED Diagnoses: EDG ICD-10 OPIOID OVERDOSE,State of Residence (U.S.): WA_WY,
+Session Date Range,1/1/2023 - 7/17/2025 (Based On Arrival Date),,
+Measure,Number of ED Encounters,,
+Export User,Stephanie Perniciaro,,
+Date of Export,8/8/2025,,
+,,,
+,,,
+,,,Number of ED Encounters
+Year,County of Residence,Age at Time of Visit,
+Jan 1 – Dec 31 2023,"KING, WA",Less than 18 Years,14
+,,≥ 18 and < 45 Years,325
+,,≥ 45 and < 65 Years,92
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,463
+,"MILWAUKEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,215
+,,≥ 45 and < 65 Years,139
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,381
+,"CLARK, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,102
+,,≥ 45 and < 65 Years,45
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,157
+,"DANE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,95
+,,≥ 45 and < 65 Years,51
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,159
+,"SNOHOMISH, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,64
+,,≥ 45 and < 65 Years,29
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,97
+,"BERKELEY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,50
+,,≥ 45 and < 65 Years,27
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,79
+,"BROWN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,56
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,79
+,"SKAGIT, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,39
+,,≥ 45 and < 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,63
+,"WOOD, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,43
+,,≥ 45 and < 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,60
+,"LA CROSSE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,44
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,59
+,"MERCER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,27
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,43
+,"HARRISON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,22
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"OHIO, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,28
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"PIERCE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,29
+,"MONONGALIA, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,29
+,,≥ 45 and < 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,42
+,"LARAMIE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"MARION, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,24
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"WAUKESHA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"KANAWHA, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALWORTH, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"KENOSHA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"RACINE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,15
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"ROCK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"JEFFERSON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,17
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"DOUGLAS, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"SHEBOYGAN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MANITOWOC, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"WINNEBAGO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"COWLITZ, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CHELAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"WASHINGTON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,13
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"DOUGLAS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMPSHIRE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OZAUKEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRAXTON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ISLAND, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UPSHUR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARINETTE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINERAL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NICHOLAS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RITCHIE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAU CLAIRE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRESTON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THURSTON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHATCOM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALBANY, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OUTAGAMIE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHIPPEWA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOND DU LAC, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WETZEL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YAKIMA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KITSAP, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OCONTO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VERNON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DODGE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDOWELL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TREMPEALEAU, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOKE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREEN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEWAUNEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLEASANTS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RALEIGH, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAUK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DODDRIDGE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNEAU, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARATHON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKANOGAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPOKANE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOOD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASHLAND, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURNETT, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOREST, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILMER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NATRONA, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONEIDA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PACIFIC, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PORTAGE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CROIX, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHAWANO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHBURN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYS HARBOR, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANGLADE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIERCE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAWYER, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUCKER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAUPACA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WIRT, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASOTIN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARBOUR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALUMET, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARBON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLALLAM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONVERSE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOSHEN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IOWA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KITTITAS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENOMINEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARK, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEND OREILLE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEPIN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLATTE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POCAHONTAS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SKAMANIA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMMERS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TYLER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALLA WALLA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHAKIE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITMAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYOMING, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,52
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,73
+,Total,Less than 18 Years,48
+,,≥ 18 and < 45 Years,1610
+,,≥ 45 and < 65 Years,636
+,,65 Years or more,155
+,,No value,10 or fewer
+,,Total,2449
+Jan 1 – Dec 31 2024,"KING, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,234
+,,≥ 45 and < 65 Years,105
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,369
+,"MILWAUKEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,162
+,,≥ 45 and < 65 Years,93
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,276
+,"CLARK, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,79
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,100
+,"DANE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,64
+,,≥ 45 and < 65 Years,26
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,101
+,"SNOHOMISH, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,49
+,,≥ 45 and < 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,76
+,"BERKELEY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,42
+,,≥ 45 and < 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,65
+,"BROWN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,31
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"SKAGIT, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,41
+,,≥ 45 and < 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,59
+,"WOOD, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"LA CROSSE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,23
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"MERCER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,16
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,36
+,"HARRISON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,12
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"OHIO, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,18
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"PIERCE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,19
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"MONONGALIA, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LARAMIE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MARION, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"WAUKESHA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"KANAWHA, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"WALWORTH, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"KENOSHA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"RACINE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"JEFFERSON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"SHEBOYGAN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MANITOWOC, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"WINNEBAGO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"COWLITZ, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHELAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MARSHALL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WASHINGTON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMPSHIRE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OZAUKEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRAXTON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ISLAND, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UPSHUR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARINETTE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINERAL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NICHOLAS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RITCHIE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAU CLAIRE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRESTON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THURSTON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHATCOM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALBANY, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OUTAGAMIE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHIPPEWA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOND DU LAC, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WETZEL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YAKIMA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KITSAP, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OCONTO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VERNON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DODGE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDOWELL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TREMPEALEAU, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOKE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREEN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEWAUNEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLEASANTS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RALEIGH, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAUK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DODDRIDGE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNEAU, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARATHON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKANOGAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPOKANE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOOD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASHLAND, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURNETT, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOREST, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILMER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NATRONA, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONEIDA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PACIFIC, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PORTAGE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CROIX, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHAWANO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHBURN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYS HARBOR, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANGLADE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIERCE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAWYER, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUCKER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAUPACA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WIRT, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASOTIN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARBOUR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALUMET, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARBON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLALLAM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONVERSE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOSHEN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IOWA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KITTITAS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENOMINEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARK, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEND OREILLE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEPIN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLATTE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POCAHONTAS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SKAMANIA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMMERS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TYLER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALLA WALLA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHAKIE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITMAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYOMING, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,36
+,,≥ 45 and < 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,58
+,Total,Less than 18 Years,27
+,,≥ 18 and < 45 Years,1123
+,,≥ 45 and < 65 Years,471
+,,65 Years or more,134
+,,No value,10 or fewer
+,,Total,1755
+Jan 1 – Jul 17 2025,"KING, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,115
+,,≥ 45 and < 65 Years,46
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,179
+,"MILWAUKEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,41
+,,≥ 45 and < 65 Years,27
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,82
+,"CLARK, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,44
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,67
+,"DANE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,21
+,,≥ 45 and < 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,43
+,"SNOHOMISH, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,25
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,46
+,"BERKELEY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"BROWN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,20
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"SKAGIT, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,14
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"WOOD, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"LA CROSSE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MERCER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"HARRISON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OHIO, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"PIERCE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MONONGALIA, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LARAMIE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MARION, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAUKESHA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KANAWHA, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,11
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"WALWORTH, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENOSHA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RACINE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"JEFFERSON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHEBOYGAN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MANITOWOC, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINNEBAGO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COWLITZ, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHELAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMPSHIRE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OZAUKEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRAXTON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ISLAND, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UPSHUR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARINETTE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINERAL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NICHOLAS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RITCHIE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAU CLAIRE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRESTON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THURSTON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHATCOM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALBANY, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OUTAGAMIE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHIPPEWA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOND DU LAC, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WETZEL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YAKIMA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KITSAP, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OCONTO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VERNON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DODGE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDOWELL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TREMPEALEAU, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOKE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREEN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEWAUNEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLEASANTS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RALEIGH, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAUK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DODDRIDGE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNEAU, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARATHON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKANOGAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPOKANE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOOD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASHLAND, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURNETT, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOREST, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILMER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NATRONA, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONEIDA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PACIFIC, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PORTAGE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CROIX, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHAWANO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHBURN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYS HARBOR, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANGLADE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIERCE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAWYER, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUCKER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAUPACA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WIRT, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASOTIN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARBOUR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALUMET, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARBON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLALLAM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONVERSE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOSHEN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IOWA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KITTITAS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENOMINEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARK, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEND OREILLE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEPIN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLATTE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POCAHONTAS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SKAMANIA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMMERS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TYLER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALLA WALLA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHAKIE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITMAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYOMING, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,10 or fewer
+,,≥ 18 and < 45 Years,10 or fewer
+,,≥ 45 and < 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,Total,Less than 18 Years,11
+,,≥ 18 and < 45 Years,456
+,,≥ 45 and < 65 Years,209
+,,65 Years or more,89
+,,No value,10 or fewer
+,,Total,765

--- a/data/epic/raw/staging/D02a_Falls_EDvisits_CountiesAL_KS_Year_Age.csv
+++ b/data/epic/raw/staging/D02a_Falls_EDvisits_CountiesAL_KS_Year_Age.csv
@@ -1,0 +1,11678 @@
+﻿Session Title,Falls in AL-KS,,
+Session Description,county level by year,,
+Session ID,2748495,,
+Data Model,ED Encounters,,
+Population Base,All ED Encounters,,
+Population Criteria Filters: These criteria are a summary and do not fully reflect the content of the exported session.,State of Residence (U.S.): StateGroupA,ED Diagnoses: Fall,
+Session Date Range,1/1/2023 - 7/10/2025 (Based On Arrival Date),,
+Measure,Number of ED Encounters,,
+Export User,Stephanie Perniciaro,,
+Date of Export,8/8/2025,,
+,,,
+,,,
+,,,Number of ED Encounters
+Year,County of Residence,Age at Time of Visit,
+Jan 1 – Dec 31 2023,"COOK, IL",Less than 65 Years,6242
+,,65 Years or more,10697
+,,No value,10 or fewer
+,,Total,16939
+,"SAN DIEGO, CA",Less than 65 Years,3817
+,,65 Years or more,9341
+,,No value,10 or fewer
+,,Total,13158
+,"ORANGE, FL",Less than 65 Years,6203
+,,65 Years or more,7344
+,,No value,10 or fewer
+,,Total,13547
+,"LEE, FL",Less than 65 Years,3706
+,,65 Years or more,8124
+,,No value,10 or fewer
+,,Total,11830
+,"DUVAL, FL",Less than 65 Years,4590
+,,65 Years or more,4892
+,,No value,10 or fewer
+,,Total,9482
+,"MARICOPA, AZ",Less than 65 Years,3025
+,,65 Years or more,6229
+,,No value,10 or fewer
+,,Total,9254
+,"HONOLULU, HI",Less than 65 Years,3378
+,,65 Years or more,4840
+,,No value,10 or fewer
+,,Total,8218
+,"BROWARD, FL",Less than 65 Years,2995
+,,65 Years or more,4813
+,,No value,10 or fewer
+,,Total,7808
+,"NEW HAVEN, CT",Less than 65 Years,2582
+,,65 Years or more,4792
+,,No value,10 or fewer
+,,Total,7374
+,"VOLUSIA, FL",Less than 65 Years,2302
+,,65 Years or more,5017
+,,No value,10 or fewer
+,,Total,7319
+,"FRESNO, CA",Less than 65 Years,3042
+,,65 Years or more,3208
+,,No value,10 or fewer
+,,Total,6250
+,"HILLSBOROUGH, FL",Less than 65 Years,3117
+,,65 Years or more,3561
+,,No value,10 or fewer
+,,Total,6678
+,"EL PASO, CO",Less than 65 Years,3500
+,,65 Years or more,3368
+,,No value,10 or fewer
+,,Total,6868
+,"LAKE, FL",Less than 65 Years,1748
+,,65 Years or more,4702
+,,No value,10 or fewer
+,,Total,6450
+,"HARTFORD, CT",Less than 65 Years,2134
+,,65 Years or more,3603
+,,No value,10 or fewer
+,,Total,5737
+,"ADA, ID",Less than 65 Years,1913
+,,65 Years or more,3654
+,,No value,10 or fewer
+,,Total,5567
+,"COBB, GA",Less than 65 Years,2168
+,,65 Years or more,3274
+,,No value,10 or fewer
+,,Total,5442
+,"RIVERSIDE, CA",Less than 65 Years,1965
+,,65 Years or more,3276
+,,No value,10 or fewer
+,,Total,5241
+,"SEMINOLE, FL",Less than 65 Years,1612
+,,65 Years or more,3008
+,,No value,10 or fewer
+,,Total,4620
+,"FULTON, GA",Less than 65 Years,1828
+,,65 Years or more,2165
+,,No value,10 or fewer
+,,Total,3993
+,"FAIRFIELD, CT",Less than 65 Years,1420
+,,65 Years or more,2659
+,,No value,10 or fewer
+,,Total,4079
+,"MARION, IN",Less than 65 Years,1950
+,,65 Years or more,2040
+,,No value,10 or fewer
+,,Total,3990
+,"PULASKI, AR",Less than 65 Years,1858
+,,65 Years or more,2182
+,,No value,10 or fewer
+,,Total,4040
+,"ALLEN, IN",Less than 65 Years,1551
+,,65 Years or more,2095
+,,No value,10 or fewer
+,,Total,3646
+,"OSCEOLA, FL",Less than 65 Years,2000
+,,65 Years or more,1504
+,,No value,10 or fewer
+,,Total,3504
+,"HALL, GA",Less than 65 Years,1404
+,,65 Years or more,2053
+,,No value,10 or fewer
+,,Total,3457
+,"PASCO, FL",Less than 65 Years,1168
+,,65 Years or more,2101
+,,No value,10 or fewer
+,,Total,3269
+,"DEKALB, GA",Less than 65 Years,1612
+,,65 Years or more,1635
+,,No value,10 or fewer
+,,Total,3247
+,"SAN BERNARDINO, CA",Less than 65 Years,1693
+,,65 Years or more,1467
+,,No value,10 or fewer
+,,Total,3160
+,"JOHNSON, KS",Less than 65 Years,745
+,,65 Years or more,2303
+,,No value,10 or fewer
+,,Total,3048
+,"DENVER, CO",Less than 65 Years,1795
+,,65 Years or more,1129
+,,No value,10 or fewer
+,,Total,2924
+,"PINELLAS, FL",Less than 65 Years,1175
+,,65 Years or more,2148
+,,No value,10 or fewer
+,,Total,3323
+,"POLK, IA",Less than 65 Years,1558
+,,65 Years or more,1573
+,,No value,10 or fewer
+,,Total,3131
+,"MARION, FL",Less than 65 Years,1312
+,,65 Years or more,1466
+,,No value,10 or fewer
+,,Total,2778
+,"NEW LONDON, CT",Less than 65 Years,1031
+,,65 Years or more,1984
+,,No value,10 or fewer
+,,Total,3015
+,"LAKE, IL",Less than 65 Years,636
+,,65 Years or more,2100
+,,No value,10 or fewer
+,,Total,2736
+,"LINN, IA",Less than 65 Years,1122
+,,65 Years or more,1804
+,,No value,10 or fewer
+,,Total,2926
+,"COLLIER, FL",Less than 65 Years,859
+,,65 Years or more,1987
+,,No value,10 or fewer
+,,Total,2846
+,"POLK, FL",Less than 65 Years,1178
+,,65 Years or more,1337
+,,No value,10 or fewer
+,,Total,2515
+,"WINNEBAGO, IL",Less than 65 Years,1077
+,,65 Years or more,1722
+,,No value,10 or fewer
+,,Total,2799
+,"DUPAGE, IL",Less than 65 Years,533
+,,65 Years or more,1379
+,,No value,10 or fewer
+,,Total,1912
+,"MIDDLESEX, CT",Less than 65 Years,766
+,,65 Years or more,1929
+,,No value,10 or fewer
+,,Total,2695
+,"CANYON, ID",Less than 65 Years,1099
+,,65 Years or more,1473
+,,No value,10 or fewer
+,,Total,2572
+,"LARIMER, CO",Less than 65 Years,797
+,,65 Years or more,1789
+,,No value,10 or fewer
+,,Total,2586
+,"ARAPAHOE, CO",Less than 65 Years,1069
+,,65 Years or more,690
+,,No value,10 or fewer
+,,Total,1759
+,"ORANGE, CA",Less than 65 Years,454
+,,65 Years or more,1024
+,,No value,10 or fewer
+,,Total,1478
+,"FLAGLER, FL",Less than 65 Years,613
+,,65 Years or more,1740
+,,No value,10 or fewer
+,,Total,2353
+,"ALAMEDA, CA",Less than 65 Years,1008
+,,65 Years or more,1347
+,,No value,10 or fewer
+,,Total,2355
+,"PEORIA, IL",Less than 65 Years,826
+,,65 Years or more,1482
+,,No value,10 or fewer
+,,Total,2308
+,"WELD, CO",Less than 65 Years,1035
+,,65 Years or more,1227
+,,No value,10 or fewer
+,,Total,2262
+,"CHAMPAIGN, IL",Less than 65 Years,897
+,,65 Years or more,1390
+,,No value,10 or fewer
+,,Total,2287
+,"SANTA CLARA, CA",Less than 65 Years,645
+,,65 Years or more,1499
+,,No value,10 or fewer
+,,Total,2144
+,"PIMA, AZ",Less than 65 Years,812
+,,65 Years or more,1240
+,,No value,10 or fewer
+,,Total,2052
+,"SHAWNEE, KS",Less than 65 Years,752
+,,65 Years or more,1380
+,,No value,10 or fewer
+,,Total,2132
+,"LAKE, IN",Less than 65 Years,890
+,,65 Years or more,1188
+,,No value,10 or fewer
+,,Total,2078
+,"SUMTER, FL",Less than 65 Years,251
+,,65 Years or more,1651
+,,No value,10 or fewer
+,,Total,1902
+,"MARTIN, FL",Less than 65 Years,321
+,,65 Years or more,1262
+,,No value,10 or fewer
+,,Total,1583
+,"SUSSEX, DE",Less than 65 Years,792
+,,65 Years or more,1273
+,,No value,10 or fewer
+,,Total,2065
+,"MIAMI-DADE, FL",Less than 65 Years,1117
+,,65 Years or more,899
+,,No value,10 or fewer
+,,Total,2016
+,"TAZEWELL, IL",Less than 65 Years,634
+,,65 Years or more,1419
+,,No value,10 or fewer
+,,Total,2053
+,"NASSAU, FL",Less than 65 Years,641
+,,65 Years or more,1175
+,,No value,10 or fewer
+,,Total,1816
+,"GWINNETT, GA",Less than 65 Years,904
+,,65 Years or more,916
+,,No value,10 or fewer
+,,Total,1820
+,"BALDWIN, AL",Less than 65 Years,689
+,,65 Years or more,1212
+,,No value,10 or fewer
+,,Total,1901
+,"ST JOSEPH, IN",Less than 65 Years,615
+,,65 Years or more,1180
+,,No value,10 or fewer
+,,Total,1795
+,"SAN FRANCISCO, CA",Less than 65 Years,890
+,,65 Years or more,936
+,,No value,10 or fewer
+,,Total,1826
+,"SAINT JOHNS, FL",Less than 65 Years,456
+,,65 Years or more,1023
+,,No value,10 or fewer
+,,Total,1479
+,"KENT, DE",Less than 65 Years,725
+,,65 Years or more,1188
+,,No value,10 or fewer
+,,Total,1913
+,"BOULDER, CO",Less than 65 Years,568
+,,65 Years or more,998
+,,No value,10 or fewer
+,,Total,1566
+,"LOWNDES, GA",Less than 65 Years,712
+,,65 Years or more,1044
+,,No value,10 or fewer
+,,Total,1756
+,"KANE, IL",Less than 65 Years,644
+,,65 Years or more,951
+,,No value,10 or fewer
+,,Total,1595
+,"JEFFERSON, CO",Less than 65 Years,679
+,,65 Years or more,801
+,,No value,10 or fewer
+,,Total,1480
+,"WYANDOTTE, KS",Less than 65 Years,758
+,,65 Years or more,748
+,,No value,10 or fewer
+,,Total,1506
+,"MOBILE, AL",Less than 65 Years,743
+,,65 Years or more,1005
+,,No value,10 or fewer
+,,Total,1748
+,"INDIAN RIVER, FL",Less than 65 Years,184
+,,65 Years or more,1232
+,,No value,10 or fewer
+,,Total,1416
+,"CLAY, FL",Less than 65 Years,685
+,,65 Years or more,797
+,,No value,10 or fewer
+,,Total,1482
+,"ROCK ISLAND, IL",Less than 65 Years,634
+,,65 Years or more,957
+,,No value,10 or fewer
+,,Total,1591
+,"SAINT LUCIE, FL",Less than 65 Years,379
+,,65 Years or more,794
+,,No value,10 or fewer
+,,Total,1173
+,"MCLEAN, IL",Less than 65 Years,507
+,,65 Years or more,973
+,,No value,10 or fewer
+,,Total,1480
+,"ALACHUA, FL",Less than 65 Years,727
+,,65 Years or more,868
+,,No value,10 or fewer
+,,Total,1595
+,"ADAMS, CO",Less than 65 Years,953
+,,65 Years or more,551
+,,No value,10 or fewer
+,,Total,1504
+,"PUEBLO, CO",Less than 65 Years,672
+,,65 Years or more,880
+,,No value,10 or fewer
+,,Total,1552
+,"VANDERBURGH, IN",Less than 65 Years,722
+,,65 Years or more,906
+,,No value,10 or fewer
+,,Total,1628
+,"TWIN FALLS, ID",Less than 65 Years,572
+,,65 Years or more,908
+,,No value,10 or fewer
+,,Total,1480
+,"SAN MATEO, CA",Less than 65 Years,450
+,,65 Years or more,868
+,,No value,10 or fewer
+,,Total,1318
+,"DOUGLAS, CO",Less than 65 Years,278
+,,65 Years or more,351
+,,No value,10 or fewer
+,,Total,629
+,"HIGHLANDS, FL",Less than 65 Years,395
+,,65 Years or more,806
+,,No value,10 or fewer
+,,Total,1201
+,"PALM BEACH, FL",Less than 65 Years,213
+,,65 Years or more,328
+,,No value,10 or fewer
+,,Total,541
+,"CLARK, IN",Less than 65 Years,617
+,,65 Years or more,562
+,,No value,10 or fewer
+,,Total,1179
+,"PAULDING, GA",Less than 65 Years,594
+,,65 Years or more,626
+,,No value,10 or fewer
+,,Total,1220
+,"JOHNSON, IA",Less than 65 Years,356
+,,65 Years or more,577
+,,No value,10 or fewer
+,,Total,933
+,"BARROW, GA",Less than 65 Years,556
+,,65 Years or more,543
+,,No value,10 or fewer
+,,Total,1099
+,"FLOYD, IN",Less than 65 Years,502
+,,65 Years or more,696
+,,No value,10 or fewer
+,,Total,1198
+,"WHITFIELD, GA",Less than 65 Years,150
+,,65 Years or more,148
+,,No value,10 or fewer
+,,Total,298
+,"DOUGLAS, GA",Less than 65 Years,543
+,,65 Years or more,591
+,,No value,10 or fewer
+,,Total,1134
+,"SAINT CLAIR, IL",Less than 65 Years,358
+,,65 Years or more,623
+,,No value,10 or fewer
+,,Total,981
+,"BARTHOLOMEW, IN",Less than 65 Years,316
+,,65 Years or more,635
+,,No value,10 or fewer
+,,Total,951
+,"NEW CASTLE, DE",Less than 65 Years,615
+,,65 Years or more,398
+,,No value,10 or fewer
+,,Total,1013
+,"LOS ANGELES, CA",Less than 65 Years,468
+,,65 Years or more,471
+,,No value,10 or fewer
+,,Total,939
+,"KNOX, IL",Less than 65 Years,367
+,,65 Years or more,619
+,,No value,10 or fewer
+,,Total,986
+,"WINDHAM, CT",Less than 65 Years,425
+,,65 Years or more,482
+,,No value,10 or fewer
+,,Total,907
+,"WILL, IL",Less than 65 Years,250
+,,65 Years or more,308
+,,No value,10 or fewer
+,,Total,558
+,"WOODBURY, IA",Less than 65 Years,496
+,,65 Years or more,506
+,,No value,10 or fewer
+,,Total,1002
+,"SEBASTIAN, AR",Less than 65 Years,464
+,,65 Years or more,413
+,,No value,10 or fewer
+,,Total,877
+,"HABERSHAM, GA",Less than 65 Years,279
+,,65 Years or more,380
+,,No value,10 or fewer
+,,Total,659
+,"CHEROKEE, GA",Less than 65 Years,355
+,,65 Years or more,507
+,,No value,10 or fewer
+,,Total,862
+,"JACKSON, GA",Less than 65 Years,388
+,,65 Years or more,487
+,,No value,10 or fewer
+,,Total,875
+,"GORDON, GA",Less than 65 Years,302
+,,65 Years or more,386
+,,No value,10 or fewer
+,,Total,688
+,"LA SALLE, IL",Less than 65 Years,195
+,,65 Years or more,436
+,,No value,10 or fewer
+,,Total,631
+,"LITCHFIELD, CT",Less than 65 Years,237
+,,65 Years or more,537
+,,No value,10 or fewer
+,,Total,774
+,"MCHENRY, IL",Less than 65 Years,264
+,,65 Years or more,486
+,,No value,10 or fewer
+,,Total,750
+,"MADERA, CA",Less than 65 Years,306
+,,65 Years or more,323
+,,No value,10 or fewer
+,,Total,629
+,"HOUSTON, AL",Less than 65 Years,278
+,,65 Years or more,393
+,,No value,10 or fewer
+,,Total,671
+,"WAYNE, IN",Less than 65 Years,300
+,,65 Years or more,499
+,,No value,10 or fewer
+,,Total,799
+,"KENDALL, IL",Less than 65 Years,240
+,,65 Years or more,453
+,,No value,10 or fewer
+,,Total,693
+,"KNOX, IN",Less than 65 Years,274
+,,65 Years or more,441
+,,No value,10 or fewer
+,,Total,715
+,"VERMILION, IL",Less than 65 Years,263
+,,65 Years or more,464
+,,No value,10 or fewer
+,,Total,727
+,"SANGAMON, IL",Less than 65 Years,314
+,,65 Years or more,376
+,,No value,10 or fewer
+,,Total,690
+,"NOBLE, IN",Less than 65 Years,294
+,,65 Years or more,445
+,,No value,10 or fewer
+,,Total,739
+,"BLACK HAWK, IA",Less than 65 Years,255
+,,65 Years or more,411
+,,No value,10 or fewer
+,,Total,666
+,"MADISON, IN",Less than 65 Years,263
+,,65 Years or more,389
+,,No value,10 or fewer
+,,Total,652
+,"TOLLAND, CT",Less than 65 Years,227
+,,65 Years or more,414
+,,No value,10 or fewer
+,,Total,641
+,"JOHNSON, IN",Less than 65 Years,188
+,,65 Years or more,507
+,,No value,10 or fewer
+,,Total,695
+,"SCOTT, IA",Less than 65 Years,328
+,,65 Years or more,332
+,,No value,10 or fewer
+,,Total,660
+,"CRAIGHEAD, AR",Less than 65 Years,366
+,,65 Years or more,359
+,,No value,10 or fewer
+,,Total,725
+,"SPALDING, GA",Less than 65 Years,353
+,,65 Years or more,344
+,,No value,10 or fewer
+,,Total,697
+,"FLOYD, GA",Less than 65 Years,150
+,,65 Years or more,407
+,,No value,10 or fewer
+,,Total,557
+,"CITRUS, FL",Less than 65 Years,99
+,,65 Years or more,116
+,,No value,10 or fewer
+,,Total,215
+,"MARSHALL, IN",Less than 65 Years,265
+,,65 Years or more,457
+,,No value,10 or fewer
+,,Total,722
+,"MURRAY, GA",Less than 65 Years,210
+,,65 Years or more,196
+,,No value,10 or fewer
+,,Total,406
+,"LONOKE, AR",Less than 65 Years,250
+,,65 Years or more,426
+,,No value,10 or fewer
+,,Total,676
+,"LUMPKIN, GA",Less than 65 Years,183
+,,65 Years or more,415
+,,No value,10 or fewer
+,,Total,598
+,"CONTRA COSTA, CA",Less than 65 Years,340
+,,65 Years or more,304
+,,No value,10 or fewer
+,,Total,644
+,"HUNTINGTON, IN",Less than 65 Years,248
+,,65 Years or more,387
+,,No value,10 or fewer
+,,Total,635
+,"HERNANDO, FL",Less than 65 Years,92
+,,65 Years or more,124
+,,No value,10 or fewer
+,,Total,216
+,"DUBUQUE, IA",Less than 65 Years,246
+,,65 Years or more,414
+,,No value,10 or fewer
+,,Total,660
+,"BANNOCK, ID",Less than 65 Years,328
+,,65 Years or more,363
+,,No value,10 or fewer
+,,Total,691
+,"FORSYTH, GA",Less than 65 Years,175
+,,65 Years or more,362
+,,No value,10 or fewer
+,,Total,537
+,"WHITE, GA",Less than 65 Years,197
+,,65 Years or more,337
+,,No value,10 or fewer
+,,Total,534
+,"WHITLEY, IN",Less than 65 Years,195
+,,65 Years or more,380
+,,No value,10 or fewer
+,,Total,575
+,"TROUP, GA",Less than 65 Years,235
+,,65 Years or more,330
+,,No value,10 or fewer
+,,Total,565
+,"FAULKNER, AR",Less than 65 Years,275
+,,65 Years or more,279
+,,No value,10 or fewer
+,,Total,554
+,"MARSHALL, IA",Less than 65 Years,186
+,,65 Years or more,342
+,,No value,10 or fewer
+,,Total,528
+,"MADISON, IL",Less than 65 Years,165
+,,65 Years or more,333
+,,No value,10 or fewer
+,,Total,498
+,"CRITTENDEN, AR",Less than 65 Years,364
+,,65 Years or more,252
+,,No value,10 or fewer
+,,Total,616
+,"MUSCATINE, IA",Less than 65 Years,169
+,,65 Years or more,275
+,,No value,10 or fewer
+,,Total,444
+,"WABASH, IN",Less than 65 Years,170
+,,65 Years or more,351
+,,No value,10 or fewer
+,,Total,521
+,"HAWAII, HI",Less than 65 Years,130
+,,65 Years or more,264
+,,No value,10 or fewer
+,,Total,394
+,"BOONE, IL",Less than 65 Years,128
+,,65 Years or more,363
+,,No value,10 or fewer
+,,Total,491
+,"HOWARD, IN",Less than 65 Years,151
+,,65 Years or more,263
+,,No value,10 or fewer
+,,Total,414
+,"CRAWFORD, AR",Less than 65 Years,213
+,,65 Years or more,278
+,,No value,10 or fewer
+,,Total,491
+,"SALINE, AR",Less than 65 Years,268
+,,65 Years or more,225
+,,No value,10 or fewer
+,,Total,493
+,"KOSCIUSKO, IN",Less than 65 Years,264
+,,65 Years or more,224
+,,No value,10 or fewer
+,,Total,488
+,"MESA, CO",Less than 65 Years,204
+,,65 Years or more,254
+,,No value,10 or fewer
+,,Total,458
+,"WASHINGTON, AR",Less than 65 Years,502
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,523
+,"BARTON, KS",Less than 65 Years,193
+,,65 Years or more,251
+,,No value,10 or fewer
+,,Total,444
+,"CLARKE, GA",Less than 65 Years,168
+,,65 Years or more,233
+,,No value,10 or fewer
+,,Total,401
+,"GREENE, GA",Less than 65 Years,133
+,,65 Years or more,284
+,,No value,10 or fewer
+,,Total,417
+,"ELMORE, ID",Less than 65 Years,189
+,,65 Years or more,230
+,,No value,10 or fewer
+,,Total,419
+,"WEBSTER, IA",Less than 65 Years,164
+,,65 Years or more,236
+,,No value,10 or fewer
+,,Total,400
+,"BENTON, AR",Less than 65 Years,348
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,379
+,"CLEBURNE, AR",Less than 65 Years,164
+,,65 Years or more,259
+,,No value,10 or fewer
+,,Total,423
+,"HAMILTON, IN",Less than 65 Years,127
+,,65 Years or more,277
+,,No value,10 or fewer
+,,Total,404
+,"WARRICK, IN",Less than 65 Years,135
+,,65 Years or more,267
+,,No value,10 or fewer
+,,Total,402
+,"CLINTON, IL",Less than 65 Years,82
+,,65 Years or more,231
+,,No value,10 or fewer
+,,Total,313
+,"BREVARD, FL",Less than 65 Years,185
+,,65 Years or more,181
+,,No value,10 or fewer
+,,Total,366
+,"WOODFORD, IL",Less than 65 Years,88
+,,65 Years or more,303
+,,No value,10 or fewer
+,,Total,391
+,"PAYETTE, ID",Less than 65 Years,126
+,,65 Years or more,208
+,,No value,10 or fewer
+,,Total,334
+,"FRANKLIN, GA",Less than 65 Years,152
+,,65 Years or more,192
+,,No value,10 or fewer
+,,Total,344
+,"LAGRANGE, IN",Less than 65 Years,145
+,,65 Years or more,228
+,,No value,10 or fewer
+,,Total,373
+,"EFFINGHAM, IL",Less than 65 Years,92
+,,65 Years or more,239
+,,No value,10 or fewer
+,,Total,331
+,"DALLAS, IA",Less than 65 Years,141
+,,65 Years or more,164
+,,No value,10 or fewer
+,,Total,305
+,"HENRY, IL",Less than 65 Years,131
+,,65 Years or more,195
+,,No value,10 or fewer
+,,Total,326
+,"BARTOW, GA",Less than 65 Years,167
+,,65 Years or more,144
+,,No value,10 or fewer
+,,Total,311
+,"LIVINGSTON, IL",Less than 65 Years,96
+,,65 Years or more,246
+,,No value,10 or fewer
+,,Total,342
+,"PORTER, IN",Less than 65 Years,103
+,,65 Years or more,181
+,,No value,10 or fewer
+,,Total,284
+,"BLAINE, ID",Less than 65 Years,137
+,,65 Years or more,223
+,,No value,10 or fewer
+,,Total,360
+,"LEVY, FL",Less than 65 Years,127
+,,65 Years or more,171
+,,No value,10 or fewer
+,,Total,298
+,"FRANKLIN, KS",Less than 65 Years,109
+,,65 Years or more,173
+,,No value,10 or fewer
+,,Total,282
+,"KAUAI, HI",Less than 65 Years,105
+,,65 Years or more,249
+,,No value,10 or fewer
+,,Total,354
+,"HART, GA",Less than 65 Years,103
+,,65 Years or more,197
+,,No value,10 or fewer
+,,Total,300
+,"MACON, IL",Less than 65 Years,120
+,,65 Years or more,151
+,,No value,10 or fewer
+,,Total,271
+,"RICHLAND, IL",Less than 65 Years,144
+,,65 Years or more,197
+,,No value,10 or fewer
+,,Total,341
+,"BROOMFIELD, CO",Less than 65 Years,132
+,,65 Years or more,138
+,,No value,10 or fewer
+,,Total,270
+,"GIBSON, IN",Less than 65 Years,134
+,,65 Years or more,230
+,,No value,10 or fewer
+,,Total,364
+,"CLAYTON, GA",Less than 65 Years,226
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,307
+,"JEROME, ID",Less than 65 Years,125
+,,65 Years or more,157
+,,No value,10 or fewer
+,,Total,282
+,"TELLER, CO",Less than 65 Years,104
+,,65 Years or more,174
+,,No value,10 or fewer
+,,Total,278
+,"DAWSON, GA",Less than 65 Years,99
+,,65 Years or more,177
+,,No value,10 or fewer
+,,Total,276
+,"FAYETTE, IN",Less than 65 Years,122
+,,65 Years or more,162
+,,No value,10 or fewer
+,,Total,284
+,"HENRY, GA",Less than 65 Years,200
+,,65 Years or more,104
+,,No value,10 or fewer
+,,Total,304
+,"CHARLOTTE, FL",Less than 65 Years,105
+,,65 Years or more,196
+,,No value,10 or fewer
+,,Total,301
+,"BANKS, GA",Less than 65 Years,128
+,,65 Years or more,154
+,,No value,10 or fewer
+,,Total,282
+,"CATOOSA, GA",Less than 65 Years,118
+,,65 Years or more,119
+,,No value,10 or fewer
+,,Total,237
+,"WARREN, IA",Less than 65 Years,115
+,,65 Years or more,172
+,,No value,10 or fewer
+,,Total,287
+,"BUREAU, IL",Less than 65 Years,79
+,,65 Years or more,147
+,,No value,10 or fewer
+,,Total,226
+,"GEARY, KS",Less than 65 Years,143
+,,65 Years or more,127
+,,No value,10 or fewer
+,,Total,270
+,"HARRISON, IN",Less than 65 Years,120
+,,65 Years or more,158
+,,No value,10 or fewer
+,,Total,278
+,"HARDEE, FL",Less than 65 Years,129
+,,65 Years or more,126
+,,No value,10 or fewer
+,,Total,255
+,"RICHMOND, GA",Less than 65 Years,26
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,45
+,"LEAVENWORTH, KS",Less than 65 Years,84
+,,65 Years or more,162
+,,No value,10 or fewer
+,,Total,246
+,"BERRIEN, GA",Less than 65 Years,102
+,,65 Years or more,150
+,,No value,10 or fewer
+,,Total,252
+,"WALKER, GA",Less than 65 Years,133
+,,65 Years or more,98
+,,No value,10 or fewer
+,,Total,231
+,"OBRIEN, IA",Less than 65 Years,94
+,,65 Years or more,143
+,,No value,10 or fewer
+,,Total,237
+,"HOT SPRING, AR",Less than 65 Years,93
+,,65 Years or more,159
+,,No value,10 or fewer
+,,Total,252
+,"SARASOTA, FL",Less than 65 Years,66
+,,65 Years or more,163
+,,No value,10 or fewer
+,,Total,229
+,"ELKHART, IN",Less than 65 Years,91
+,,65 Years or more,124
+,,No value,10 or fewer
+,,Total,215
+,"CAMDEN, GA",Less than 65 Years,96
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,202
+,"PINAL, AZ",Less than 65 Years,47
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,113
+,"WARREN, IL",Less than 65 Years,99
+,,65 Years or more,126
+,,No value,10 or fewer
+,,Total,225
+,"BUTTS, GA",Less than 65 Years,128
+,,65 Years or more,131
+,,No value,10 or fewer
+,,Total,259
+,"PUTNAM, FL",Less than 65 Years,107
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,201
+,"MAHASKA, IA",Less than 65 Years,49
+,,65 Years or more,139
+,,No value,10 or fewer
+,,Total,188
+,"POLK, GA",Less than 65 Years,63
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,174
+,"POSEY, IN",Less than 65 Years,81
+,,65 Years or more,137
+,,No value,10 or fewer
+,,Total,218
+,"STEPHENS, GA",Less than 65 Years,64
+,,65 Years or more,113
+,,No value,10 or fewer
+,,Total,177
+,"HANCOCK, IN",Less than 65 Years,60
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,171
+,"POINSETT, AR",Less than 65 Years,92
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,170
+,"GREENE, AR",Less than 65 Years,87
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,193
+,"CHOCTAW, AL",Less than 65 Years,76
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,171
+,"MANATEE, FL",Less than 65 Years,63
+,,65 Years or more,112
+,,No value,10 or fewer
+,,Total,175
+,"DOUGLAS, IL",Less than 65 Years,57
+,,65 Years or more,125
+,,No value,10 or fewer
+,,Total,182
+,"WHITE, AR",Less than 65 Years,98
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,195
+,"LANIER, GA",Less than 65 Years,74
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,166
+,"RABUN, GA",Less than 65 Years,44
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,135
+,"SHELBY, IL",Less than 65 Years,48
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,139
+,"CLARK, AR",Less than 65 Years,58
+,,65 Years or more,108
+,,No value,10 or fewer
+,,Total,166
+,"MONTGOMERY, IL",Less than 65 Years,45
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,137
+,"HENDRY, FL",Less than 65 Years,116
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,187
+,"PUTNAM, GA",Less than 65 Years,44
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,150
+,"DEKALB, IN",Less than 65 Years,54
+,,65 Years or more,104
+,,No value,10 or fewer
+,,Total,158
+,"POWESHIEK, IA",Less than 65 Years,51
+,,65 Years or more,100
+,,No value,10 or fewer
+,,Total,151
+,"ARKANSAS, AR",Less than 65 Years,79
+,,65 Years or more,123
+,,No value,10 or fewer
+,,Total,202
+,"CARROLL, GA",Less than 65 Years,88
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,147
+,"DEARBORN, IN",Less than 65 Years,53
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,154
+,"OSAGE, KS",Less than 65 Years,50
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,144
+,"BOND, IL",Less than 65 Years,29
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,117
+,"SACRAMENTO, CA",Less than 65 Years,78
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,148
+,"JONES, IA",Less than 65 Years,55
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,139
+,"MASSAC, IL",Less than 65 Years,69
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,180
+,"YAVAPAI, AZ",Less than 65 Years,53
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,155
+,"MACOUPIN, IL",Less than 65 Years,43
+,,65 Years or more,83
+,,No value,10 or fewer
+,,Total,126
+,"JEFFERSON, AR",Less than 65 Years,84
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,164
+,"TAMA, IA",Less than 65 Years,65
+,,65 Years or more,85
+,,No value,10 or fewer
+,,Total,150
+,"OGLE, IL",Less than 65 Years,47
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,139
+,"BENTON, IA",Less than 65 Years,62
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,153
+,"TULARE, CA",Less than 65 Years,78
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,133
+,"PICKENS, AL",Less than 65 Years,63
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,138
+,"SCOTT, IN",Less than 65 Years,40
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,70
+,"CEDAR, IA",Less than 65 Years,43
+,,65 Years or more,83
+,,No value,10 or fewer
+,,Total,126
+,"WALTON, GA",Less than 65 Years,85
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,137
+,"VALLEY, ID",Less than 65 Years,54
+,,65 Years or more,98
+,,No value,10 or fewer
+,,Total,152
+,"MARION, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, IL",Less than 65 Years,42
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,124
+,"WASHINGTON, IN",Less than 65 Years,56
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,122
+,"COLUMBIA, FL",Less than 65 Years,60
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,126
+,"LAMAR, AL",Less than 65 Years,33
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,93
+,"COLUMBIA, GA",Less than 65 Years,19
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,33
+,"COOK, GA",Less than 65 Years,44
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,114
+,"LAWRENCE, IL",Less than 65 Years,46
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,127
+,"OCONEE, GA",Less than 65 Years,36
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,114
+,"STEUBEN, IN",Less than 65 Years,30
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,121
+,"WASHINGTON, IA",Less than 65 Years,30
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,104
+,"POTTAWATTAMIE, IA",Less than 65 Years,60
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,126
+,"FAYETTE, IA",Less than 65 Years,36
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,106
+,"PITKIN, CO",Less than 65 Years,47
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,105
+,"SIOUX, IA",Less than 65 Years,30
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,93
+,"BROOKS, GA",Less than 65 Years,31
+,,65 Years or more,85
+,,No value,10 or fewer
+,,Total,116
+,"MADISON, GA",Less than 65 Years,61
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,116
+,"DALE, AL",Less than 65 Years,38
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,93
+,"ALLEN, KS",Less than 65 Years,42
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,121
+,"BAKER, FL",Less than 65 Years,67
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,125
+,"MINIDOKA, ID",Less than 65 Years,34
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,79
+,"FRANKLIN, IN",Less than 65 Years,39
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,102
+,"MAUI, HI",Less than 65 Years,39
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,102
+,"NEWTON, GA",Less than 65 Years,80
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,106
+,"COWETA, GA",Less than 65 Years,61
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,97
+,"ROCKDALE, GA",Less than 65 Years,60
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,92
+,"DREW, AR",Less than 65 Years,13
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,35
+,"MIAMI, KS",Less than 65 Years,24
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,66
+,"DOUGLAS, KS",Less than 65 Years,29
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,66
+,"CHATTOOGA, GA",Less than 65 Years,46
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,126
+,"KERN, CA",Less than 65 Years,60
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,102
+,"DELAWARE, IN",Less than 65 Years,43
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,78
+,"OWYHEE, ID",Less than 65 Years,35
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,85
+,"GRANT, AR",Less than 65 Years,37
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,81
+,"JASPER, IA",Less than 65 Years,48
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,83
+,"JEFFERSON, KS",Less than 65 Years,21
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,90
+,"HENRY, AL",Less than 65 Years,18
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,93
+,"MISSISSIPPI, AR",Less than 65 Years,40
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,91
+,"BRADFORD, FL",Less than 65 Years,38
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,100
+,"JACKSON, FL",Less than 65 Years,27
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,76
+,"DEKALB, IL",Less than 65 Years,30
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,79
+,"MERCER, IL",Less than 65 Years,34
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,113
+,"SAN JOAQUIN, CA",Less than 65 Years,57
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,107
+,"GOODING, ID",Less than 65 Years,39
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,92
+,"GEM, ID",Less than 65 Years,32
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,90
+,"HENDRICKS, IN",Less than 65 Years,41
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,90
+,"STARKE, IN",Less than 65 Years,27
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,71
+,"JASPER, IL",Less than 65 Years,33
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,95
+,"MIAMI, IN",Less than 65 Years,44
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,79
+,"JEFFERSON, AL",Less than 65 Years,44
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,96
+,"JEFFERSON, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,21
+,"VENTURA, CA",Less than 65 Years,32
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,79
+,"GENEVA, AL",Less than 65 Years,15
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,71
+,"KINGS, CA",Less than 65 Years,41
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,66
+,"FULTON, IL",Less than 65 Years,28
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,89
+,"FORD, IL",Less than 65 Years,41
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,79
+,"GARLAND, AR",Less than 65 Years,38
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,75
+,"GLYNN, GA",Less than 65 Years,34
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,83
+,"STARK, IL",Less than 65 Years,25
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,101
+,"DAVIESS, IN",Less than 65 Years,33
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,74
+,"ELBERT, CO",Less than 65 Years,28
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,43
+,"FAYETTE, GA",Less than 65 Years,39
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,69
+,"MERCED, CA",Less than 65 Years,40
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,59
+,"UNION, IN",Less than 65 Years,28
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,75
+,"PIATT, IL",Less than 65 Years,21
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,67
+,"LAMAR, GA",Less than 65 Years,43
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,77
+,"BROWN, IN",Less than 65 Years,23
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,77
+,"PLYMOUTH, IA",Less than 65 Years,29
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,68
+,"GILCHRIST, FL",Less than 65 Years,37
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,78
+,"ESCAMBIA, FL",Less than 65 Years,44
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,73
+,"JENNINGS, IN",Less than 65 Years,23
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,67
+,"MONROE, AR",Less than 65 Years,24
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,71
+,"ANDERSON, KS",Less than 65 Years,19
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,64
+,"GRANT, IN",Less than 65 Years,35
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,64
+,"IOWA, IA",Less than 65 Years,24
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,66
+,"MERIWETHER, GA",Less than 65 Years,30
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,80
+,"MASON, IL",Less than 65 Years,29
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,66
+,"RANDOLPH, IN",Less than 65 Years,18
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,64
+,"BOISE, ID",Less than 65 Years,19
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,68
+,"CLINTON, IA",Less than 65 Years,22
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,49
+,"IROQUOIS, IL",Less than 65 Years,26
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,74
+,"VAN BUREN, AR",Less than 65 Years,23
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,65
+,"FREMONT, CO",Less than 65 Years,29
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,67
+,"LA PORTE, IN",Less than 65 Years,29
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,54
+,"LEON, FL",Less than 65 Years,28
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,56
+,"OGLETHORPE, GA",Less than 65 Years,26
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,64
+,"PRAIRIE, AR",Less than 65 Years,28
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,78
+,"MADISON, FL",Less than 65 Years,15
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,74
+,"DIXIE, FL",Less than 65 Years,38
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,68
+,"PIKE, GA",Less than 65 Years,32
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,70
+,"SPENCER, IN",Less than 65 Years,21
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,60
+,"FAYETTE, IL",Less than 65 Years,19
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,70
+,"POPE, AR",Less than 65 Years,40
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,69
+,"STANISLAUS, CA",Less than 65 Years,35
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,61
+,"PLACER, CA",Less than 65 Years,20
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,58
+,"SOLANO, CA",Less than 65 Years,45
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,67
+,"BREMER, IA",Less than 65 Years,19
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,58
+,"CHATHAM, GA",Less than 65 Years,22
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,60
+,"MORGAN, IN",Less than 65 Years,23
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,54
+,"OKALOOSA, FL",Less than 65 Years,32
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,63
+,"ELBERT, GA",Less than 65 Years,27
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,62
+,"SONOMA, CA",Less than 65 Years,26
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,55
+,"SEDGWICK, KS",Less than 65 Years,30
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,56
+,"ADAMS, ID",Less than 65 Years,30
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,68
+,"JACKSON, IN",Less than 65 Years,29
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,59
+,"DONIPHAN, KS",Less than 65 Years,11
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,58
+,"FULTON, IN",Less than 65 Years,41
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,80
+,"STORY, IA",Less than 65 Years,32
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,57
+,"WASHINGTON, ID",Less than 65 Years,15
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,40
+,"BINGHAM, ID",Less than 65 Years,31
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,62
+,"CHRISTIAN, IL",Less than 65 Years,31
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,69
+,"WELLS, IN",Less than 65 Years,25
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,61
+,"CLAY, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,40
+,"MARIN, CA",Less than 65 Years,29
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,72
+,"SANTA CRUZ, CA",Less than 65 Years,23
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,48
+,"SUWANNEE, FL",Less than 65 Years,15
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,56
+,"MONTEREY, CA",Less than 65 Years,30
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,59
+,"ROUTT, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,53
+,"DADE, GA",Less than 65 Years,33
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,51
+,"CONWAY, AR",Less than 65 Years,23
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,58
+,"CRAWFORD, IL",Less than 65 Years,23
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,64
+,"THOMAS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILMER, GA",Less than 65 Years,21
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,42
+,"SANTA BARBARA, CA",Less than 65 Years,21
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,46
+,"CHARLTON, GA",Less than 65 Years,17
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,44
+,"COLES, IL",Less than 65 Years,21
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,52
+,"ESCAMBIA, AL",Less than 65 Years,20
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,38
+,"MOHAVE, AZ",Less than 65 Years,16
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,61
+,"UNION, FL",Less than 65 Years,25
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,51
+,"JACKSON, KS",Less than 65 Years,18
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,51
+,"MORGAN, GA",Less than 65 Years,19
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,46
+,"HOUSTON, GA",Less than 65 Years,18
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,36
+,"PICKENS, GA",Less than 65 Years,14
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,41
+,"MADISON, AL",Less than 65 Years,20
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,41
+,"SAN LUIS OBISPO, CA",Less than 65 Years,16
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,46
+,"SUMTER, AL",Less than 65 Years,17
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,38
+,"PIKE, IN",Less than 65 Years,18
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,51
+,"IMPERIAL, CA",Less than 65 Years,19
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,46
+,"LATAH, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"LOUISA, IA",Less than 65 Years,21
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,48
+,"UNION, GA",Less than 65 Years,16
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,46
+,"BAY, FL",Less than 65 Years,26
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,42
+,"COCHISE, AZ",Less than 65 Years,17
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,51
+,"LAWRENCE, AR",Less than 65 Years,23
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,47
+,"LYON, IA",Less than 65 Years,18
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,44
+,"BIBB, GA",Less than 65 Years,36
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,56
+,"CHEROKEE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,38
+,"CALHOUN, IA",Less than 65 Years,14
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,47
+,"PARK, CO",Less than 65 Years,16
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,35
+,"HARALSON, GA",Less than 65 Years,29
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,45
+,"CRAWFORD, IN",Less than 65 Years,20
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,33
+,"MOULTRIE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,44
+,"MUSCOGEE, GA",Less than 65 Years,21
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,36
+,"PUTNAM, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,34
+,"SANTA ROSA, FL",Less than 65 Years,17
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,43
+,"BUCHANAN, IA",Less than 65 Years,18
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,47
+,"EAGLE, CO",Less than 65 Years,24
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,44
+,"EL DORADO, CA",Less than 65 Years,13
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,37
+,"JACKSON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,38
+,"HAMILTON, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,37
+,"SAINT FRANCIS, AR",Less than 65 Years,17
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,46
+,"CERRO GORDO, IA",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"PERRY, AR",Less than 65 Years,23
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,42
+,"CASSIA, ID",Less than 65 Years,20
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,44
+,"FRANKLIN, AR",Less than 65 Years,15
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,29
+,"GILA, AZ",Less than 65 Years,14
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,44
+,"ANCHORAGE, AK",Less than 65 Years,16
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,36
+,"GARFIELD, CO",Less than 65 Years,27
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,43
+,"WASHINGTON, AL",Less than 65 Years,25
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,46
+,"JOHNSON, IL",Less than 65 Years,18
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,48
+,"RIPLEY, IN",Less than 65 Years,15
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,37
+,"BARBOUR, AL",Less than 65 Years,16
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,34
+,"JO DAVIESS, IL",Less than 65 Years,14
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,35
+,"JACKSON, AL",Less than 65 Years,19
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,43
+,"LINCOLN, ID",Less than 65 Years,20
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,50
+,"OTERO, CO",Less than 65 Years,19
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,40
+,"ADAMS, IN",Less than 65 Years,12
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,33
+,"LOGAN, IL",Less than 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"OKEECHOBEE, FL",Less than 65 Years,17
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,32
+,"FANNIN, GA",Less than 65 Years,12
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,32
+,"MADISON, AR",Less than 65 Years,38
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,40
+,"WAPELLO, IA",Less than 65 Years,20
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,34
+,"HEARD, GA",Less than 65 Years,15
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,43
+,"LASSEN, CA",Less than 65 Years,19
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,38
+,"LEE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,29
+,"STEPHENSON, IL",Less than 65 Years,13
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,33
+,"WHITE, IL",Less than 65 Years,12
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,27
+,"YUMA, AZ",Less than 65 Years,12
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,35
+,"WABAUNSEE, KS",Less than 65 Years,14
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,39
+,"MADISON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,28
+,"WHITESIDE, IL",Less than 65 Years,12
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,37
+,"COFFEE, AL",Less than 65 Years,12
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,28
+,"GRUNDY, IL",Less than 65 Years,12
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,26
+,"EARLY, GA",Less than 65 Years,12
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,33
+,"CLINCH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,32
+,"ECHOLS, GA",Less than 65 Years,13
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,31
+,"KEOKUK, IA",Less than 65 Years,12
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,37
+,"BALDWIN, GA",Less than 65 Years,21
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,32
+,"KANKAKEE, IL",Less than 65 Years,14
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,27
+,"MILLS, IA",Less than 65 Years,22
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,43
+,"OSCEOLA, IA",Less than 65 Years,22
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,34
+,"CROSS, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,26
+,"HOLMES, FL",Less than 65 Years,13
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,33
+,"MCDONOUGH, IL",Less than 65 Years,14
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,34
+,"DECATUR, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,27
+,"SHELBY, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,28
+,"WASHINGTON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,25
+,"HENRY, IN",Less than 65 Years,15
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,28
+,"CASS, IN",Less than 65 Years,11
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,26
+,"CHAMBERS, AL",Less than 65 Years,16
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,35
+,"HUMBOLDT, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,19
+,"ASHLEY, AR",Less than 65 Years,11
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,26
+,"BUTLER, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,32
+,"MOFFAT, CO",Less than 65 Years,27
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,35
+,"SHELBY, IN",Less than 65 Years,19
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,33
+,"UNION, AR",Less than 65 Years,19
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,35
+,"LINN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,29
+,"HARRIS, GA",Less than 65 Years,16
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,34
+,"LOGAN, AR",Less than 65 Years,12
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,28
+,"POTTAWATOMIE, KS",Less than 65 Years,11
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,34
+,"RILEY, KS",Less than 65 Years,19
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,38
+,"OUACHITA, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,31
+,"DESOTO, FL",Less than 65 Years,20
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,32
+,"INDEPENDENCE, AR",Less than 65 Years,11
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,26
+,"KOOTENAI, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,29
+,"MARION, IA",Less than 65 Years,17
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,35
+,"BONNEVILLE, ID",Less than 65 Years,13
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,28
+,"MENARD, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,27
+,"MONROE, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,31
+,"ATCHISON, KS",Less than 65 Years,14
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,31
+,"COCONINO, AZ",Less than 65 Years,18
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,38
+,"GLADES, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,25
+,"NAVAJO, AZ",Less than 65 Years,13
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,24
+,"CUMBERLAND, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,15
+,"ALLAMAKEE, IA",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"BOONE, IA",Less than 65 Years,16
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,31
+,"HENDERSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,21
+,"IDAHO, ID",Less than 65 Years,11
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,34
+,"LINCOLN, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"VIGO, IN",Less than 65 Years,17
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,32
+,"WILLIAMSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,30
+,"DICKINSON, KS",Less than 65 Years,12
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,26
+,"RANDOLPH, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,23
+,"ALEXANDER, IL",Less than 65 Years,12
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,31
+,"HENRY, IA",Less than 65 Years,11
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,23
+,"TOWNS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,34
+,"TUSCALOOSA, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"GRUNDY, IA",Less than 65 Years,11
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,30
+,"NEVADA, CA",Less than 65 Years,11
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,26
+,"HANCOCK, GA",Less than 65 Years,19
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,30
+,"CALHOUN, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"DES MOINES, IA",Less than 65 Years,15
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,32
+,"PLUMAS, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,24
+,"GRAND, CO",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"BOONE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,21
+,"DUBOIS, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,23
+,"LAS ANIMAS, CO",Less than 65 Years,12
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,26
+,"MONROE, IN",Less than 65 Years,12
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,26
+,"SALINE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,22
+,"SHASTA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,26
+,"TIPPECANOE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,22
+,"LEE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"MARENGO, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"YOLO, CA",Less than 65 Years,12
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,27
+,"RANDOLPH, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"JASPER, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"PULASKI, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,21
+,"GUTHRIE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WABASH, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,25
+,"MONTGOMERY, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,22
+,"MORGAN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,19
+,"NAPA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,22
+,"PHILLIPS, AR",Less than 65 Years,12
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,27
+,"JACKSON, AR",Less than 65 Years,12
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,24
+,"CLAY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"FOUNTAIN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,22
+,"JOHNSON, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,22
+,"POWER, ID",Less than 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"BUTTE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,24
+,"MARIPOSA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,20
+,"PAGE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,23
+,"SEMINOLE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,24
+,"TIPTON, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"LEE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"UPSON, GA",Less than 65 Years,15
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,27
+,"CUSTER, CO",Less than 65 Years,13
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,29
+,"DELAWARE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,19
+,"DELTA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"JASPER, GA",Less than 65 Years,14
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,25
+,"MARION, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,24
+,"CHICOT, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CROWLEY, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"SANTA CRUZ, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,14
+,"SHARP, AR",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"BURKE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAFFEE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,26
+,"WALTON, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"ADAMS, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,29
+,"BRADLEY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"YELL, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"COFFEY, KS",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"MONROE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,22
+,"PAWNEE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"POPE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"APACHE, AZ",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"DALLAS, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,20
+,"STAFFORD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,23
+,"CLAY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,14
+,"STONE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"WARE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CLAYTON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"EDGAR, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,25
+,"MORGAN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,22
+,"BRANTLEY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"DESHA, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"EDWARDS, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,18
+,"MONROE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"MONTROSE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,18
+,"RANDOLPH, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CLEVELAND, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"COLQUITT, GA",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"TIFT, GA",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CHICKASAW, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"HUERFANO, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"NEVADA, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"TAYLOR, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,17
+,"CARROLL, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"EFFINGHAM, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"GALLATIN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,17
+,"HARDIN, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,19
+,"HUMBOLDT, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"BRYAN, GA",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CLARKE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LA PLATA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"SCOTT, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"UNION, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"FRANKLIN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"JACKSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"PIKE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGHERTY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"LYON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"MCDUFFIE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREMONT, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MONTGOMERY, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"SHELBY, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,17
+,"SULLIVAN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"TAYLOR, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,13
+,"WAYNE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"JERSEY, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"LEE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"SAN BENITO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BOURBON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,16
+,"CASS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"COLBERT, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CULLMAN, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"LOGAN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARKE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CRAWFORD, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,22
+,"FAIRBANKS NORTH STAR, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"GILPIN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"APPANOOSE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"RUSSELL, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COVINGTON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CRAWFORD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAUDERDALE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEARCY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WOODRUFF, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"ELMORE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"INYO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KOSSUTH, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIBERTY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"PERRY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"TUOLUMNE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,13
+,"WRIGHT, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BEN HILL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"HAMILTON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MILLER, AR",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"POLK, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"PROWERS, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"WOODSON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,15
+,"CHEROKEE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKINSON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ETOWAH, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MONROE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"WINNESHIEK, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENDOCINO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WASHINGTON, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WINNEBAGO, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAXTER, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEAR CREEK, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMMIT, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWITZERLAND, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"GUNNISON, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IZARD, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,15
+,"JEFFERSON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"PIERCE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARCHULETA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,15
+,"FLOYD, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRADY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CARROLL, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMANUEL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HEMPSTEAD, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"RIO GRANDE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"SAINT CLAIR, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"SUTTER, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"WILKES, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATKINSON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BULLOCH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GADSDEN, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LIMESTONE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MATANUSKA SUSITNA, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MONTGOMERY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PULASKI, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THOMAS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAIR, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLACKFORD, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"LAWRENCE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCINTOSH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONONA, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"RENO, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"RUSH, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALINE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VERMILLION, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENT, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BONNER, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTEZUMA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"NEMAHA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORANGE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MORRIS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAKULLA, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUENA VISTA, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENAI PENINSULA, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEZ PERCE, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEACH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALLADEGA, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OHIO, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POCAHONTAS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SISKIYOU, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YUBA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUDUBON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLIS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUCAS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEOSHO, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUTAUGA, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEBURNE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARVEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IDA, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAURENS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LITTLE RIVER, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALIAFERRO, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALLAPOOSA, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOOMBS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALAMOSA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AMADOR, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JAY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIT CARSON, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSH, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TEHAMA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YUMA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLOUNT, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA PAZ, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MODOC, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIERRA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BACA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALAVERAS, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMAS, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHILTON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DODGE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMMET, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JENKINS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARKE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"QUITMAN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN BUREN, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALKER, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APPLING, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARIBOU, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRISP, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREMONT, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWEN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHUYLER, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TELFAIR, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TETON, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WORTH, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONECUH, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLASCOCK, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAHAM, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMTER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAR LAKE, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COWLEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GULF, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HALE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEMHI, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PALO ALTO, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHILLIPS, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAC, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN MIGUEL, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKINSON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILSON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALLAS, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FORD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCPHERSON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIO BLANCO, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WORTH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAKER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOUNDARY, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRENSHAW, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOOLY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDWARDS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FINNEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRWIN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFF DAVIS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LONG, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCREVEN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TATTNALL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILCOX, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILCOX, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEARWATER, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONEJOS, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LABETTE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEVIER, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEWARD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERMAN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TURNER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BACON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENEWAH, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLECKLEY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLSWORTH, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNEAU, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIOWA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONEIDA, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTTAWA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRATT, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHLEY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHOSHONE, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMNER, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TERRELL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUSA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEL NORTE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLENN, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENWOOD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEWELL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIBERTY, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHWEST ARCTIC, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RAWLINS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAGUACHE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERIDAN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHEELER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BETHEL, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CANDLER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEYENNE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLOUD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COSTILLA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELK, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENLEE, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEARNY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PULASKI, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINSTON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BULLOCK, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KETCHIKAN GATEWAY, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIOWA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KODIAK ISLAND, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINERAL, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NESS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSBORNE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PETERSBURG, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REPUBLIC, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEDGWICK, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOUTHEAST FAIRBANKS, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEWART, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALBOT, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TWIGGS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALEUTIANS WEST, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIBB, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTTE, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHASE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAUTAUQUA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOVE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAHAM, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREELEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HINSDALE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINGMAN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEADE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORTON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOME, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OURAY, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHILLIPS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROOKS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSSELL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SITKA, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TREUTLEN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRINITY, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALPINE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARBER, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHATTAHOOCHEE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DILLINGHAM, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EVANS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARPER, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HASKELL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTH SLOPE, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRINCE OF WALES HYDER, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RINGGOLD, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALLACE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WICHITA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WRANGELL, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YUKON KOYUKUK, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 65 Years,7096
+,,65 Years or more,12068
+,,No value,10 or fewer
+,,Total,19164
+,Total,Less than 65 Years,164763
+,,65 Years or more,250994
+,,No value,10 or fewer
+,,Total,415757
+Jan 1 – Dec 31 2024,"COOK, IL",Less than 65 Years,7758
+,,65 Years or more,13319
+,,No value,10 or fewer
+,,Total,21077
+,"SAN DIEGO, CA",Less than 65 Years,6183
+,,65 Years or more,13862
+,,No value,10 or fewer
+,,Total,20045
+,"ORANGE, FL",Less than 65 Years,7055
+,,65 Years or more,8783
+,,No value,10 or fewer
+,,Total,15838
+,"LEE, FL",Less than 65 Years,3850
+,,65 Years or more,9332
+,,No value,10 or fewer
+,,Total,13182
+,"DUVAL, FL",Less than 65 Years,5633
+,,65 Years or more,5680
+,,No value,10 or fewer
+,,Total,11313
+,"MARICOPA, AZ",Less than 65 Years,3379
+,,65 Years or more,7544
+,,No value,10 or fewer
+,,Total,10923
+,"HONOLULU, HI",Less than 65 Years,3427
+,,65 Years or more,4944
+,,No value,10 or fewer
+,,Total,8371
+,"BROWARD, FL",Less than 65 Years,3301
+,,65 Years or more,5170
+,,No value,10 or fewer
+,,Total,8471
+,"NEW HAVEN, CT",Less than 65 Years,2944
+,,65 Years or more,5259
+,,No value,10 or fewer
+,,Total,8203
+,"VOLUSIA, FL",Less than 65 Years,2455
+,,65 Years or more,5499
+,,No value,10 or fewer
+,,Total,7954
+,"FRESNO, CA",Less than 65 Years,3769
+,,65 Years or more,4521
+,,No value,10 or fewer
+,,Total,8290
+,"HILLSBOROUGH, FL",Less than 65 Years,3519
+,,65 Years or more,4192
+,,No value,10 or fewer
+,,Total,7711
+,"EL PASO, CO",Less than 65 Years,3614
+,,65 Years or more,4025
+,,No value,10 or fewer
+,,Total,7639
+,"LAKE, FL",Less than 65 Years,2167
+,,65 Years or more,5629
+,,No value,10 or fewer
+,,Total,7796
+,"HARTFORD, CT",Less than 65 Years,2731
+,,65 Years or more,4208
+,,No value,10 or fewer
+,,Total,6939
+,"ADA, ID",Less than 65 Years,2180
+,,65 Years or more,4262
+,,No value,10 or fewer
+,,Total,6442
+,"COBB, GA",Less than 65 Years,2357
+,,65 Years or more,3762
+,,No value,10 or fewer
+,,Total,6119
+,"RIVERSIDE, CA",Less than 65 Years,2343
+,,65 Years or more,3601
+,,No value,10 or fewer
+,,Total,5944
+,"SEMINOLE, FL",Less than 65 Years,1887
+,,65 Years or more,3666
+,,No value,10 or fewer
+,,Total,5553
+,"FULTON, GA",Less than 65 Years,2070
+,,65 Years or more,2614
+,,No value,10 or fewer
+,,Total,4684
+,"FAIRFIELD, CT",Less than 65 Years,1693
+,,65 Years or more,2727
+,,No value,10 or fewer
+,,Total,4420
+,"MARION, IN",Less than 65 Years,2123
+,,65 Years or more,2213
+,,No value,10 or fewer
+,,Total,4336
+,"PULASKI, AR",Less than 65 Years,1753
+,,65 Years or more,2441
+,,No value,10 or fewer
+,,Total,4194
+,"ALLEN, IN",Less than 65 Years,1534
+,,65 Years or more,2367
+,,No value,10 or fewer
+,,Total,3901
+,"OSCEOLA, FL",Less than 65 Years,2370
+,,65 Years or more,1707
+,,No value,10 or fewer
+,,Total,4077
+,"HALL, GA",Less than 65 Years,1604
+,,65 Years or more,2332
+,,No value,10 or fewer
+,,Total,3936
+,"PASCO, FL",Less than 65 Years,1348
+,,65 Years or more,2640
+,,No value,10 or fewer
+,,Total,3988
+,"DEKALB, GA",Less than 65 Years,1965
+,,65 Years or more,1953
+,,No value,10 or fewer
+,,Total,3918
+,"SAN BERNARDINO, CA",Less than 65 Years,2031
+,,65 Years or more,1746
+,,No value,10 or fewer
+,,Total,3777
+,"JOHNSON, KS",Less than 65 Years,959
+,,65 Years or more,2820
+,,No value,10 or fewer
+,,Total,3779
+,"DENVER, CO",Less than 65 Years,2398
+,,65 Years or more,1692
+,,No value,10 or fewer
+,,Total,4090
+,"PINELLAS, FL",Less than 65 Years,1197
+,,65 Years or more,2468
+,,No value,10 or fewer
+,,Total,3665
+,"POLK, IA",Less than 65 Years,1543
+,,65 Years or more,1777
+,,No value,10 or fewer
+,,Total,3320
+,"MARION, FL",Less than 65 Years,1667
+,,65 Years or more,1950
+,,No value,10 or fewer
+,,Total,3617
+,"NEW LONDON, CT",Less than 65 Years,1208
+,,65 Years or more,2308
+,,No value,10 or fewer
+,,Total,3516
+,"LAKE, IL",Less than 65 Years,901
+,,65 Years or more,2450
+,,No value,10 or fewer
+,,Total,3351
+,"LINN, IA",Less than 65 Years,1085
+,,65 Years or more,1943
+,,No value,10 or fewer
+,,Total,3029
+,"COLLIER, FL",Less than 65 Years,953
+,,65 Years or more,2345
+,,No value,10 or fewer
+,,Total,3298
+,"POLK, FL",Less than 65 Years,1505
+,,65 Years or more,1761
+,,No value,10 or fewer
+,,Total,3266
+,"WINNEBAGO, IL",Less than 65 Years,1138
+,,65 Years or more,1853
+,,No value,10 or fewer
+,,Total,2991
+,"DUPAGE, IL",Less than 65 Years,872
+,,65 Years or more,2338
+,,No value,10 or fewer
+,,Total,3210
+,"MIDDLESEX, CT",Less than 65 Years,853
+,,65 Years or more,2068
+,,No value,10 or fewer
+,,Total,2921
+,"CANYON, ID",Less than 65 Years,1267
+,,65 Years or more,1685
+,,No value,10 or fewer
+,,Total,2952
+,"LARIMER, CO",Less than 65 Years,884
+,,65 Years or more,2068
+,,No value,10 or fewer
+,,Total,2952
+,"ARAPAHOE, CO",Less than 65 Years,1540
+,,65 Years or more,1717
+,,No value,10 or fewer
+,,Total,3257
+,"ORANGE, CA",Less than 65 Years,848
+,,65 Years or more,2563
+,,No value,10 or fewer
+,,Total,3411
+,"FLAGLER, FL",Less than 65 Years,769
+,,65 Years or more,2084
+,,No value,10 or fewer
+,,Total,2853
+,"ALAMEDA, CA",Less than 65 Years,1212
+,,65 Years or more,1628
+,,No value,10 or fewer
+,,Total,2840
+,"PEORIA, IL",Less than 65 Years,978
+,,65 Years or more,1874
+,,No value,10 or fewer
+,,Total,2852
+,"WELD, CO",Less than 65 Years,1054
+,,65 Years or more,1524
+,,No value,10 or fewer
+,,Total,2578
+,"CHAMPAIGN, IL",Less than 65 Years,1008
+,,65 Years or more,1580
+,,No value,10 or fewer
+,,Total,2588
+,"SANTA CLARA, CA",Less than 65 Years,781
+,,65 Years or more,1793
+,,No value,10 or fewer
+,,Total,2574
+,"PIMA, AZ",Less than 65 Years,1159
+,,65 Years or more,1572
+,,No value,10 or fewer
+,,Total,2731
+,"SHAWNEE, KS",Less than 65 Years,802
+,,65 Years or more,1619
+,,No value,10 or fewer
+,,Total,2421
+,"LAKE, IN",Less than 65 Years,1087
+,,65 Years or more,1281
+,,No value,10 or fewer
+,,Total,2368
+,"SUMTER, FL",Less than 65 Years,309
+,,65 Years or more,2083
+,,No value,10 or fewer
+,,Total,2392
+,"MARTIN, FL",Less than 65 Years,466
+,,65 Years or more,1890
+,,No value,10 or fewer
+,,Total,2356
+,"SUSSEX, DE",Less than 65 Years,858
+,,65 Years or more,1379
+,,No value,10 or fewer
+,,Total,2237
+,"MIAMI-DADE, FL",Less than 65 Years,1268
+,,65 Years or more,1011
+,,No value,10 or fewer
+,,Total,2279
+,"TAZEWELL, IL",Less than 65 Years,672
+,,65 Years or more,1510
+,,No value,10 or fewer
+,,Total,2182
+,"NASSAU, FL",Less than 65 Years,731
+,,65 Years or more,1440
+,,No value,10 or fewer
+,,Total,2171
+,"GWINNETT, GA",Less than 65 Years,1036
+,,65 Years or more,1095
+,,No value,10 or fewer
+,,Total,2131
+,"BALDWIN, AL",Less than 65 Years,641
+,,65 Years or more,1337
+,,No value,10 or fewer
+,,Total,1978
+,"ST JOSEPH, IN",Less than 65 Years,787
+,,65 Years or more,1255
+,,No value,10 or fewer
+,,Total,2042
+,"SAN FRANCISCO, CA",Less than 65 Years,938
+,,65 Years or more,1055
+,,No value,10 or fewer
+,,Total,1993
+,"SAINT JOHNS, FL",Less than 65 Years,671
+,,65 Years or more,1281
+,,No value,10 or fewer
+,,Total,1952
+,"KENT, DE",Less than 65 Years,734
+,,65 Years or more,1093
+,,No value,10 or fewer
+,,Total,1827
+,"BOULDER, CO",Less than 65 Years,663
+,,65 Years or more,1366
+,,No value,10 or fewer
+,,Total,2029
+,"LOWNDES, GA",Less than 65 Years,871
+,,65 Years or more,1017
+,,No value,10 or fewer
+,,Total,1888
+,"KANE, IL",Less than 65 Years,723
+,,65 Years or more,1117
+,,No value,10 or fewer
+,,Total,1840
+,"JEFFERSON, CO",Less than 65 Years,833
+,,65 Years or more,1119
+,,No value,10 or fewer
+,,Total,1952
+,"WYANDOTTE, KS",Less than 65 Years,1017
+,,65 Years or more,846
+,,No value,10 or fewer
+,,Total,1863
+,"MOBILE, AL",Less than 65 Years,694
+,,65 Years or more,1050
+,,No value,10 or fewer
+,,Total,1744
+,"INDIAN RIVER, FL",Less than 65 Years,262
+,,65 Years or more,1583
+,,No value,10 or fewer
+,,Total,1845
+,"CLAY, FL",Less than 65 Years,920
+,,65 Years or more,990
+,,No value,10 or fewer
+,,Total,1910
+,"ROCK ISLAND, IL",Less than 65 Years,719
+,,65 Years or more,1055
+,,No value,10 or fewer
+,,Total,1774
+,"SAINT LUCIE, FL",Less than 65 Years,639
+,,65 Years or more,1256
+,,No value,10 or fewer
+,,Total,1895
+,"MCLEAN, IL",Less than 65 Years,573
+,,65 Years or more,1094
+,,No value,10 or fewer
+,,Total,1667
+,"ALACHUA, FL",Less than 65 Years,774
+,,65 Years or more,950
+,,No value,10 or fewer
+,,Total,1724
+,"ADAMS, CO",Less than 65 Years,1151
+,,65 Years or more,646
+,,No value,10 or fewer
+,,Total,1797
+,"PUEBLO, CO",Less than 65 Years,682
+,,65 Years or more,1010
+,,No value,10 or fewer
+,,Total,1692
+,"VANDERBURGH, IN",Less than 65 Years,675
+,,65 Years or more,913
+,,No value,10 or fewer
+,,Total,1588
+,"TWIN FALLS, ID",Less than 65 Years,575
+,,65 Years or more,953
+,,No value,10 or fewer
+,,Total,1528
+,"SAN MATEO, CA",Less than 65 Years,536
+,,65 Years or more,1073
+,,No value,10 or fewer
+,,Total,1609
+,"DOUGLAS, CO",Less than 65 Years,588
+,,65 Years or more,1198
+,,No value,10 or fewer
+,,Total,1786
+,"HIGHLANDS, FL",Less than 65 Years,450
+,,65 Years or more,956
+,,No value,10 or fewer
+,,Total,1406
+,"PALM BEACH, FL",Less than 65 Years,411
+,,65 Years or more,921
+,,No value,10 or fewer
+,,Total,1332
+,"CLARK, IN",Less than 65 Years,632
+,,65 Years or more,569
+,,No value,10 or fewer
+,,Total,1201
+,"PAULDING, GA",Less than 65 Years,595
+,,65 Years or more,737
+,,No value,10 or fewer
+,,Total,1332
+,"JOHNSON, IA",Less than 65 Years,494
+,,65 Years or more,943
+,,No value,10 or fewer
+,,Total,1437
+,"BARROW, GA",Less than 65 Years,621
+,,65 Years or more,646
+,,No value,10 or fewer
+,,Total,1267
+,"FLOYD, IN",Less than 65 Years,507
+,,65 Years or more,653
+,,No value,10 or fewer
+,,Total,1160
+,"WHITFIELD, GA",Less than 65 Years,812
+,,65 Years or more,899
+,,No value,10 or fewer
+,,Total,1711
+,"DOUGLAS, GA",Less than 65 Years,517
+,,65 Years or more,595
+,,No value,10 or fewer
+,,Total,1112
+,"SAINT CLAIR, IL",Less than 65 Years,394
+,,65 Years or more,792
+,,No value,10 or fewer
+,,Total,1186
+,"BARTHOLOMEW, IN",Less than 65 Years,332
+,,65 Years or more,755
+,,No value,10 or fewer
+,,Total,1087
+,"NEW CASTLE, DE",Less than 65 Years,700
+,,65 Years or more,405
+,,No value,10 or fewer
+,,Total,1105
+,"LOS ANGELES, CA",Less than 65 Years,520
+,,65 Years or more,578
+,,No value,10 or fewer
+,,Total,1098
+,"KNOX, IL",Less than 65 Years,388
+,,65 Years or more,689
+,,No value,10 or fewer
+,,Total,1077
+,"WINDHAM, CT",Less than 65 Years,487
+,,65 Years or more,553
+,,No value,10 or fewer
+,,Total,1040
+,"WILL, IL",Less than 65 Years,481
+,,65 Years or more,698
+,,No value,10 or fewer
+,,Total,1179
+,"WOODBURY, IA",Less than 65 Years,432
+,,65 Years or more,562
+,,No value,10 or fewer
+,,Total,994
+,"SEBASTIAN, AR",Less than 65 Years,531
+,,65 Years or more,507
+,,No value,10 or fewer
+,,Total,1038
+,"HABERSHAM, GA",Less than 65 Years,457
+,,65 Years or more,652
+,,No value,10 or fewer
+,,Total,1109
+,"CHEROKEE, GA",Less than 65 Years,364
+,,65 Years or more,616
+,,No value,10 or fewer
+,,Total,980
+,"JACKSON, GA",Less than 65 Years,398
+,,65 Years or more,583
+,,No value,10 or fewer
+,,Total,981
+,"GORDON, GA",Less than 65 Years,470
+,,65 Years or more,587
+,,No value,10 or fewer
+,,Total,1057
+,"LA SALLE, IL",Less than 65 Years,302
+,,65 Years or more,702
+,,No value,10 or fewer
+,,Total,1004
+,"LITCHFIELD, CT",Less than 65 Years,288
+,,65 Years or more,541
+,,No value,10 or fewer
+,,Total,829
+,"MCHENRY, IL",Less than 65 Years,307
+,,65 Years or more,596
+,,No value,10 or fewer
+,,Total,903
+,"MADERA, CA",Less than 65 Years,510
+,,65 Years or more,557
+,,No value,10 or fewer
+,,Total,1067
+,"HOUSTON, AL",Less than 65 Years,359
+,,65 Years or more,566
+,,No value,10 or fewer
+,,Total,925
+,"WAYNE, IN",Less than 65 Years,361
+,,65 Years or more,481
+,,No value,10 or fewer
+,,Total,842
+,"KENDALL, IL",Less than 65 Years,281
+,,65 Years or more,550
+,,No value,10 or fewer
+,,Total,831
+,"KNOX, IN",Less than 65 Years,332
+,,65 Years or more,484
+,,No value,10 or fewer
+,,Total,816
+,"VERMILION, IL",Less than 65 Years,326
+,,65 Years or more,510
+,,No value,10 or fewer
+,,Total,836
+,"SANGAMON, IL",Less than 65 Years,431
+,,65 Years or more,408
+,,No value,10 or fewer
+,,Total,839
+,"NOBLE, IN",Less than 65 Years,335
+,,65 Years or more,478
+,,No value,10 or fewer
+,,Total,813
+,"BLACK HAWK, IA",Less than 65 Years,268
+,,65 Years or more,435
+,,No value,10 or fewer
+,,Total,703
+,"MADISON, IN",Less than 65 Years,296
+,,65 Years or more,512
+,,No value,10 or fewer
+,,Total,808
+,"TOLLAND, CT",Less than 65 Years,241
+,,65 Years or more,467
+,,No value,10 or fewer
+,,Total,708
+,"JOHNSON, IN",Less than 65 Years,217
+,,65 Years or more,532
+,,No value,10 or fewer
+,,Total,749
+,"SCOTT, IA",Less than 65 Years,335
+,,65 Years or more,442
+,,No value,10 or fewer
+,,Total,777
+,"CRAIGHEAD, AR",Less than 65 Years,298
+,,65 Years or more,378
+,,No value,10 or fewer
+,,Total,676
+,"SPALDING, GA",Less than 65 Years,353
+,,65 Years or more,341
+,,No value,10 or fewer
+,,Total,694
+,"FLOYD, GA",Less than 65 Years,232
+,,65 Years or more,518
+,,No value,10 or fewer
+,,Total,750
+,"CITRUS, FL",Less than 65 Years,206
+,,65 Years or more,400
+,,No value,10 or fewer
+,,Total,606
+,"MARSHALL, IN",Less than 65 Years,294
+,,65 Years or more,378
+,,No value,10 or fewer
+,,Total,672
+,"MURRAY, GA",Less than 65 Years,430
+,,65 Years or more,423
+,,No value,10 or fewer
+,,Total,853
+,"LONOKE, AR",Less than 65 Years,235
+,,65 Years or more,440
+,,No value,10 or fewer
+,,Total,675
+,"LUMPKIN, GA",Less than 65 Years,245
+,,65 Years or more,477
+,,No value,10 or fewer
+,,Total,722
+,"CONTRA COSTA, CA",Less than 65 Years,376
+,,65 Years or more,304
+,,No value,10 or fewer
+,,Total,680
+,"HUNTINGTON, IN",Less than 65 Years,236
+,,65 Years or more,405
+,,No value,10 or fewer
+,,Total,641
+,"HERNANDO, FL",Less than 65 Years,184
+,,65 Years or more,334
+,,No value,10 or fewer
+,,Total,518
+,"DUBUQUE, IA",Less than 65 Years,209
+,,65 Years or more,374
+,,No value,10 or fewer
+,,Total,583
+,"BANNOCK, ID",Less than 65 Years,263
+,,65 Years or more,337
+,,No value,10 or fewer
+,,Total,600
+,"FORSYTH, GA",Less than 65 Years,265
+,,65 Years or more,415
+,,No value,10 or fewer
+,,Total,680
+,"WHITE, GA",Less than 65 Years,253
+,,65 Years or more,375
+,,No value,10 or fewer
+,,Total,628
+,"WHITLEY, IN",Less than 65 Years,183
+,,65 Years or more,380
+,,No value,10 or fewer
+,,Total,563
+,"TROUP, GA",Less than 65 Years,227
+,,65 Years or more,354
+,,No value,10 or fewer
+,,Total,581
+,"FAULKNER, AR",Less than 65 Years,285
+,,65 Years or more,309
+,,No value,10 or fewer
+,,Total,594
+,"MARSHALL, IA",Less than 65 Years,206
+,,65 Years or more,394
+,,No value,10 or fewer
+,,Total,600
+,"MADISON, IL",Less than 65 Years,196
+,,65 Years or more,444
+,,No value,10 or fewer
+,,Total,640
+,"CRITTENDEN, AR",Less than 65 Years,301
+,,65 Years or more,223
+,,No value,10 or fewer
+,,Total,524
+,"MUSCATINE, IA",Less than 65 Years,259
+,,65 Years or more,378
+,,No value,10 or fewer
+,,Total,637
+,"WABASH, IN",Less than 65 Years,167
+,,65 Years or more,400
+,,No value,10 or fewer
+,,Total,567
+,"HAWAII, HI",Less than 65 Years,217
+,,65 Years or more,413
+,,No value,10 or fewer
+,,Total,630
+,"BOONE, IL",Less than 65 Years,183
+,,65 Years or more,391
+,,No value,10 or fewer
+,,Total,574
+,"HOWARD, IN",Less than 65 Years,267
+,,65 Years or more,359
+,,No value,10 or fewer
+,,Total,626
+,"CRAWFORD, AR",Less than 65 Years,243
+,,65 Years or more,326
+,,No value,10 or fewer
+,,Total,569
+,"SALINE, AR",Less than 65 Years,278
+,,65 Years or more,271
+,,No value,10 or fewer
+,,Total,549
+,"KOSCIUSKO, IN",Less than 65 Years,269
+,,65 Years or more,265
+,,No value,10 or fewer
+,,Total,534
+,"MESA, CO",Less than 65 Years,253
+,,65 Years or more,293
+,,No value,10 or fewer
+,,Total,546
+,"WASHINGTON, AR",Less than 65 Years,522
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,542
+,"BARTON, KS",Less than 65 Years,204
+,,65 Years or more,291
+,,No value,10 or fewer
+,,Total,495
+,"CLARKE, GA",Less than 65 Years,240
+,,65 Years or more,255
+,,No value,10 or fewer
+,,Total,495
+,"GREENE, GA",Less than 65 Years,152
+,,65 Years or more,347
+,,No value,10 or fewer
+,,Total,499
+,"ELMORE, ID",Less than 65 Years,191
+,,65 Years or more,249
+,,No value,10 or fewer
+,,Total,440
+,"WEBSTER, IA",Less than 65 Years,184
+,,65 Years or more,274
+,,No value,10 or fewer
+,,Total,458
+,"BENTON, AR",Less than 65 Years,462
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,491
+,"CLEBURNE, AR",Less than 65 Years,157
+,,65 Years or more,285
+,,No value,10 or fewer
+,,Total,442
+,"HAMILTON, IN",Less than 65 Years,110
+,,65 Years or more,314
+,,No value,10 or fewer
+,,Total,424
+,"WARRICK, IN",Less than 65 Years,138
+,,65 Years or more,262
+,,No value,10 or fewer
+,,Total,400
+,"CLINTON, IL",Less than 65 Years,142
+,,65 Years or more,341
+,,No value,10 or fewer
+,,Total,483
+,"BREVARD, FL",Less than 65 Years,228
+,,65 Years or more,205
+,,No value,10 or fewer
+,,Total,433
+,"WOODFORD, IL",Less than 65 Years,94
+,,65 Years or more,299
+,,No value,10 or fewer
+,,Total,393
+,"PAYETTE, ID",Less than 65 Years,144
+,,65 Years or more,241
+,,No value,10 or fewer
+,,Total,385
+,"FRANKLIN, GA",Less than 65 Years,188
+,,65 Years or more,192
+,,No value,10 or fewer
+,,Total,380
+,"LAGRANGE, IN",Less than 65 Years,167
+,,65 Years or more,219
+,,No value,10 or fewer
+,,Total,386
+,"EFFINGHAM, IL",Less than 65 Years,107
+,,65 Years or more,278
+,,No value,10 or fewer
+,,Total,385
+,"DALLAS, IA",Less than 65 Years,168
+,,65 Years or more,213
+,,No value,10 or fewer
+,,Total,381
+,"HENRY, IL",Less than 65 Years,132
+,,65 Years or more,232
+,,No value,10 or fewer
+,,Total,364
+,"BARTOW, GA",Less than 65 Years,204
+,,65 Years or more,192
+,,No value,10 or fewer
+,,Total,396
+,"LIVINGSTON, IL",Less than 65 Years,110
+,,65 Years or more,227
+,,No value,10 or fewer
+,,Total,337
+,"PORTER, IN",Less than 65 Years,129
+,,65 Years or more,196
+,,No value,10 or fewer
+,,Total,325
+,"BLAINE, ID",Less than 65 Years,99
+,,65 Years or more,216
+,,No value,10 or fewer
+,,Total,315
+,"LEVY, FL",Less than 65 Years,159
+,,65 Years or more,186
+,,No value,10 or fewer
+,,Total,345
+,"FRANKLIN, KS",Less than 65 Years,114
+,,65 Years or more,225
+,,No value,10 or fewer
+,,Total,339
+,"KAUAI, HI",Less than 65 Years,101
+,,65 Years or more,236
+,,No value,10 or fewer
+,,Total,337
+,"HART, GA",Less than 65 Years,127
+,,65 Years or more,209
+,,No value,10 or fewer
+,,Total,336
+,"MACON, IL",Less than 65 Years,139
+,,65 Years or more,227
+,,No value,10 or fewer
+,,Total,366
+,"RICHLAND, IL",Less than 65 Years,118
+,,65 Years or more,206
+,,No value,10 or fewer
+,,Total,324
+,"BROOMFIELD, CO",Less than 65 Years,157
+,,65 Years or more,204
+,,No value,10 or fewer
+,,Total,361
+,"GIBSON, IN",Less than 65 Years,126
+,,65 Years or more,188
+,,No value,10 or fewer
+,,Total,314
+,"CLAYTON, GA",Less than 65 Years,235
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,305
+,"JEROME, ID",Less than 65 Years,165
+,,65 Years or more,193
+,,No value,10 or fewer
+,,Total,358
+,"TELLER, CO",Less than 65 Years,129
+,,65 Years or more,222
+,,No value,10 or fewer
+,,Total,351
+,"DAWSON, GA",Less than 65 Years,143
+,,65 Years or more,212
+,,No value,10 or fewer
+,,Total,355
+,"FAYETTE, IN",Less than 65 Years,131
+,,65 Years or more,210
+,,No value,10 or fewer
+,,Total,341
+,"HENRY, GA",Less than 65 Years,225
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,331
+,"CHARLOTTE, FL",Less than 65 Years,92
+,,65 Years or more,217
+,,No value,10 or fewer
+,,Total,309
+,"BANKS, GA",Less than 65 Years,137
+,,65 Years or more,193
+,,No value,10 or fewer
+,,Total,330
+,"CATOOSA, GA",Less than 65 Years,156
+,,65 Years or more,189
+,,No value,10 or fewer
+,,Total,345
+,"WARREN, IA",Less than 65 Years,128
+,,65 Years or more,170
+,,No value,10 or fewer
+,,Total,298
+,"BUREAU, IL",Less than 65 Years,130
+,,65 Years or more,241
+,,No value,10 or fewer
+,,Total,371
+,"GEARY, KS",Less than 65 Years,151
+,,65 Years or more,149
+,,No value,10 or fewer
+,,Total,300
+,"HARRISON, IN",Less than 65 Years,137
+,,65 Years or more,150
+,,No value,10 or fewer
+,,Total,287
+,"HARDEE, FL",Less than 65 Years,140
+,,65 Years or more,138
+,,No value,10 or fewer
+,,Total,278
+,"RICHMOND, GA",Less than 65 Years,94
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,167
+,"LEAVENWORTH, KS",Less than 65 Years,97
+,,65 Years or more,163
+,,No value,10 or fewer
+,,Total,260
+,"BERRIEN, GA",Less than 65 Years,109
+,,65 Years or more,125
+,,No value,10 or fewer
+,,Total,234
+,"WALKER, GA",Less than 65 Years,184
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,286
+,"OBRIEN, IA",Less than 65 Years,83
+,,65 Years or more,191
+,,No value,10 or fewer
+,,Total,274
+,"HOT SPRING, AR",Less than 65 Years,96
+,,65 Years or more,135
+,,No value,10 or fewer
+,,Total,231
+,"SARASOTA, FL",Less than 65 Years,57
+,,65 Years or more,198
+,,No value,10 or fewer
+,,Total,255
+,"ELKHART, IN",Less than 65 Years,135
+,,65 Years or more,118
+,,No value,10 or fewer
+,,Total,253
+,"CAMDEN, GA",Less than 65 Years,128
+,,65 Years or more,113
+,,No value,10 or fewer
+,,Total,241
+,"PINAL, AZ",Less than 65 Years,67
+,,65 Years or more,116
+,,No value,10 or fewer
+,,Total,183
+,"WARREN, IL",Less than 65 Years,69
+,,65 Years or more,166
+,,No value,10 or fewer
+,,Total,235
+,"BUTTS, GA",Less than 65 Years,109
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,197
+,"PUTNAM, FL",Less than 65 Years,122
+,,65 Years or more,104
+,,No value,10 or fewer
+,,Total,226
+,"MAHASKA, IA",Less than 65 Years,53
+,,65 Years or more,167
+,,No value,10 or fewer
+,,Total,220
+,"POLK, GA",Less than 65 Years,76
+,,65 Years or more,149
+,,No value,10 or fewer
+,,Total,225
+,"POSEY, IN",Less than 65 Years,55
+,,65 Years or more,145
+,,No value,10 or fewer
+,,Total,200
+,"STEPHENS, GA",Less than 65 Years,100
+,,65 Years or more,113
+,,No value,10 or fewer
+,,Total,213
+,"HANCOCK, IN",Less than 65 Years,81
+,,65 Years or more,129
+,,No value,10 or fewer
+,,Total,210
+,"POINSETT, AR",Less than 65 Years,85
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,196
+,"GREENE, AR",Less than 65 Years,75
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,176
+,"CHOCTAW, AL",Less than 65 Years,102
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,212
+,"MANATEE, FL",Less than 65 Years,84
+,,65 Years or more,116
+,,No value,10 or fewer
+,,Total,200
+,"DOUGLAS, IL",Less than 65 Years,57
+,,65 Years or more,135
+,,No value,10 or fewer
+,,Total,192
+,"WHITE, AR",Less than 65 Years,86
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,166
+,"LANIER, GA",Less than 65 Years,103
+,,65 Years or more,100
+,,No value,10 or fewer
+,,Total,203
+,"RABUN, GA",Less than 65 Years,46
+,,65 Years or more,153
+,,No value,10 or fewer
+,,Total,199
+,"SHELBY, IL",Less than 65 Years,56
+,,65 Years or more,123
+,,No value,10 or fewer
+,,Total,179
+,"CLARK, AR",Less than 65 Years,82
+,,65 Years or more,116
+,,No value,10 or fewer
+,,Total,198
+,"MONTGOMERY, IL",Less than 65 Years,78
+,,65 Years or more,130
+,,No value,10 or fewer
+,,Total,208
+,"HENDRY, FL",Less than 65 Years,93
+,,65 Years or more,72
+,,No value,10 or fewer
+,,Total,165
+,"PUTNAM, GA",Less than 65 Years,60
+,,65 Years or more,127
+,,No value,10 or fewer
+,,Total,187
+,"DEKALB, IN",Less than 65 Years,46
+,,65 Years or more,108
+,,No value,10 or fewer
+,,Total,154
+,"POWESHIEK, IA",Less than 65 Years,50
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,156
+,"ARKANSAS, AR",Less than 65 Years,48
+,,65 Years or more,86
+,,No value,10 or fewer
+,,Total,134
+,"CARROLL, GA",Less than 65 Years,99
+,,65 Years or more,65
+,,No value,10 or fewer
+,,Total,164
+,"DEARBORN, IN",Less than 65 Years,60
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,162
+,"OSAGE, KS",Less than 65 Years,53
+,,65 Years or more,131
+,,No value,10 or fewer
+,,Total,184
+,"BOND, IL",Less than 65 Years,58
+,,65 Years or more,126
+,,No value,10 or fewer
+,,Total,184
+,"SACRAMENTO, CA",Less than 65 Years,95
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,165
+,"JONES, IA",Less than 65 Years,93
+,,65 Years or more,99
+,,No value,10 or fewer
+,,Total,192
+,"MASSAC, IL",Less than 65 Years,43
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,144
+,"YAVAPAI, AZ",Less than 65 Years,45
+,,65 Years or more,109
+,,No value,10 or fewer
+,,Total,154
+,"MACOUPIN, IL",Less than 65 Years,70
+,,65 Years or more,131
+,,No value,10 or fewer
+,,Total,201
+,"JEFFERSON, AR",Less than 65 Years,72
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,146
+,"TAMA, IA",Less than 65 Years,56
+,,65 Years or more,86
+,,No value,10 or fewer
+,,Total,142
+,"OGLE, IL",Less than 65 Years,49
+,,65 Years or more,103
+,,No value,10 or fewer
+,,Total,152
+,"BENTON, IA",Less than 65 Years,52
+,,65 Years or more,99
+,,No value,10 or fewer
+,,Total,151
+,"TULARE, CA",Less than 65 Years,84
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,146
+,"PICKENS, AL",Less than 65 Years,74
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,150
+,"SCOTT, IN",Less than 65 Years,72
+,,65 Years or more,98
+,,No value,10 or fewer
+,,Total,170
+,"CEDAR, IA",Less than 65 Years,48
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,154
+,"WALTON, GA",Less than 65 Years,90
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,153
+,"VALLEY, ID",Less than 65 Years,49
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,122
+,"MARION, AL",Less than 65 Years,81
+,,65 Years or more,107
+,,No value,10 or fewer
+,,Total,188
+,"MARSHALL, IL",Less than 65 Years,40
+,,65 Years or more,108
+,,No value,10 or fewer
+,,Total,148
+,"WASHINGTON, IN",Less than 65 Years,69
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,130
+,"COLUMBIA, FL",Less than 65 Years,60
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,126
+,"LAMAR, AL",Less than 65 Years,68
+,,65 Years or more,86
+,,No value,10 or fewer
+,,Total,154
+,"COLUMBIA, GA",Less than 65 Years,51
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,107
+,"COOK, GA",Less than 65 Years,50
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,132
+,"LAWRENCE, IL",Less than 65 Years,34
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,116
+,"OCONEE, GA",Less than 65 Years,40
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,137
+,"STEUBEN, IN",Less than 65 Years,54
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,123
+,"WASHINGTON, IA",Less than 65 Years,43
+,,65 Years or more,103
+,,No value,10 or fewer
+,,Total,146
+,"POTTAWATTAMIE, IA",Less than 65 Years,66
+,,65 Years or more,64
+,,No value,10 or fewer
+,,Total,130
+,"FAYETTE, IA",Less than 65 Years,37
+,,65 Years or more,93
+,,No value,10 or fewer
+,,Total,130
+,"PITKIN, CO",Less than 65 Years,67
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,141
+,"SIOUX, IA",Less than 65 Years,54
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,164
+,"BROOKS, GA",Less than 65 Years,39
+,,65 Years or more,90
+,,No value,10 or fewer
+,,Total,129
+,"MADISON, GA",Less than 65 Years,48
+,,65 Years or more,67
+,,No value,10 or fewer
+,,Total,115
+,"DALE, AL",Less than 65 Years,61
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,145
+,"ALLEN, KS",Less than 65 Years,27
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,111
+,"BAKER, FL",Less than 65 Years,66
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,105
+,"MINIDOKA, ID",Less than 65 Years,70
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,151
+,"FRANKLIN, IN",Less than 65 Years,43
+,,65 Years or more,85
+,,No value,10 or fewer
+,,Total,128
+,"MAUI, HI",Less than 65 Years,40
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,109
+,"NEWTON, GA",Less than 65 Years,93
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,111
+,"COWETA, GA",Less than 65 Years,54
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,105
+,"ROCKDALE, GA",Less than 65 Years,75
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,114
+,"DREW, AR",Less than 65 Years,61
+,,65 Years or more,98
+,,No value,10 or fewer
+,,Total,159
+,"MIAMI, KS",Less than 65 Years,34
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,92
+,"DOUGLAS, KS",Less than 65 Years,42
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,113
+,"CHATTOOGA, GA",Less than 65 Years,40
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,81
+,"KERN, CA",Less than 65 Years,56
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,98
+,"DELAWARE, IN",Less than 65 Years,56
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,116
+,"OWYHEE, ID",Less than 65 Years,39
+,,65 Years or more,67
+,,No value,10 or fewer
+,,Total,106
+,"GRANT, AR",Less than 65 Years,54
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,107
+,"JASPER, IA",Less than 65 Years,53
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,93
+,"JEFFERSON, KS",Less than 65 Years,24
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,112
+,"HENRY, AL",Less than 65 Years,30
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,93
+,"MISSISSIPPI, AR",Less than 65 Years,38
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,98
+,"BRADFORD, FL",Less than 65 Years,36
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,88
+,"JACKSON, FL",Less than 65 Years,36
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,118
+,"DEKALB, IL",Less than 65 Years,41
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,98
+,"MERCER, IL",Less than 65 Years,21
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,83
+,"SAN JOAQUIN, CA",Less than 65 Years,37
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,79
+,"GOODING, ID",Less than 65 Years,42
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,87
+,"GEM, ID",Less than 65 Years,39
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,93
+,"HENDRICKS, IN",Less than 65 Years,40
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,92
+,"STARKE, IN",Less than 65 Years,39
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,112
+,"JASPER, IL",Less than 65 Years,33
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,91
+,"MIAMI, IN",Less than 65 Years,54
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,96
+,"JEFFERSON, AL",Less than 65 Years,39
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,80
+,"JEFFERSON, IN",Less than 65 Years,21
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,35
+,"VENTURA, CA",Less than 65 Years,41
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,100
+,"GENEVA, AL",Less than 65 Years,41
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,99
+,"KINGS, CA",Less than 65 Years,55
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,102
+,"FULTON, IL",Less than 65 Years,27
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,98
+,"FORD, IL",Less than 65 Years,28
+,,65 Years or more,64
+,,No value,10 or fewer
+,,Total,92
+,"GARLAND, AR",Less than 65 Years,48
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,100
+,"GLYNN, GA",Less than 65 Years,30
+,,65 Years or more,68
+,,No value,10 or fewer
+,,Total,98
+,"STARK, IL",Less than 65 Years,26
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,80
+,"DAVIESS, IN",Less than 65 Years,26
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,88
+,"ELBERT, CO",Less than 65 Years,42
+,,65 Years or more,68
+,,No value,10 or fewer
+,,Total,110
+,"FAYETTE, GA",Less than 65 Years,61
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,96
+,"MERCED, CA",Less than 65 Years,71
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,92
+,"UNION, IN",Less than 65 Years,30
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,84
+,"PIATT, IL",Less than 65 Years,24
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,86
+,"LAMAR, GA",Less than 65 Years,41
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,79
+,"BROWN, IN",Less than 65 Years,16
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,77
+,"PLYMOUTH, IA",Less than 65 Years,24
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,78
+,"GILCHRIST, FL",Less than 65 Years,31
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,70
+,"ESCAMBIA, FL",Less than 65 Years,40
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,80
+,"JENNINGS, IN",Less than 65 Years,34
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,78
+,"MONROE, AR",Less than 65 Years,28
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,80
+,"ANDERSON, KS",Less than 65 Years,37
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,86
+,"GRANT, IN",Less than 65 Years,36
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,82
+,"IOWA, IA",Less than 65 Years,19
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,78
+,"MERIWETHER, GA",Less than 65 Years,22
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,74
+,"MASON, IL",Less than 65 Years,34
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,78
+,"RANDOLPH, IN",Less than 65 Years,20
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,71
+,"BOISE, ID",Less than 65 Years,23
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,72
+,"CLINTON, IA",Less than 65 Years,19
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,45
+,"IROQUOIS, IL",Less than 65 Years,18
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,59
+,"VAN BUREN, AR",Less than 65 Years,39
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,79
+,"FREMONT, CO",Less than 65 Years,31
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,78
+,"LA PORTE, IN",Less than 65 Years,32
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,70
+,"LEON, FL",Less than 65 Years,48
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,85
+,"OGLETHORPE, GA",Less than 65 Years,29
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,75
+,"PRAIRIE, AR",Less than 65 Years,26
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,71
+,"MADISON, FL",Less than 65 Years,19
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,76
+,"DIXIE, FL",Less than 65 Years,39
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,69
+,"PIKE, GA",Less than 65 Years,24
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,62
+,"SPENCER, IN",Less than 65 Years,27
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,72
+,"FAYETTE, IL",Less than 65 Years,21
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,66
+,"POPE, AR",Less than 65 Years,28
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,66
+,"STANISLAUS, CA",Less than 65 Years,37
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,70
+,"PLACER, CA",Less than 65 Years,36
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,77
+,"SOLANO, CA",Less than 65 Years,38
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,70
+,"BREMER, IA",Less than 65 Years,20
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,71
+,"CHATHAM, GA",Less than 65 Years,25
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,61
+,"MORGAN, IN",Less than 65 Years,30
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,74
+,"OKALOOSA, FL",Less than 65 Years,36
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,79
+,"ELBERT, GA",Less than 65 Years,27
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,66
+,"SONOMA, CA",Less than 65 Years,25
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,71
+,"SEDGWICK, KS",Less than 65 Years,35
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,76
+,"ADAMS, ID",Less than 65 Years,17
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,48
+,"JACKSON, IN",Less than 65 Years,26
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,62
+,"DONIPHAN, KS",Less than 65 Years,20
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,70
+,"FULTON, IN",Less than 65 Years,29
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,53
+,"STORY, IA",Less than 65 Years,35
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,68
+,"WASHINGTON, ID",Less than 65 Years,23
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,78
+,"BINGHAM, ID",Less than 65 Years,33
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,63
+,"CHRISTIAN, IL",Less than 65 Years,14
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,51
+,"WELLS, IN",Less than 65 Years,28
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,57
+,"CLAY, IL",Less than 65 Years,21
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,68
+,"MARIN, CA",Less than 65 Years,26
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,52
+,"SANTA CRUZ, CA",Less than 65 Years,24
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,70
+,"SUWANNEE, FL",Less than 65 Years,28
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,59
+,"MONTEREY, CA",Less than 65 Years,28
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,60
+,"ROUTT, CO",Less than 65 Years,27
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,63
+,"DADE, GA",Less than 65 Years,38
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,55
+,"CONWAY, AR",Less than 65 Years,26
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,59
+,"CRAWFORD, IL",Less than 65 Years,12
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,62
+,"THOMAS, KS",Less than 65 Years,22
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,88
+,"GILMER, GA",Less than 65 Years,19
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,65
+,"SANTA BARBARA, CA",Less than 65 Years,31
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,71
+,"CHARLTON, GA",Less than 65 Years,27
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,58
+,"COLES, IL",Less than 65 Years,32
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,63
+,"ESCAMBIA, AL",Less than 65 Years,38
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,62
+,"MOHAVE, AZ",Less than 65 Years,17
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,52
+,"UNION, FL",Less than 65 Years,27
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,54
+,"JACKSON, KS",Less than 65 Years,15
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,59
+,"MORGAN, GA",Less than 65 Years,18
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,56
+,"HOUSTON, GA",Less than 65 Years,28
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,64
+,"PICKENS, GA",Less than 65 Years,31
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,68
+,"MADISON, AL",Less than 65 Years,29
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,58
+,"SAN LUIS OBISPO, CA",Less than 65 Years,21
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,56
+,"SUMTER, AL",Less than 65 Years,31
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,56
+,"PIKE, IN",Less than 65 Years,22
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,50
+,"IMPERIAL, CA",Less than 65 Years,21
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,61
+,"LATAH, ID",Less than 65 Years,34
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,76
+,"LOUISA, IA",Less than 65 Years,21
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,54
+,"UNION, GA",Less than 65 Years,17
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,58
+,"BAY, FL",Less than 65 Years,24
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,50
+,"COCHISE, AZ",Less than 65 Years,12
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,49
+,"LAWRENCE, AR",Less than 65 Years,27
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,55
+,"LYON, IA",Less than 65 Years,21
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,64
+,"BIBB, GA",Less than 65 Years,22
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,45
+,"CHEROKEE, AL",Less than 65 Years,13
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,55
+,"CALHOUN, IA",Less than 65 Years,14
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,44
+,"PARK, CO",Less than 65 Years,21
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,43
+,"HARALSON, GA",Less than 65 Years,20
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,46
+,"CRAWFORD, IN",Less than 65 Years,24
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,48
+,"MOULTRIE, IL",Less than 65 Years,11
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,51
+,"MUSCOGEE, GA",Less than 65 Years,33
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,54
+,"PUTNAM, IL",Less than 65 Years,12
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,50
+,"SANTA ROSA, FL",Less than 65 Years,23
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,41
+,"BUCHANAN, IA",Less than 65 Years,12
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,39
+,"EAGLE, CO",Less than 65 Years,18
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,35
+,"EL DORADO, CA",Less than 65 Years,16
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,48
+,"JACKSON, IA",Less than 65 Years,15
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,45
+,"HAMILTON, FL",Less than 65 Years,25
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,58
+,"SAINT FRANCIS, AR",Less than 65 Years,14
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,40
+,"CERRO GORDO, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"PERRY, AR",Less than 65 Years,16
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,43
+,"CASSIA, ID",Less than 65 Years,16
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,36
+,"FRANKLIN, AR",Less than 65 Years,18
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,53
+,"GILA, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,39
+,"ANCHORAGE, AK",Less than 65 Years,22
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,45
+,"GARFIELD, CO",Less than 65 Years,25
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,40
+,"WASHINGTON, AL",Less than 65 Years,17
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,44
+,"JOHNSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,34
+,"RIPLEY, IN",Less than 65 Years,19
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,39
+,"BARBOUR, AL",Less than 65 Years,18
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,44
+,"JO DAVIESS, IL",Less than 65 Years,13
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,46
+,"JACKSON, AL",Less than 65 Years,22
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,53
+,"LINCOLN, ID",Less than 65 Years,14
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,34
+,"OTERO, CO",Less than 65 Years,19
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,38
+,"ADAMS, IN",Less than 65 Years,30
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,53
+,"LOGAN, IL",Less than 65 Years,21
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,38
+,"OKEECHOBEE, FL",Less than 65 Years,21
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,36
+,"FANNIN, GA",Less than 65 Years,14
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,45
+,"MADISON, AR",Less than 65 Years,38
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,39
+,"WAPELLO, IA",Less than 65 Years,19
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,50
+,"HEARD, GA",Less than 65 Years,20
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,38
+,"LASSEN, CA",Less than 65 Years,19
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,38
+,"LEE, IL",Less than 65 Years,16
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,43
+,"STEPHENSON, IL",Less than 65 Years,16
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,48
+,"WHITE, IL",Less than 65 Years,18
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,48
+,"YUMA, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,44
+,"WABAUNSEE, KS",Less than 65 Years,15
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,36
+,"MADISON, IA",Less than 65 Years,18
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,43
+,"WHITESIDE, IL",Less than 65 Years,13
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,32
+,"COFFEE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,34
+,"GRUNDY, IL",Less than 65 Years,19
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,42
+,"EARLY, GA",Less than 65 Years,16
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,44
+,"CLINCH, GA",Less than 65 Years,17
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,40
+,"ECHOLS, GA",Less than 65 Years,16
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,39
+,"KEOKUK, IA",Less than 65 Years,13
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,39
+,"BALDWIN, GA",Less than 65 Years,14
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,36
+,"KANKAKEE, IL",Less than 65 Years,24
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,42
+,"MILLS, IA",Less than 65 Years,16
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,33
+,"OSCEOLA, IA",Less than 65 Years,23
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,38
+,"CROSS, AR",Less than 65 Years,24
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,46
+,"HOLMES, FL",Less than 65 Years,14
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,32
+,"MCDONOUGH, IL",Less than 65 Years,16
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,39
+,"DECATUR, IN",Less than 65 Years,16
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,38
+,"SHELBY, AL",Less than 65 Years,20
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,39
+,"WASHINGTON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,41
+,"HENRY, IN",Less than 65 Years,19
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,33
+,"CASS, IN",Less than 65 Years,22
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,43
+,"CHAMBERS, AL",Less than 65 Years,20
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,38
+,"HUMBOLDT, CA",Less than 65 Years,20
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,48
+,"ASHLEY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,35
+,"BUTLER, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,22
+,"MOFFAT, CO",Less than 65 Years,20
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,31
+,"SHELBY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,28
+,"UNION, AR",Less than 65 Years,11
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,32
+,"LINN, KS",Less than 65 Years,12
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,31
+,"HARRIS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"LOGAN, AR",Less than 65 Years,15
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,35
+,"POTTAWATOMIE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,32
+,"RILEY, KS",Less than 65 Years,15
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,31
+,"OUACHITA, AR",Less than 65 Years,11
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,28
+,"DESOTO, FL",Less than 65 Years,20
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,31
+,"INDEPENDENCE, AR",Less than 65 Years,21
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,41
+,"KOOTENAI, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,31
+,"MARION, IA",Less than 65 Years,15
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,33
+,"BONNEVILLE, ID",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"MENARD, IL",Less than 65 Years,18
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,37
+,"MONROE, FL",Less than 65 Years,15
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,31
+,"ATCHISON, KS",Less than 65 Years,11
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,28
+,"COCONINO, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,24
+,"GLADES, FL",Less than 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"NAVAJO, AZ",Less than 65 Years,11
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,36
+,"CUMBERLAND, IL",Less than 65 Years,14
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,46
+,"ALLAMAKEE, IA",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"BOONE, IA",Less than 65 Years,11
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,23
+,"HENDERSON, IL",Less than 65 Years,13
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,31
+,"IDAHO, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,24
+,"LINCOLN, AR",Less than 65 Years,16
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,38
+,"VIGO, IN",Less than 65 Years,16
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,30
+,"WILLIAMSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,28
+,"DICKINSON, KS",Less than 65 Years,11
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,30
+,"RANDOLPH, AL",Less than 65 Years,12
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,32
+,"ALEXANDER, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"HENRY, IA",Less than 65 Years,15
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,38
+,"TOWNS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,22
+,"TUSCALOOSA, AL",Less than 65 Years,24
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,38
+,"GRUNDY, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,29
+,"NEVADA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,28
+,"HANCOCK, GA",Less than 65 Years,11
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,27
+,"CALHOUN, AL",Less than 65 Years,14
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,38
+,"DES MOINES, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,27
+,"PLUMAS, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,27
+,"GRAND, CO",Less than 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"BOONE, IN",Less than 65 Years,13
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,28
+,"DUBOIS, IN",Less than 65 Years,11
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,30
+,"LAS ANIMAS, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,27
+,"MONROE, IN",Less than 65 Years,13
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,25
+,"SALINE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,25
+,"SHASTA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,22
+,"TIPPECANOE, IN",Less than 65 Years,13
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,27
+,"LEE, IA",Less than 65 Years,11
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,36
+,"MARENGO, AL",Less than 65 Years,19
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,36
+,"YOLO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,27
+,"RANDOLPH, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,25
+,"JASPER, IN",Less than 65 Years,15
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,26
+,"PULASKI, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,30
+,"GUTHRIE, IA",Less than 65 Years,14
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,30
+,"WABASH, IL",Less than 65 Years,11
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,24
+,"MONTGOMERY, AL",Less than 65 Years,12
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,24
+,"MORGAN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,25
+,"NAPA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,29
+,"PHILLIPS, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,24
+,"JACKSON, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"CLAY, AR",Less than 65 Years,12
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,31
+,"FOUNTAIN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,31
+,"JOHNSON, AR",Less than 65 Years,13
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,24
+,"POWER, ID",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"BUTTE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,25
+,"MARIPOSA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,23
+,"PAGE, IA",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"SEMINOLE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,17
+,"TIPTON, IN",Less than 65 Years,12
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,27
+,"LEE, AL",Less than 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"UPSON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CUSTER, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,19
+,"DELAWARE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,22
+,"DELTA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,21
+,"JASPER, GA",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MARION, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,16
+,"CHICOT, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,20
+,"CROWLEY, CO",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"SANTA CRUZ, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,27
+,"SHARP, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,21
+,"BURKE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CHAFFEE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"WALTON, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,23
+,"ADAMS, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"BRADLEY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,24
+,"YELL, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,21
+,"COFFEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MONROE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"PAWNEE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,18
+,"POPE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"APACHE, AZ",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"DALLAS, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"STAFFORD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,18
+,"CLAY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,22
+,"STONE, AR",Less than 65 Years,12
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,23
+,"WARE, GA",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"CLAYTON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"EDGAR, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"BRANTLEY, GA",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"DESHA, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,20
+,"EDWARDS, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"MONROE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"MONTROSE, CO",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"RANDOLPH, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,22
+,"CLEVELAND, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"COLQUITT, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"TIFT, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CHICKASAW, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HUERFANO, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,17
+,"NEVADA, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"TAYLOR, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CARROLL, AR",Less than 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"EFFINGHAM, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"GALLATIN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,18
+,"HARDIN, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"HUMBOLDT, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,21
+,"BRYAN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARKE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,16
+,"LA PLATA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"SCOTT, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"UNION, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"FRANKLIN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,14
+,"JACKSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"PIKE, AR",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"DOUGHERTY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"LYON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"MCDUFFIE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREMONT, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,21
+,"MONTGOMERY, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"SHELBY, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,13
+,"SULLIVAN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,16
+,"TAYLOR, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,17
+,"WAYNE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,20
+,"JERSEY, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"LEE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"SAN BENITO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,19
+,"BOURBON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CASS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"COLBERT, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CULLMAN, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"LOGAN, CO",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"CASS, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CLARKE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CRAWFORD, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAIRBANKS NORTH STAR, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"GILPIN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"APPANOOSE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,18
+,"RUSSELL, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"COVINGTON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CRAWFORD, KS",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"LAUDERDALE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEARCY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"WOODRUFF, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ELMORE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"INYO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,20
+,"JEFFERSON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KOSSUTH, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,20
+,"LIBERTY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"PERRY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"TUOLUMNE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"WRIGHT, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"BEN HILL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HAMILTON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLER, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"POLK, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"PROWERS, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"WOODSON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"DECATUR, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"DICKINSON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"ETOWAH, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MONROE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINNESHIEK, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CARROLL, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"COFFEE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MARSHALL, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"MENDOCINO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WINNEBAGO, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAXTER, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEAR CREEK, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"PIKE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMMIT, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWITZERLAND, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"FRANKLIN, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"GREENE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"GUNNISON, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,15
+,"IZARD, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"JEFFERSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"PIERCE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARCHULETA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRADY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"EMANUEL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HEMPSTEAD, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MORGAN, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"RIO GRANDE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CLAIR, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"SUTTER, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKES, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATKINSON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BULLOCH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GADSDEN, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIMESTONE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MATANUSKA SUSITNA, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"PULASKI, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"THOMAS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ADAIR, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLACKFORD, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CLARK, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LAFAYETTE, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCINTOSH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,15
+,"MONONA, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RENO, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSH, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALINE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"VERMILLION, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"BENT, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BONNER, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CLAY, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTEZUMA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEMAHA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORANGE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"COLUMBIA, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MONTGOMERY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRIS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WAKULLA, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"BUENA VISTA, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENAI PENINSULA, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEZ PERCE, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEACH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALLADEGA, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"NEWTON, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OHIO, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POCAHONTAS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SISKIYOU, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YUBA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUDUBON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLIS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUCAS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEOSHO, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUTAUGA, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEBURNE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARVEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IDA, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAURENS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LITTLE RIVER, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALIAFERRO, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALLAPOOSA, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOOMBS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WARREN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALAMOSA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AMADOR, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JAY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIT CARSON, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSH, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TEHAMA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YUMA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLOUNT, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA PAZ, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MODOC, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIERRA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BACA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALAVERAS, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMAS, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHILTON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DODGE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMMET, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JENKINS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARKE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"QUITMAN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN BUREN, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALKER, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APPLING, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARIBOU, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRISP, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREMONT, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWEN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHUYLER, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TELFAIR, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TETON, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WORTH, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONECUH, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLASCOCK, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAHAM, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMTER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAR LAKE, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COWLEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GULF, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HALE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEMHI, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PALO ALTO, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHILLIPS, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAC, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN MIGUEL, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKINSON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILSON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALLAS, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FORD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCPHERSON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIO BLANCO, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WORTH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAKER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOUNDARY, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRENSHAW, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOOLY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDWARDS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FINNEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRWIN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFF DAVIS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LONG, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCREVEN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TATTNALL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILCOX, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILCOX, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEARWATER, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONEJOS, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LABETTE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEVIER, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEWARD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERMAN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TURNER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BACON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENEWAH, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLECKLEY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLSWORTH, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNEAU, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIOWA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONEIDA, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTTAWA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRATT, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHLEY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHOSHONE, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMNER, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TERRELL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUSA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEL NORTE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLENN, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENWOOD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEWELL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIBERTY, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHWEST ARCTIC, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RAWLINS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAGUACHE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERIDAN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHEELER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BETHEL, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CANDLER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEYENNE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLOUD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COSTILLA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELK, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENLEE, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEARNY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PULASKI, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINSTON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BULLOCK, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KETCHIKAN GATEWAY, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIOWA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KODIAK ISLAND, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINERAL, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NESS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSBORNE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PETERSBURG, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REPUBLIC, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEDGWICK, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOUTHEAST FAIRBANKS, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEWART, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALBOT, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TWIGGS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALEUTIANS WEST, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIBB, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTTE, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHASE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAUTAUQUA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOVE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAHAM, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREELEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HINSDALE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINGMAN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEADE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORTON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOME, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OURAY, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHILLIPS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROOKS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSSELL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SITKA, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TREUTLEN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRINITY, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALPINE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARBER, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHATTAHOOCHEE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DILLINGHAM, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EVANS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARPER, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HASKELL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTH SLOPE, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRINCE OF WALES HYDER, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RINGGOLD, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALLACE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WICHITA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WRANGELL, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YUKON KOYUKUK, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 65 Years,8079
+,,65 Years or more,13889
+,,No value,10 or fewer
+,,Total,21968
+,Total,Less than 65 Years,192706
+,,65 Years or more,301967
+,,No value,10 or fewer
+,,Total,494674
+Jan 1 – Jul 10 2025,"COOK, IL",Less than 65 Years,5022
+,,65 Years or more,8080
+,,No value,10 or fewer
+,,Total,13102
+,"SAN DIEGO, CA",Less than 65 Years,3538
+,,65 Years or more,8715
+,,No value,10 or fewer
+,,Total,12253
+,"ORANGE, FL",Less than 65 Years,3956
+,,65 Years or more,5010
+,,No value,10 or fewer
+,,Total,8966
+,"LEE, FL",Less than 65 Years,1937
+,,65 Years or more,4932
+,,No value,10 or fewer
+,,Total,6869
+,"DUVAL, FL",Less than 65 Years,3060
+,,65 Years or more,3127
+,,No value,10 or fewer
+,,Total,6187
+,"MARICOPA, AZ",Less than 65 Years,1946
+,,65 Years or more,4386
+,,No value,10 or fewer
+,,Total,6332
+,"HONOLULU, HI",Less than 65 Years,1910
+,,65 Years or more,2893
+,,No value,10 or fewer
+,,Total,4803
+,"BROWARD, FL",Less than 65 Years,1732
+,,65 Years or more,2978
+,,No value,10 or fewer
+,,Total,4710
+,"NEW HAVEN, CT",Less than 65 Years,1863
+,,65 Years or more,3161
+,,No value,10 or fewer
+,,Total,5024
+,"VOLUSIA, FL",Less than 65 Years,1385
+,,65 Years or more,3251
+,,No value,10 or fewer
+,,Total,4636
+,"FRESNO, CA",Less than 65 Years,2318
+,,65 Years or more,2687
+,,No value,10 or fewer
+,,Total,5005
+,"HILLSBOROUGH, FL",Less than 65 Years,2184
+,,65 Years or more,2372
+,,No value,10 or fewer
+,,Total,4556
+,"EL PASO, CO",Less than 65 Years,2046
+,,65 Years or more,2179
+,,No value,10 or fewer
+,,Total,4225
+,"LAKE, FL",Less than 65 Years,1216
+,,65 Years or more,3231
+,,No value,10 or fewer
+,,Total,4447
+,"HARTFORD, CT",Less than 65 Years,1790
+,,65 Years or more,2724
+,,No value,10 or fewer
+,,Total,4514
+,"ADA, ID",Less than 65 Years,1304
+,,65 Years or more,2479
+,,No value,10 or fewer
+,,Total,3783
+,"COBB, GA",Less than 65 Years,1446
+,,65 Years or more,2143
+,,No value,10 or fewer
+,,Total,3589
+,"RIVERSIDE, CA",Less than 65 Years,1241
+,,65 Years or more,2061
+,,No value,10 or fewer
+,,Total,3302
+,"SEMINOLE, FL",Less than 65 Years,1087
+,,65 Years or more,2187
+,,No value,10 or fewer
+,,Total,3274
+,"FULTON, GA",Less than 65 Years,1223
+,,65 Years or more,1468
+,,No value,10 or fewer
+,,Total,2691
+,"FAIRFIELD, CT",Less than 65 Years,995
+,,65 Years or more,1500
+,,No value,10 or fewer
+,,Total,2495
+,"MARION, IN",Less than 65 Years,1317
+,,65 Years or more,1313
+,,No value,10 or fewer
+,,Total,2630
+,"PULASKI, AR",Less than 65 Years,1011
+,,65 Years or more,1434
+,,No value,10 or fewer
+,,Total,2445
+,"ALLEN, IN",Less than 65 Years,954
+,,65 Years or more,1429
+,,No value,10 or fewer
+,,Total,2383
+,"OSCEOLA, FL",Less than 65 Years,1263
+,,65 Years or more,1037
+,,No value,10 or fewer
+,,Total,2300
+,"HALL, GA",Less than 65 Years,907
+,,65 Years or more,1337
+,,No value,10 or fewer
+,,Total,2244
+,"PASCO, FL",Less than 65 Years,801
+,,65 Years or more,1474
+,,No value,10 or fewer
+,,Total,2275
+,"DEKALB, GA",Less than 65 Years,1073
+,,65 Years or more,1095
+,,No value,10 or fewer
+,,Total,2168
+,"SAN BERNARDINO, CA",Less than 65 Years,1282
+,,65 Years or more,1057
+,,No value,10 or fewer
+,,Total,2339
+,"JOHNSON, KS",Less than 65 Years,690
+,,65 Years or more,1736
+,,No value,10 or fewer
+,,Total,2426
+,"DENVER, CO",Less than 65 Years,1289
+,,65 Years or more,936
+,,No value,10 or fewer
+,,Total,2225
+,"PINELLAS, FL",Less than 65 Years,614
+,,65 Years or more,1263
+,,No value,10 or fewer
+,,Total,1877
+,"POLK, IA",Less than 65 Years,936
+,,65 Years or more,1136
+,,No value,10 or fewer
+,,Total,2072
+,"MARION, FL",Less than 65 Years,909
+,,65 Years or more,1195
+,,No value,10 or fewer
+,,Total,2104
+,"NEW LONDON, CT",Less than 65 Years,679
+,,65 Years or more,1285
+,,No value,10 or fewer
+,,Total,1964
+,"LAKE, IL",Less than 65 Years,595
+,,65 Years or more,1490
+,,No value,10 or fewer
+,,Total,2085
+,"LINN, IA",Less than 65 Years,689
+,,65 Years or more,1196
+,,No value,10 or fewer
+,,Total,1885
+,"COLLIER, FL",Less than 65 Years,453
+,,65 Years or more,1194
+,,No value,10 or fewer
+,,Total,1647
+,"POLK, FL",Less than 65 Years,924
+,,65 Years or more,1078
+,,No value,10 or fewer
+,,Total,2002
+,"WINNEBAGO, IL",Less than 65 Years,613
+,,65 Years or more,995
+,,No value,10 or fewer
+,,Total,1608
+,"DUPAGE, IL",Less than 65 Years,628
+,,65 Years or more,1478
+,,No value,10 or fewer
+,,Total,2106
+,"MIDDLESEX, CT",Less than 65 Years,471
+,,65 Years or more,1136
+,,No value,10 or fewer
+,,Total,1607
+,"CANYON, ID",Less than 65 Years,732
+,,65 Years or more,950
+,,No value,10 or fewer
+,,Total,1682
+,"LARIMER, CO",Less than 65 Years,542
+,,65 Years or more,1075
+,,No value,10 or fewer
+,,Total,1617
+,"ARAPAHOE, CO",Less than 65 Years,1023
+,,65 Years or more,1048
+,,No value,10 or fewer
+,,Total,2071
+,"ORANGE, CA",Less than 65 Years,511
+,,65 Years or more,1667
+,,No value,10 or fewer
+,,Total,2178
+,"FLAGLER, FL",Less than 65 Years,426
+,,65 Years or more,1215
+,,No value,10 or fewer
+,,Total,1641
+,"ALAMEDA, CA",Less than 65 Years,604
+,,65 Years or more,880
+,,No value,10 or fewer
+,,Total,1484
+,"PEORIA, IL",Less than 65 Years,477
+,,65 Years or more,883
+,,No value,10 or fewer
+,,Total,1360
+,"WELD, CO",Less than 65 Years,606
+,,65 Years or more,798
+,,No value,10 or fewer
+,,Total,1404
+,"CHAMPAIGN, IL",Less than 65 Years,495
+,,65 Years or more,852
+,,No value,10 or fewer
+,,Total,1347
+,"SANTA CLARA, CA",Less than 65 Years,428
+,,65 Years or more,1009
+,,No value,10 or fewer
+,,Total,1437
+,"PIMA, AZ",Less than 65 Years,476
+,,65 Years or more,889
+,,No value,10 or fewer
+,,Total,1365
+,"SHAWNEE, KS",Less than 65 Years,508
+,,65 Years or more,898
+,,No value,10 or fewer
+,,Total,1406
+,"LAKE, IN",Less than 65 Years,634
+,,65 Years or more,701
+,,No value,10 or fewer
+,,Total,1335
+,"SUMTER, FL",Less than 65 Years,210
+,,65 Years or more,1149
+,,No value,10 or fewer
+,,Total,1359
+,"MARTIN, FL",Less than 65 Years,358
+,,65 Years or more,1202
+,,No value,10 or fewer
+,,Total,1560
+,"SUSSEX, DE",Less than 65 Years,453
+,,65 Years or more,744
+,,No value,10 or fewer
+,,Total,1197
+,"MIAMI-DADE, FL",Less than 65 Years,593
+,,65 Years or more,557
+,,No value,10 or fewer
+,,Total,1150
+,"TAZEWELL, IL",Less than 65 Years,337
+,,65 Years or more,813
+,,No value,10 or fewer
+,,Total,1150
+,"NASSAU, FL",Less than 65 Years,466
+,,65 Years or more,858
+,,No value,10 or fewer
+,,Total,1324
+,"GWINNETT, GA",Less than 65 Years,586
+,,65 Years or more,595
+,,No value,10 or fewer
+,,Total,1181
+,"BALDWIN, AL",Less than 65 Years,378
+,,65 Years or more,708
+,,No value,10 or fewer
+,,Total,1086
+,"ST JOSEPH, IN",Less than 65 Years,448
+,,65 Years or more,679
+,,No value,10 or fewer
+,,Total,1127
+,"SAN FRANCISCO, CA",Less than 65 Years,506
+,,65 Years or more,565
+,,No value,10 or fewer
+,,Total,1071
+,"SAINT JOHNS, FL",Less than 65 Years,514
+,,65 Years or more,881
+,,No value,10 or fewer
+,,Total,1395
+,"KENT, DE",Less than 65 Years,376
+,,65 Years or more,650
+,,No value,10 or fewer
+,,Total,1026
+,"BOULDER, CO",Less than 65 Years,389
+,,65 Years or more,763
+,,No value,10 or fewer
+,,Total,1152
+,"LOWNDES, GA",Less than 65 Years,432
+,,65 Years or more,531
+,,No value,10 or fewer
+,,Total,963
+,"KANE, IL",Less than 65 Years,434
+,,65 Years or more,712
+,,No value,10 or fewer
+,,Total,1146
+,"JEFFERSON, CO",Less than 65 Years,486
+,,65 Years or more,662
+,,No value,10 or fewer
+,,Total,1148
+,"WYANDOTTE, KS",Less than 65 Years,583
+,,65 Years or more,496
+,,No value,10 or fewer
+,,Total,1079
+,"MOBILE, AL",Less than 65 Years,360
+,,65 Years or more,595
+,,No value,10 or fewer
+,,Total,955
+,"INDIAN RIVER, FL",Less than 65 Years,167
+,,65 Years or more,999
+,,No value,10 or fewer
+,,Total,1166
+,"CLAY, FL",Less than 65 Years,497
+,,65 Years or more,483
+,,No value,10 or fewer
+,,Total,980
+,"ROCK ISLAND, IL",Less than 65 Years,370
+,,65 Years or more,612
+,,No value,10 or fewer
+,,Total,982
+,"SAINT LUCIE, FL",Less than 65 Years,417
+,,65 Years or more,813
+,,No value,10 or fewer
+,,Total,1230
+,"MCLEAN, IL",Less than 65 Years,407
+,,65 Years or more,729
+,,No value,10 or fewer
+,,Total,1136
+,"ALACHUA, FL",Less than 65 Years,437
+,,65 Years or more,526
+,,No value,10 or fewer
+,,Total,963
+,"ADAMS, CO",Less than 65 Years,651
+,,65 Years or more,314
+,,No value,10 or fewer
+,,Total,965
+,"PUEBLO, CO",Less than 65 Years,386
+,,65 Years or more,590
+,,No value,10 or fewer
+,,Total,976
+,"VANDERBURGH, IN",Less than 65 Years,391
+,,65 Years or more,547
+,,No value,10 or fewer
+,,Total,938
+,"TWIN FALLS, ID",Less than 65 Years,326
+,,65 Years or more,464
+,,No value,10 or fewer
+,,Total,790
+,"SAN MATEO, CA",Less than 65 Years,273
+,,65 Years or more,539
+,,No value,10 or fewer
+,,Total,812
+,"DOUGLAS, CO",Less than 65 Years,436
+,,65 Years or more,780
+,,No value,10 or fewer
+,,Total,1216
+,"HIGHLANDS, FL",Less than 65 Years,221
+,,65 Years or more,607
+,,No value,10 or fewer
+,,Total,828
+,"PALM BEACH, FL",Less than 65 Years,383
+,,65 Years or more,1137
+,,No value,10 or fewer
+,,Total,1520
+,"CLARK, IN",Less than 65 Years,533
+,,65 Years or more,467
+,,No value,10 or fewer
+,,Total,1000
+,"PAULDING, GA",Less than 65 Years,355
+,,65 Years or more,458
+,,No value,10 or fewer
+,,Total,813
+,"JOHNSON, IA",Less than 65 Years,235
+,,65 Years or more,499
+,,No value,10 or fewer
+,,Total,734
+,"BARROW, GA",Less than 65 Years,372
+,,65 Years or more,328
+,,No value,10 or fewer
+,,Total,700
+,"FLOYD, IN",Less than 65 Years,315
+,,65 Years or more,383
+,,No value,10 or fewer
+,,Total,698
+,"WHITFIELD, GA",Less than 65 Years,465
+,,65 Years or more,565
+,,No value,10 or fewer
+,,Total,1030
+,"DOUGLAS, GA",Less than 65 Years,376
+,,65 Years or more,339
+,,No value,10 or fewer
+,,Total,715
+,"SAINT CLAIR, IL",Less than 65 Years,241
+,,65 Years or more,452
+,,No value,10 or fewer
+,,Total,693
+,"BARTHOLOMEW, IN",Less than 65 Years,250
+,,65 Years or more,424
+,,No value,10 or fewer
+,,Total,674
+,"NEW CASTLE, DE",Less than 65 Years,395
+,,65 Years or more,193
+,,No value,10 or fewer
+,,Total,588
+,"LOS ANGELES, CA",Less than 65 Years,340
+,,65 Years or more,313
+,,No value,10 or fewer
+,,Total,653
+,"KNOX, IL",Less than 65 Years,163
+,,65 Years or more,362
+,,No value,10 or fewer
+,,Total,525
+,"WINDHAM, CT",Less than 65 Years,290
+,,65 Years or more,336
+,,No value,10 or fewer
+,,Total,626
+,"WILL, IL",Less than 65 Years,324
+,,65 Years or more,476
+,,No value,10 or fewer
+,,Total,800
+,"WOODBURY, IA",Less than 65 Years,249
+,,65 Years or more,276
+,,No value,10 or fewer
+,,Total,525
+,"SEBASTIAN, AR",Less than 65 Years,328
+,,65 Years or more,256
+,,No value,10 or fewer
+,,Total,584
+,"HABERSHAM, GA",Less than 65 Years,285
+,,65 Years or more,377
+,,No value,10 or fewer
+,,Total,662
+,"CHEROKEE, GA",Less than 65 Years,235
+,,65 Years or more,348
+,,No value,10 or fewer
+,,Total,583
+,"JACKSON, GA",Less than 65 Years,232
+,,65 Years or more,309
+,,No value,10 or fewer
+,,Total,541
+,"GORDON, GA",Less than 65 Years,290
+,,65 Years or more,310
+,,No value,10 or fewer
+,,Total,600
+,"LA SALLE, IL",Less than 65 Years,194
+,,65 Years or more,409
+,,No value,10 or fewer
+,,Total,603
+,"LITCHFIELD, CT",Less than 65 Years,224
+,,65 Years or more,392
+,,No value,10 or fewer
+,,Total,616
+,"MCHENRY, IL",Less than 65 Years,194
+,,65 Years or more,353
+,,No value,10 or fewer
+,,Total,547
+,"MADERA, CA",Less than 65 Years,190
+,,65 Years or more,253
+,,No value,10 or fewer
+,,Total,443
+,"HOUSTON, AL",Less than 65 Years,238
+,,65 Years or more,288
+,,No value,10 or fewer
+,,Total,526
+,"WAYNE, IN",Less than 65 Years,187
+,,65 Years or more,276
+,,No value,10 or fewer
+,,Total,463
+,"KENDALL, IL",Less than 65 Years,173
+,,65 Years or more,372
+,,No value,10 or fewer
+,,Total,545
+,"KNOX, IN",Less than 65 Years,199
+,,65 Years or more,281
+,,No value,10 or fewer
+,,Total,480
+,"VERMILION, IL",Less than 65 Years,155
+,,65 Years or more,272
+,,No value,10 or fewer
+,,Total,427
+,"SANGAMON, IL",Less than 65 Years,222
+,,65 Years or more,236
+,,No value,10 or fewer
+,,Total,458
+,"NOBLE, IN",Less than 65 Years,162
+,,65 Years or more,238
+,,No value,10 or fewer
+,,Total,400
+,"BLACK HAWK, IA",Less than 65 Years,235
+,,65 Years or more,344
+,,No value,10 or fewer
+,,Total,579
+,"MADISON, IN",Less than 65 Years,174
+,,65 Years or more,309
+,,No value,10 or fewer
+,,Total,483
+,"TOLLAND, CT",Less than 65 Years,194
+,,65 Years or more,376
+,,No value,10 or fewer
+,,Total,570
+,"JOHNSON, IN",Less than 65 Years,128
+,,65 Years or more,307
+,,No value,10 or fewer
+,,Total,435
+,"SCOTT, IA",Less than 65 Years,188
+,,65 Years or more,230
+,,No value,10 or fewer
+,,Total,418
+,"CRAIGHEAD, AR",Less than 65 Years,193
+,,65 Years or more,235
+,,No value,10 or fewer
+,,Total,428
+,"SPALDING, GA",Less than 65 Years,223
+,,65 Years or more,212
+,,No value,10 or fewer
+,,Total,435
+,"FLOYD, GA",Less than 65 Years,142
+,,65 Years or more,327
+,,No value,10 or fewer
+,,Total,469
+,"CITRUS, FL",Less than 65 Years,259
+,,65 Years or more,685
+,,No value,10 or fewer
+,,Total,944
+,"MARSHALL, IN",Less than 65 Years,166
+,,65 Years or more,202
+,,No value,10 or fewer
+,,Total,368
+,"MURRAY, GA",Less than 65 Years,236
+,,65 Years or more,267
+,,No value,10 or fewer
+,,Total,503
+,"LONOKE, AR",Less than 65 Years,122
+,,65 Years or more,249
+,,No value,10 or fewer
+,,Total,371
+,"LUMPKIN, GA",Less than 65 Years,151
+,,65 Years or more,231
+,,No value,10 or fewer
+,,Total,382
+,"CONTRA COSTA, CA",Less than 65 Years,192
+,,65 Years or more,181
+,,No value,10 or fewer
+,,Total,373
+,"HUNTINGTON, IN",Less than 65 Years,169
+,,65 Years or more,247
+,,No value,10 or fewer
+,,Total,416
+,"HERNANDO, FL",Less than 65 Years,309
+,,65 Years or more,641
+,,No value,10 or fewer
+,,Total,950
+,"DUBUQUE, IA",Less than 65 Years,131
+,,65 Years or more,278
+,,No value,10 or fewer
+,,Total,409
+,"BANNOCK, ID",Less than 65 Years,122
+,,65 Years or more,183
+,,No value,10 or fewer
+,,Total,305
+,"FORSYTH, GA",Less than 65 Years,137
+,,65 Years or more,242
+,,No value,10 or fewer
+,,Total,379
+,"WHITE, GA",Less than 65 Years,149
+,,65 Years or more,222
+,,No value,10 or fewer
+,,Total,371
+,"WHITLEY, IN",Less than 65 Years,124
+,,65 Years or more,223
+,,No value,10 or fewer
+,,Total,347
+,"TROUP, GA",Less than 65 Years,145
+,,65 Years or more,192
+,,No value,10 or fewer
+,,Total,337
+,"FAULKNER, AR",Less than 65 Years,157
+,,65 Years or more,175
+,,No value,10 or fewer
+,,Total,332
+,"MARSHALL, IA",Less than 65 Years,121
+,,65 Years or more,229
+,,No value,10 or fewer
+,,Total,350
+,"MADISON, IL",Less than 65 Years,104
+,,65 Years or more,231
+,,No value,10 or fewer
+,,Total,335
+,"CRITTENDEN, AR",Less than 65 Years,154
+,,65 Years or more,137
+,,No value,10 or fewer
+,,Total,291
+,"MUSCATINE, IA",Less than 65 Years,134
+,,65 Years or more,213
+,,No value,10 or fewer
+,,Total,347
+,"WABASH, IN",Less than 65 Years,101
+,,65 Years or more,222
+,,No value,10 or fewer
+,,Total,323
+,"HAWAII, HI",Less than 65 Years,121
+,,65 Years or more,260
+,,No value,10 or fewer
+,,Total,381
+,"BOONE, IL",Less than 65 Years,111
+,,65 Years or more,223
+,,No value,10 or fewer
+,,Total,334
+,"HOWARD, IN",Less than 65 Years,162
+,,65 Years or more,183
+,,No value,10 or fewer
+,,Total,345
+,"CRAWFORD, AR",Less than 65 Years,136
+,,65 Years or more,167
+,,No value,10 or fewer
+,,Total,303
+,"SALINE, AR",Less than 65 Years,158
+,,65 Years or more,157
+,,No value,10 or fewer
+,,Total,315
+,"KOSCIUSKO, IN",Less than 65 Years,156
+,,65 Years or more,162
+,,No value,10 or fewer
+,,Total,318
+,"MESA, CO",Less than 65 Years,152
+,,65 Years or more,179
+,,No value,10 or fewer
+,,Total,331
+,"WASHINGTON, AR",Less than 65 Years,253
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,262
+,"BARTON, KS",Less than 65 Years,120
+,,65 Years or more,196
+,,No value,10 or fewer
+,,Total,316
+,"CLARKE, GA",Less than 65 Years,136
+,,65 Years or more,148
+,,No value,10 or fewer
+,,Total,284
+,"GREENE, GA",Less than 65 Years,76
+,,65 Years or more,179
+,,No value,10 or fewer
+,,Total,255
+,"ELMORE, ID",Less than 65 Years,122
+,,65 Years or more,136
+,,No value,10 or fewer
+,,Total,258
+,"WEBSTER, IA",Less than 65 Years,93
+,,65 Years or more,158
+,,No value,10 or fewer
+,,Total,251
+,"BENTON, AR",Less than 65 Years,203
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,213
+,"CLEBURNE, AR",Less than 65 Years,67
+,,65 Years or more,139
+,,No value,10 or fewer
+,,Total,206
+,"HAMILTON, IN",Less than 65 Years,79
+,,65 Years or more,164
+,,No value,10 or fewer
+,,Total,243
+,"WARRICK, IN",Less than 65 Years,86
+,,65 Years or more,173
+,,No value,10 or fewer
+,,Total,259
+,"CLINTON, IL",Less than 65 Years,70
+,,65 Years or more,194
+,,No value,10 or fewer
+,,Total,264
+,"BREVARD, FL",Less than 65 Years,103
+,,65 Years or more,127
+,,No value,10 or fewer
+,,Total,230
+,"WOODFORD, IL",Less than 65 Years,58
+,,65 Years or more,171
+,,No value,10 or fewer
+,,Total,229
+,"PAYETTE, ID",Less than 65 Years,105
+,,65 Years or more,179
+,,No value,10 or fewer
+,,Total,284
+,"FRANKLIN, GA",Less than 65 Years,113
+,,65 Years or more,129
+,,No value,10 or fewer
+,,Total,242
+,"LAGRANGE, IN",Less than 65 Years,76
+,,65 Years or more,130
+,,No value,10 or fewer
+,,Total,206
+,"EFFINGHAM, IL",Less than 65 Years,67
+,,65 Years or more,149
+,,No value,10 or fewer
+,,Total,216
+,"DALLAS, IA",Less than 65 Years,113
+,,65 Years or more,132
+,,No value,10 or fewer
+,,Total,245
+,"HENRY, IL",Less than 65 Years,88
+,,65 Years or more,147
+,,No value,10 or fewer
+,,Total,235
+,"BARTOW, GA",Less than 65 Years,102
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,208
+,"LIVINGSTON, IL",Less than 65 Years,87
+,,65 Years or more,139
+,,No value,10 or fewer
+,,Total,226
+,"PORTER, IN",Less than 65 Years,102
+,,65 Years or more,188
+,,No value,10 or fewer
+,,Total,290
+,"BLAINE, ID",Less than 65 Years,72
+,,65 Years or more,148
+,,No value,10 or fewer
+,,Total,220
+,"LEVY, FL",Less than 65 Years,107
+,,65 Years or more,128
+,,No value,10 or fewer
+,,Total,235
+,"FRANKLIN, KS",Less than 65 Years,104
+,,65 Years or more,148
+,,No value,10 or fewer
+,,Total,252
+,"KAUAI, HI",Less than 65 Years,52
+,,65 Years or more,129
+,,No value,10 or fewer
+,,Total,181
+,"HART, GA",Less than 65 Years,87
+,,65 Years or more,140
+,,No value,10 or fewer
+,,Total,227
+,"MACON, IL",Less than 65 Years,79
+,,65 Years or more,126
+,,No value,10 or fewer
+,,Total,205
+,"RICHLAND, IL",Less than 65 Years,82
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,176
+,"BROOMFIELD, CO",Less than 65 Years,89
+,,65 Years or more,118
+,,No value,10 or fewer
+,,Total,207
+,"GIBSON, IN",Less than 65 Years,58
+,,65 Years or more,93
+,,No value,10 or fewer
+,,Total,151
+,"CLAYTON, GA",Less than 65 Years,161
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,214
+,"JEROME, ID",Less than 65 Years,83
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,184
+,"TELLER, CO",Less than 65 Years,67
+,,65 Years or more,123
+,,No value,10 or fewer
+,,Total,190
+,"DAWSON, GA",Less than 65 Years,76
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,186
+,"FAYETTE, IN",Less than 65 Years,82
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,192
+,"HENRY, GA",Less than 65 Years,124
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,181
+,"CHARLOTTE, FL",Less than 65 Years,72
+,,65 Years or more,130
+,,No value,10 or fewer
+,,Total,202
+,"BANKS, GA",Less than 65 Years,85
+,,65 Years or more,107
+,,No value,10 or fewer
+,,Total,192
+,"CATOOSA, GA",Less than 65 Years,93
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,204
+,"WARREN, IA",Less than 65 Years,76
+,,65 Years or more,117
+,,No value,10 or fewer
+,,Total,193
+,"BUREAU, IL",Less than 65 Years,68
+,,65 Years or more,103
+,,No value,10 or fewer
+,,Total,171
+,"GEARY, KS",Less than 65 Years,98
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,186
+,"HARRISON, IN",Less than 65 Years,82
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,164
+,"HARDEE, FL",Less than 65 Years,99
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,181
+,"RICHMOND, GA",Less than 65 Years,237
+,,65 Years or more,253
+,,No value,10 or fewer
+,,Total,490
+,"LEAVENWORTH, KS",Less than 65 Years,78
+,,65 Years or more,90
+,,No value,10 or fewer
+,,Total,168
+,"BERRIEN, GA",Less than 65 Years,75
+,,65 Years or more,100
+,,No value,10 or fewer
+,,Total,175
+,"WALKER, GA",Less than 65 Years,74
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,132
+,"OBRIEN, IA",Less than 65 Years,47
+,,65 Years or more,89
+,,No value,10 or fewer
+,,Total,136
+,"HOT SPRING, AR",Less than 65 Years,63
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,137
+,"SARASOTA, FL",Less than 65 Years,37
+,,65 Years or more,93
+,,No value,10 or fewer
+,,Total,130
+,"ELKHART, IN",Less than 65 Years,57
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,135
+,"CAMDEN, GA",Less than 65 Years,75
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,144
+,"PINAL, AZ",Less than 65 Years,83
+,,65 Years or more,205
+,,No value,10 or fewer
+,,Total,288
+,"WARREN, IL",Less than 65 Years,50
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,121
+,"BUTTS, GA",Less than 65 Years,62
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,117
+,"PUTNAM, FL",Less than 65 Years,77
+,,65 Years or more,64
+,,No value,10 or fewer
+,,Total,141
+,"MAHASKA, IA",Less than 65 Years,41
+,,65 Years or more,118
+,,No value,10 or fewer
+,,Total,159
+,"POLK, GA",Less than 65 Years,41
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,136
+,"POSEY, IN",Less than 65 Years,26
+,,65 Years or more,86
+,,No value,10 or fewer
+,,Total,112
+,"STEPHENS, GA",Less than 65 Years,56
+,,65 Years or more,67
+,,No value,10 or fewer
+,,Total,123
+,"HANCOCK, IN",Less than 65 Years,48
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,122
+,"POINSETT, AR",Less than 65 Years,57
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,127
+,"GREENE, AR",Less than 65 Years,56
+,,65 Years or more,64
+,,No value,10 or fewer
+,,Total,120
+,"CHOCTAW, AL",Less than 65 Years,37
+,,65 Years or more,64
+,,No value,10 or fewer
+,,Total,101
+,"MANATEE, FL",Less than 65 Years,40
+,,65 Years or more,68
+,,No value,10 or fewer
+,,Total,108
+,"DOUGLAS, IL",Less than 65 Years,28
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,99
+,"WHITE, AR",Less than 65 Years,52
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,99
+,"LANIER, GA",Less than 65 Years,49
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,89
+,"RABUN, GA",Less than 65 Years,32
+,,65 Years or more,85
+,,No value,10 or fewer
+,,Total,117
+,"SHELBY, IL",Less than 65 Years,48
+,,65 Years or more,83
+,,No value,10 or fewer
+,,Total,131
+,"CLARK, AR",Less than 65 Years,30
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,79
+,"MONTGOMERY, IL",Less than 65 Years,40
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,97
+,"HENDRY, FL",Less than 65 Years,50
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,87
+,"PUTNAM, GA",Less than 65 Years,36
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,98
+,"DEKALB, IN",Less than 65 Years,44
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,120
+,"POWESHIEK, IA",Less than 65 Years,43
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,123
+,"ARKANSAS, AR",Less than 65 Years,31
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,92
+,"CARROLL, GA",Less than 65 Years,61
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,109
+,"DEARBORN, IN",Less than 65 Years,38
+,,65 Years or more,65
+,,No value,10 or fewer
+,,Total,103
+,"OSAGE, KS",Less than 65 Years,29
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,89
+,"BOND, IL",Less than 65 Years,31
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,115
+,"SACRAMENTO, CA",Less than 65 Years,50
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,101
+,"JONES, IA",Less than 65 Years,30
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,79
+,"MASSAC, IL",Less than 65 Years,32
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,83
+,"YAVAPAI, AZ",Less than 65 Years,25
+,,65 Years or more,68
+,,No value,10 or fewer
+,,Total,93
+,"MACOUPIN, IL",Less than 65 Years,16
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,74
+,"JEFFERSON, AR",Less than 65 Years,42
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,89
+,"TAMA, IA",Less than 65 Years,39
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,98
+,"OGLE, IL",Less than 65 Years,30
+,,65 Years or more,67
+,,No value,10 or fewer
+,,Total,97
+,"BENTON, IA",Less than 65 Years,34
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,80
+,"TULARE, CA",Less than 65 Years,58
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,103
+,"PICKENS, AL",Less than 65 Years,41
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,87
+,"SCOTT, IN",Less than 65 Years,52
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,122
+,"CEDAR, IA",Less than 65 Years,23
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,81
+,"WALTON, GA",Less than 65 Years,49
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,71
+,"VALLEY, ID",Less than 65 Years,35
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,82
+,"MARION, AL",Less than 65 Years,87
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,157
+,"MARSHALL, IL",Less than 65 Years,18
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,74
+,"WASHINGTON, IN",Less than 65 Years,49
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,94
+,"COLUMBIA, FL",Less than 65 Years,41
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,89
+,"LAMAR, AL",Less than 65 Years,40
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,94
+,"COLUMBIA, GA",Less than 65 Years,101
+,,65 Years or more,93
+,,No value,10 or fewer
+,,Total,194
+,"COOK, GA",Less than 65 Years,33
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,81
+,"LAWRENCE, IL",Less than 65 Years,22
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,84
+,"OCONEE, GA",Less than 65 Years,20
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,75
+,"STEUBEN, IN",Less than 65 Years,29
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,76
+,"WASHINGTON, IA",Less than 65 Years,20
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,69
+,"POTTAWATTAMIE, IA",Less than 65 Years,32
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,62
+,"FAYETTE, IA",Less than 65 Years,23
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,81
+,"PITKIN, CO",Less than 65 Years,43
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,71
+,"SIOUX, IA",Less than 65 Years,17
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,57
+,"BROOKS, GA",Less than 65 Years,20
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,66
+,"MADISON, GA",Less than 65 Years,44
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,79
+,"DALE, AL",Less than 65 Years,33
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,71
+,"ALLEN, KS",Less than 65 Years,13
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,75
+,"BAKER, FL",Less than 65 Years,45
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,76
+,"MINIDOKA, ID",Less than 65 Years,36
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,69
+,"FRANKLIN, IN",Less than 65 Years,12
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,68
+,"MAUI, HI",Less than 65 Years,35
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,83
+,"NEWTON, GA",Less than 65 Years,54
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,73
+,"COWETA, GA",Less than 65 Years,47
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,70
+,"ROCKDALE, GA",Less than 65 Years,42
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,66
+,"DREW, AR",Less than 65 Years,23
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,75
+,"MIAMI, KS",Less than 65 Years,44
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,107
+,"DOUGLAS, KS",Less than 65 Years,39
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,83
+,"CHATTOOGA, GA",Less than 65 Years,17
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,51
+,"KERN, CA",Less than 65 Years,40
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,58
+,"DELAWARE, IN",Less than 65 Years,32
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,62
+,"OWYHEE, ID",Less than 65 Years,29
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,62
+,"GRANT, AR",Less than 65 Years,26
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,64
+,"JASPER, IA",Less than 65 Years,19
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,76
+,"JEFFERSON, KS",Less than 65 Years,12
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,49
+,"HENRY, AL",Less than 65 Years,25
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,63
+,"MISSISSIPPI, AR",Less than 65 Years,20
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,59
+,"BRADFORD, FL",Less than 65 Years,27
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,58
+,"JACKSON, FL",Less than 65 Years,13
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,52
+,"DEKALB, IL",Less than 65 Years,25
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,68
+,"MERCER, IL",Less than 65 Years,14
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,49
+,"SAN JOAQUIN, CA",Less than 65 Years,36
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,59
+,"GOODING, ID",Less than 65 Years,30
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,65
+,"GEM, ID",Less than 65 Years,25
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,60
+,"HENDRICKS, IN",Less than 65 Years,30
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,58
+,"STARKE, IN",Less than 65 Years,19
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,54
+,"JASPER, IL",Less than 65 Years,11
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,48
+,"MIAMI, IN",Less than 65 Years,37
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,58
+,"JEFFERSON, AL",Less than 65 Years,30
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,56
+,"JEFFERSON, IN",Less than 65 Years,55
+,,65 Years or more,120
+,,No value,10 or fewer
+,,Total,175
+,"VENTURA, CA",Less than 65 Years,23
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,51
+,"GENEVA, AL",Less than 65 Years,28
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,56
+,"KINGS, CA",Less than 65 Years,30
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,58
+,"FULTON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,38
+,"FORD, IL",Less than 65 Years,18
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,52
+,"GARLAND, AR",Less than 65 Years,22
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,48
+,"GLYNN, GA",Less than 65 Years,16
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,41
+,"STARK, IL",Less than 65 Years,13
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,38
+,"DAVIESS, IN",Less than 65 Years,22
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,55
+,"ELBERT, CO",Less than 65 Years,20
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,63
+,"FAYETTE, GA",Less than 65 Years,29
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,42
+,"MERCED, CA",Less than 65 Years,35
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,54
+,"UNION, IN",Less than 65 Years,15
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,46
+,"PIATT, IL",Less than 65 Years,15
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,48
+,"LAMAR, GA",Less than 65 Years,20
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,44
+,"BROWN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,44
+,"PLYMOUTH, IA",Less than 65 Years,24
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,50
+,"GILCHRIST, FL",Less than 65 Years,23
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,45
+,"ESCAMBIA, FL",Less than 65 Years,13
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,36
+,"JENNINGS, IN",Less than 65 Years,14
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,41
+,"MONROE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,35
+,"ANDERSON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,35
+,"GRANT, IN",Less than 65 Years,17
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,39
+,"IOWA, IA",Less than 65 Years,17
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,40
+,"MERIWETHER, GA",Less than 65 Years,13
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,30
+,"MASON, IL",Less than 65 Years,19
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,39
+,"RANDOLPH, IN",Less than 65 Years,16
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,46
+,"BOISE, ID",Less than 65 Years,14
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,39
+,"CLINTON, IA",Less than 65 Years,30
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,85
+,"IROQUOIS, IL",Less than 65 Years,13
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,46
+,"VAN BUREN, AR",Less than 65 Years,12
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,35
+,"FREMONT, CO",Less than 65 Years,15
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,33
+,"LA PORTE, IN",Less than 65 Years,22
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,54
+,"LEON, FL",Less than 65 Years,15
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,37
+,"OGLETHORPE, GA",Less than 65 Years,17
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,38
+,"PRAIRIE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,27
+,"MADISON, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,25
+,"DIXIE, FL",Less than 65 Years,18
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,37
+,"PIKE, GA",Less than 65 Years,16
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,42
+,"SPENCER, IN",Less than 65 Years,18
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,41
+,"FAYETTE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,36
+,"POPE, AR",Less than 65 Years,14
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,35
+,"STANISLAUS, CA",Less than 65 Years,24
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,39
+,"PLACER, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,34
+,"SOLANO, CA",Less than 65 Years,19
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,32
+,"BREMER, IA",Less than 65 Years,11
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,39
+,"CHATHAM, GA",Less than 65 Years,22
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,47
+,"MORGAN, IN",Less than 65 Years,18
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,40
+,"OKALOOSA, FL",Less than 65 Years,13
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,25
+,"ELBERT, GA",Less than 65 Years,14
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,36
+,"SONOMA, CA",Less than 65 Years,17
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,38
+,"SEDGWICK, KS",Less than 65 Years,11
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,31
+,"ADAMS, ID",Less than 65 Years,19
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,46
+,"JACKSON, IN",Less than 65 Years,26
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,41
+,"DONIPHAN, KS",Less than 65 Years,12
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,33
+,"FULTON, IN",Less than 65 Years,13
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,27
+,"STORY, IA",Less than 65 Years,19
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,35
+,"WASHINGTON, ID",Less than 65 Years,17
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,42
+,"BINGHAM, ID",Less than 65 Years,22
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,33
+,"CHRISTIAN, IL",Less than 65 Years,16
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,38
+,"WELLS, IN",Less than 65 Years,17
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,39
+,"CLAY, IL",Less than 65 Years,19
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,48
+,"MARIN, CA",Less than 65 Years,15
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,30
+,"SANTA CRUZ, CA",Less than 65 Years,12
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,36
+,"SUWANNEE, FL",Less than 65 Years,20
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,39
+,"MONTEREY, CA",Less than 65 Years,14
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,33
+,"ROUTT, CO",Less than 65 Years,17
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,36
+,"DADE, GA",Less than 65 Years,25
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,44
+,"CONWAY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,31
+,"CRAWFORD, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,21
+,"THOMAS, KS",Less than 65 Years,19
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,55
+,"GILMER, GA",Less than 65 Years,12
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,38
+,"SANTA BARBARA, CA",Less than 65 Years,15
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,26
+,"CHARLTON, GA",Less than 65 Years,21
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,40
+,"COLES, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,27
+,"ESCAMBIA, AL",Less than 65 Years,21
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,41
+,"MOHAVE, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,27
+,"UNION, FL",Less than 65 Years,14
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,35
+,"JACKSON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,28
+,"MORGAN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,36
+,"HOUSTON, GA",Less than 65 Years,26
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,37
+,"PICKENS, GA",Less than 65 Years,12
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,27
+,"MADISON, AL",Less than 65 Years,19
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,36
+,"SAN LUIS OBISPO, CA",Less than 65 Years,12
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,33
+,"SUMTER, AL",Less than 65 Years,17
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,41
+,"PIKE, IN",Less than 65 Years,14
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,33
+,"IMPERIAL, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,26
+,"LATAH, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,43
+,"LOUISA, IA",Less than 65 Years,15
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,29
+,"UNION, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,27
+,"BAY, FL",Less than 65 Years,17
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,36
+,"COCHISE, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,27
+,"LAWRENCE, AR",Less than 65 Years,12
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,24
+,"LYON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,18
+,"BIBB, GA",Less than 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"CHEROKEE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,27
+,"CALHOUN, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,25
+,"PARK, CO",Less than 65 Years,15
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,37
+,"HARALSON, GA",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"CRAWFORD, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,32
+,"MOULTRIE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,18
+,"MUSCOGEE, GA",Less than 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"PUTNAM, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,29
+,"SANTA ROSA, FL",Less than 65 Years,12
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,29
+,"BUCHANAN, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,26
+,"EAGLE, CO",Less than 65 Years,25
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,33
+,"EL DORADO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,27
+,"JACKSON, IA",Less than 65 Years,12
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,29
+,"HAMILTON, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"SAINT FRANCIS, AR",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"CERRO GORDO, IA",Less than 65 Years,22
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,84
+,"PERRY, AR",Less than 65 Years,11
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,25
+,"CASSIA, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,29
+,"FRANKLIN, AR",Less than 65 Years,15
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,27
+,"GILA, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,26
+,"ANCHORAGE, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,26
+,"GARFIELD, CO",Less than 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"WASHINGTON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"JOHNSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,24
+,"RIPLEY, IN",Less than 65 Years,13
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,30
+,"BARBOUR, AL",Less than 65 Years,12
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,27
+,"JO DAVIESS, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,24
+,"JACKSON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,20
+,"OTERO, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,26
+,"ADAMS, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"LOGAN, IL",Less than 65 Years,18
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,40
+,"OKEECHOBEE, FL",Less than 65 Years,21
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,34
+,"FANNIN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,24
+,"MADISON, AR",Less than 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"WAPELLO, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,17
+,"HEARD, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"LASSEN, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,24
+,"LEE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,28
+,"STEPHENSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,19
+,"WHITE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,25
+,"YUMA, AZ",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"WABAUNSEE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,24
+,"MADISON, IA",Less than 65 Years,12
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,27
+,"WHITESIDE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,28
+,"COFFEE, AL",Less than 65 Years,14
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,33
+,"GRUNDY, IL",Less than 65 Years,13
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,27
+,"EARLY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,17
+,"CLINCH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"ECHOLS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,23
+,"KEOKUK, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,17
+,"BALDWIN, GA",Less than 65 Years,11
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,24
+,"KANKAKEE, IL",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"MILLS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"OSCEOLA, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"CROSS, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"HOLMES, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,24
+,"MCDONOUGH, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"DECATUR, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"SHELBY, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"WASHINGTON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,20
+,"HENRY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,24
+,"CASS, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"CHAMBERS, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HUMBOLDT, CA",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"ASHLEY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,22
+,"BUTLER, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,29
+,"MOFFAT, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"SHELBY, IN",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"UNION, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"LINN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,22
+,"HARRIS, GA",Less than 65 Years,13
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,24
+,"LOGAN, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"POTTAWATOMIE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,15
+,"RILEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"OUACHITA, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,21
+,"DESOTO, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"INDEPENDENCE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"KOOTENAI, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,19
+,"MARION, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"BONNEVILLE, ID",Less than 65 Years,13
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,26
+,"MENARD, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"MONROE, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"ATCHISON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,18
+,"COCONINO, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"GLADES, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,25
+,"NAVAJO, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"CUMBERLAND, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,14
+,"ALLAMAKEE, IA",Less than 65 Years,12
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,26
+,"BOONE, IA",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"HENDERSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,21
+,"IDAHO, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"LINCOLN, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"VIGO, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WILLIAMSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,15
+,"DICKINSON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"RANDOLPH, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,17
+,"ALEXANDER, IL",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"HENRY, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOWNS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,15
+,"TUSCALOOSA, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"GRUNDY, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"NEVADA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"HANCOCK, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CALHOUN, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DES MOINES, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLUMAS, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,17
+,"GRAND, CO",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"BOONE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"DUBOIS, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"LAS ANIMAS, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MONROE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"SALINE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,19
+,"SHASTA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,18
+,"TIPPECANOE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,17
+,"LEE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARENGO, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"YOLO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"RANDOLPH, AR",Less than 65 Years,11
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,23
+,"JASPER, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"PULASKI, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"GUTHRIE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,20
+,"WABASH, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MONTGOMERY, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"MORGAN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"NAPA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHILLIPS, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CLAY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"FOUNTAIN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"POWER, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BUTTE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARIPOSA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,14
+,"PAGE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SEMINOLE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"TIPTON, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"LEE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"UPSON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CUSTER, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELAWARE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"DELTA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"JASPER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MARION, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CHICOT, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,16
+,"CROWLEY, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"SANTA CRUZ, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"SHARP, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"BURKE, GA",Less than 65 Years,18
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,37
+,"CHAFFEE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALTON, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"ADAMS, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRADLEY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"YELL, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MONROE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"PAWNEE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"POPE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"APACHE, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALLAS, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STAFFORD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"STONE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAYTON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,17
+,"EDGAR, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MORGAN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRANTLEY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"DESHA, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"EDWARDS, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MONROE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTROSE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEVELAND, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"COLQUITT, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"TIFT, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CHICKASAW, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,19
+,"HUERFANO, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEVADA, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"TAYLOR, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EFFINGHAM, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALLATIN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HUMBOLDT, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRYAN, GA",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CLARKE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"LA PLATA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SCOTT, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"FRANKLIN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGHERTY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDUFFIE, GA",Less than 65 Years,14
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,25
+,"FREMONT, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLIVAN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JERSEY, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN BENITO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOURBON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLBERT, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,13
+,"CULLMAN, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASS, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARKE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAIRBANKS NORTH STAR, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILPIN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APPANOOSE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"CARROLL, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSSELL, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"COVINGTON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAUDERDALE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"SEARCY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODRUFF, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELMORE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"INYO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, GA",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"KOSSUTH, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIBERTY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TUOLUMNE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WRIGHT, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEN HILL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLER, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PROWERS, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODSON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKINSON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ETOWAH, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINNESHIEK, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENDOCINO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINNEBAGO, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"BAXTER, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEAR CREEK, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SUMMIT, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWITZERLAND, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,19
+,"BOONE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GUNNISON, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"HANCOCK, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IZARD, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIERCE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARCHULETA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"GRADY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMANUEL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"HEMPSTEAD, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIO GRANDE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CLAIR, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUTTER, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKES, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATKINSON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BULLOCH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GADSDEN, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIMESTONE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MATANUSKA SUSITNA, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PULASKI, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THOMAS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAIR, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLACKFORD, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCINTOSH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONONA, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RENO, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSH, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALINE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VERMILLION, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENT, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BONNER, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAYETTE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTEZUMA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEMAHA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORANGE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRIS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAKULLA, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUENA VISTA, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENAI PENINSULA, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEZ PERCE, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEACH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALLADEGA, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OHIO, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POCAHONTAS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SISKIYOU, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YUBA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUDUBON, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLIS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUCAS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEOSHO, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUTAUGA, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEBURNE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARVEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IDA, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAURENS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LITTLE RIVER, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALIAFERRO, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALLAPOOSA, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOOMBS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALAMOSA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AMADOR, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JAY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIT CARSON, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIKE, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSH, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TEHAMA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YUMA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLOUNT, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA PAZ, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MODOC, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIERRA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BACA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALAVERAS, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMAS, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHILTON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DODGE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMMET, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JENKINS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARKE, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"QUITMAN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN BUREN, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALKER, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APPLING, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARIBOU, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRISP, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREMONT, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWEN, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHUYLER, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TELFAIR, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TETON, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WORTH, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONECUH, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLASCOCK, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAHAM, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONO, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMTER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAR LAKE, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COWLEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GULF, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HALE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEMHI, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PALO ALTO, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHILLIPS, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAC, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN MIGUEL, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILKINSON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILSON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALLAS, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVIS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FORD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCPHERSON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIO BLANCO, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WORTH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAKER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, IN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOUNDARY, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRENSHAW, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOOLY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDWARDS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FINNEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRWIN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFF DAVIS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LONG, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCREVEN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TATTNALL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILCOX, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILCOX, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEARWATER, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONEJOS, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LABETTE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEVIER, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEWARD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERMAN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TURNER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BACON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENEWAH, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLECKLEY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROWN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLSWORTH, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FULTON, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNEAU, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIOWA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, AR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONEIDA, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTTAWA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRATT, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHLEY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHOSHONE, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMNER, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TERRELL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEROKEE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUSA, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEL NORTE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLENN, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENWOOD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEWELL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIBERTY, FL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTHWEST ARCTIC, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANDOLPH, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RAWLINS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAGUACHE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERIDAN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHEELER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BETHEL, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CANDLER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEYENNE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLOUD, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COSTILLA, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELK, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENLEE, AZ",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEARNY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PULASKI, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, IL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINSTON, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BULLOCK, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DECATUR, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KETCHIKAN GATEWAY, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIOWA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KODIAK ISLAND, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINERAL, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NESS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSBORNE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PETERSBURG, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REPUBLIC, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEDGWICK, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOUTHEAST FAIRBANKS, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEWART, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TALBOT, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TWIGGS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALEUTIANS WEST, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIBB, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTTE, ID",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHASE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHAUTAUQUA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOVE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAHAM, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREELEY, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENE, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HINSDALE, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINGMAN, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEADE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORTON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOME, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OURAY, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHILLIPS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROOKS, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSSELL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SITKA, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TREUTLEN, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRINITY, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALPINE, CA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARBER, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHATTAHOOCHEE, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DILLINGHAM, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EVANS, GA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARPER, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HASKELL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NORTH SLOPE, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, AL",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRINCE OF WALES HYDER, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RINGGOLD, IA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, CO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALLACE, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WICHITA, KS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WRANGELL, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YUKON KOYUKUK, AK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 65 Years,5030
+,,65 Years or more,8687
+,,No value,10 or fewer
+,,Total,13717
+,Total,Less than 65 Years,113139
+,,65 Years or more,177931
+,,No value,10 or fewer
+,,Total,291070

--- a/data/epic/raw/staging/D02b_Falls_EDvisits_CountiesKY_NC_Year_Age.csv
+++ b/data/epic/raw/staging/D02b_Falls_EDvisits_CountiesKY_NC_Year_Age.csv
@@ -1,0 +1,12037 @@
+﻿Session Title,Falls in KY-NC,,
+Session ID,2748287,,
+Data Model,ED Encounters,,
+Population Base,All ED Encounters,,
+Population Criteria Filters: These criteria are a summary and do not fully reflect the content of the exported session.,State of Residence (U.S.): StateGroupB,ED Diagnoses: Fall,
+Session Date Range,1/1/2023 - 7/17/2025 (Based On Arrival Date),,
+Measure,Number of ED Encounters,,
+Export User,Stephanie Perniciaro,,
+Date of Export,8/8/2025,,
+,,,
+,,,
+,,,Number of ED Encounters
+Year,County of Residence,Age at Time of Visit,
+Jan 1 – Dec 31 2023,"WAYNE, MI",Less than 65 Years,4314
+,,65 Years or more,6345
+,,No value,10 or fewer
+,,Total,10659
+,"WAKE, NC",Less than 65 Years,3771
+,,65 Years or more,6276
+,,No value,10 or fewer
+,,Total,10047
+,"MIDDLESEX, MA",Less than 65 Years,2787
+,,65 Years or more,6432
+,,No value,10 or fewer
+,,Total,9219
+,"MONROE, NY",Less than 65 Years,2349
+,,65 Years or more,4873
+,,No value,10 or fewer
+,,Total,7222
+,"JEFFERSON, KY",Less than 65 Years,3587
+,,65 Years or more,3887
+,,No value,10 or fewer
+,,Total,7474
+,"KENT, MI",Less than 65 Years,2363
+,,65 Years or more,4223
+,,No value,10 or fewer
+,,Total,6586
+,"KINGS, NY",Less than 65 Years,3622
+,,65 Years or more,2935
+,,No value,10 or fewer
+,,Total,6557
+,"HENNEPIN, MN",Less than 65 Years,2593
+,,65 Years or more,3894
+,,No value,10 or fewer
+,,Total,6487
+,"SUFFOLK, NY",Less than 65 Years,2207
+,,65 Years or more,4283
+,,No value,10 or fewer
+,,Total,6490
+,"OAKLAND, MI",Less than 65 Years,1236
+,,65 Years or more,3342
+,,No value,10 or fewer
+,,Total,4578
+,"WORCESTER, MA",Less than 65 Years,1929
+,,65 Years or more,3025
+,,No value,10 or fewer
+,,Total,4954
+,"GUILFORD, NC",Less than 65 Years,1975
+,,65 Years or more,3525
+,,No value,10 or fewer
+,,Total,5500
+,"MECKLENBURG, NC",Less than 65 Years,1939
+,,65 Years or more,3032
+,,No value,10 or fewer
+,,Total,4971
+,"MACOMB, MI",Less than 65 Years,1138
+,,65 Years or more,3147
+,,No value,10 or fewer
+,,Total,4285
+,"NASSAU, NY",Less than 65 Years,1503
+,,65 Years or more,3456
+,,No value,10 or fewer
+,,Total,4959
+,"CAMDEN, NJ",Less than 65 Years,1944
+,,65 Years or more,2811
+,,No value,10 or fewer
+,,Total,4755
+,"ERIE, NY",Less than 65 Years,1544
+,,65 Years or more,2994
+,,No value,10 or fewer
+,,Total,4538
+,"SHELBY, TN",Less than 65 Years,1252
+,,65 Years or more,1744
+,,No value,10 or fewer
+,,Total,2996
+,"EAST BATON ROUGE, LA",Less than 65 Years,2034
+,,65 Years or more,1967
+,,No value,10 or fewer
+,,Total,4001
+,"CLARK, NV",Less than 65 Years,1801
+,,65 Years or more,2237
+,,No value,10 or fewer
+,,Total,4038
+,"QUEENS, NY",Less than 65 Years,2252
+,,65 Years or more,2056
+,,No value,10 or fewer
+,,Total,4308
+,"FORSYTH, NC",Less than 65 Years,1352
+,,65 Years or more,2652
+,,No value,10 or fewer
+,,Total,4004
+,"JEFFERSON, LA",Less than 65 Years,1871
+,,65 Years or more,2103
+,,No value,10 or fewer
+,,Total,3974
+,"OCEAN, NJ",Less than 65 Years,798
+,,65 Years or more,2042
+,,No value,10 or fewer
+,,Total,2840
+,"ESSEX, NJ",Less than 65 Years,592
+,,65 Years or more,789
+,,No value,10 or fewer
+,,Total,1381
+,"ESSEX, MA",Less than 65 Years,893
+,,65 Years or more,2487
+,,No value,10 or fewer
+,,Total,3380
+,"SUFFOLK, MA",Less than 65 Years,1559
+,,65 Years or more,1238
+,,No value,10 or fewer
+,,Total,2797
+,"BRISTOL, MA",Less than 65 Years,1237
+,,65 Years or more,2178
+,,No value,10 or fewer
+,,Total,3415
+,"LAFAYETTE, LA",Less than 65 Years,1833
+,,65 Years or more,1646
+,,No value,10 or fewer
+,,Total,3479
+,"CUMBERLAND, NC",Less than 65 Years,1483
+,,65 Years or more,1990
+,,No value,10 or fewer
+,,Total,3473
+,"BURLINGTON, NJ",Less than 65 Years,1004
+,,65 Years or more,2193
+,,No value,10 or fewer
+,,Total,3197
+,"JACKSON, MI",Less than 65 Years,1249
+,,65 Years or more,2016
+,,No value,10 or fewer
+,,Total,3265
+,"MIDDLESEX, NJ",Less than 65 Years,1098
+,,65 Years or more,1865
+,,No value,10 or fewer
+,,Total,2963
+,"JACKSON, MO",Less than 65 Years,1093
+,,65 Years or more,1994
+,,No value,10 or fewer
+,,Total,3087
+,"WASHOE, NV",Less than 65 Years,1402
+,,65 Years or more,1837
+,,No value,10 or fewer
+,,Total,3239
+,"ALBANY, NY",Less than 65 Years,762
+,,65 Years or more,1697
+,,No value,10 or fewer
+,,Total,2459
+,"FAYETTE, KY",Less than 65 Years,1475
+,,65 Years or more,1541
+,,No value,10 or fewer
+,,Total,3016
+,"WASHTENAW, MI",Less than 65 Years,879
+,,65 Years or more,2060
+,,No value,10 or fewer
+,,Total,2939
+,"JOHNSTON, NC",Less than 65 Years,1098
+,,65 Years or more,1645
+,,No value,10 or fewer
+,,Total,2743
+,"KALAMAZOO, MI",Less than 65 Years,934
+,,65 Years or more,1775
+,,No value,10 or fewer
+,,Total,2709
+,"LANCASTER, NE",Less than 65 Years,961
+,,65 Years or more,1511
+,,No value,10 or fewer
+,,Total,2472
+,"SULLIVAN, TN",Less than 65 Years,1025
+,,65 Years or more,1780
+,,No value,10 or fewer
+,,Total,2805
+,"WASHINGTON, MD",Less than 65 Years,879
+,,65 Years or more,1631
+,,No value,10 or fewer
+,,Total,2510
+,"MUSKEGON, MI",Less than 65 Years,951
+,,65 Years or more,1549
+,,No value,10 or fewer
+,,Total,2500
+,"HINDS, MS",Less than 65 Years,1192
+,,65 Years or more,1146
+,,No value,10 or fewer
+,,Total,2338
+,"PITT, NC",Less than 65 Years,1011
+,,65 Years or more,1236
+,,No value,10 or fewer
+,,Total,2247
+,"ALAMANCE, NC",Less than 65 Years,793
+,,65 Years or more,1485
+,,No value,10 or fewer
+,,Total,2278
+,"HAMILTON, TN",Less than 65 Years,950
+,,65 Years or more,1229
+,,No value,10 or fewer
+,,Total,2179
+,"ORLEANS, LA",Less than 65 Years,1100
+,,65 Years or more,1156
+,,No value,10 or fewer
+,,Total,2256
+,"WAYNE, NC",Less than 65 Years,928
+,,65 Years or more,1441
+,,No value,10 or fewer
+,,Total,2369
+,"JACKSON, MS",Less than 65 Years,875
+,,65 Years or more,1199
+,,No value,10 or fewer
+,,Total,2074
+,"LIVINGSTON, LA",Less than 65 Years,1081
+,,65 Years or more,1054
+,,No value,10 or fewer
+,,Total,2135
+,"BROOME, NY",Less than 65 Years,993
+,,65 Years or more,1325
+,,No value,10 or fewer
+,,Total,2318
+,"DAKOTA, MN",Less than 65 Years,760
+,,65 Years or more,1349
+,,No value,10 or fewer
+,,Total,2109
+,"LIVINGSTON, MI",Less than 65 Years,552
+,,65 Years or more,1614
+,,No value,10 or fewer
+,,Total,2166
+,"BERRIEN, MI",Less than 65 Years,690
+,,65 Years or more,1255
+,,No value,10 or fewer
+,,Total,1945
+,"PRINCE GEORGES, MD",Less than 65 Years,910
+,,65 Years or more,966
+,,No value,10 or fewer
+,,Total,1876
+,"HUDSON, NJ",Less than 65 Years,685
+,,65 Years or more,439
+,,No value,10 or fewer
+,,Total,1124
+,"BALTIMORE, MD",Less than 65 Years,642
+,,65 Years or more,1312
+,,No value,10 or fewer
+,,Total,1954
+,"BRUNSWICK, NC",Less than 65 Years,392
+,,65 Years or more,972
+,,No value,10 or fewer
+,,Total,1364
+,"TANGIPAHOA, LA",Less than 65 Years,973
+,,65 Years or more,1072
+,,No value,10 or fewer
+,,Total,2045
+,"ANNE ARUNDEL, MD",Less than 65 Years,710
+,,65 Years or more,1087
+,,No value,10 or fewer
+,,Total,1797
+,"ORANGE, NY",Less than 65 Years,742
+,,65 Years or more,1210
+,,No value,10 or fewer
+,,Total,1952
+,"RAMSEY, MN",Less than 65 Years,780
+,,65 Years or more,1191
+,,No value,10 or fewer
+,,Total,1971
+,"MONTGOMERY, MD",Less than 65 Years,778
+,,65 Years or more,1140
+,,No value,10 or fewer
+,,Total,1918
+,"ROBESON, NC",Less than 65 Years,891
+,,65 Years or more,1080
+,,No value,10 or fewer
+,,Total,1971
+,"SOMERSET, NJ",Less than 65 Years,532
+,,65 Years or more,1212
+,,No value,10 or fewer
+,,Total,1744
+,"SAINT LOUIS, MN",Less than 65 Years,696
+,,65 Years or more,1154
+,,No value,10 or fewer
+,,Total,1850
+,"ONEIDA, NY",Less than 65 Years,602
+,,65 Years or more,1234
+,,No value,10 or fewer
+,,Total,1836
+,"BALTIMORE CITY, MD",Less than 65 Years,985
+,,65 Years or more,617
+,,No value,10 or fewer
+,,Total,1602
+,"OUACHITA, LA",Less than 65 Years,691
+,,65 Years or more,1041
+,,No value,10 or fewer
+,,Total,1732
+,"CALHOUN, MI",Less than 65 Years,697
+,,65 Years or more,1144
+,,No value,10 or fewer
+,,Total,1841
+,"DOUGLAS, NE",Less than 65 Years,912
+,,65 Years or more,832
+,,No value,10 or fewer
+,,Total,1744
+,"NASH, NC",Less than 65 Years,573
+,,65 Years or more,1018
+,,No value,10 or fewer
+,,Total,1591
+,"CHITTENDEN, VT",Less than 65 Years,515
+,,65 Years or more,1100
+,,No value,10 or fewer
+,,Total,1615
+,"RENSSELAER, NY",Less than 65 Years,552
+,,65 Years or more,900
+,,No value,10 or fewer
+,,Total,1452
+,"WICOMICO, MD",Less than 65 Years,729
+,,65 Years or more,911
+,,No value,10 or fewer
+,,Total,1640
+,"MONROE, MI",Less than 65 Years,510
+,,65 Years or more,971
+,,No value,10 or fewer
+,,Total,1481
+,"BERNALILLO, NM",Less than 65 Years,652
+,,65 Years or more,1037
+,,No value,10 or fewer
+,,Total,1689
+,"NEW HANOVER, NC",Less than 65 Years,69
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,166
+,"HENDERSON, NC",Less than 65 Years,328
+,,65 Years or more,1138
+,,No value,10 or fewer
+,,Total,1466
+,"UNION, NJ",Less than 65 Years,476
+,,65 Years or more,555
+,,No value,10 or fewer
+,,Total,1031
+,"HARNETT, NC",Less than 65 Years,640
+,,65 Years or more,978
+,,No value,10 or fewer
+,,Total,1618
+,"GLOUCESTER, NJ",Less than 65 Years,469
+,,65 Years or more,988
+,,No value,10 or fewer
+,,Total,1457
+,"ROCKINGHAM, NC",Less than 65 Years,571
+,,65 Years or more,983
+,,No value,10 or fewer
+,,Total,1554
+,"PLYMOUTH, MA",Less than 65 Years,313
+,,65 Years or more,579
+,,No value,10 or fewer
+,,Total,892
+,"LENOIR, NC",Less than 65 Years,593
+,,65 Years or more,777
+,,No value,10 or fewer
+,,Total,1370
+,"DESOTO, MS",Less than 65 Years,392
+,,65 Years or more,672
+,,No value,10 or fewer
+,,Total,1064
+,"CUMBERLAND, ME",Less than 65 Years,371
+,,65 Years or more,1109
+,,No value,10 or fewer
+,,Total,1480
+,"ORANGE, NC",Less than 65 Years,467
+,,65 Years or more,943
+,,No value,10 or fewer
+,,Total,1410
+,"OTTAWA, MI",Less than 65 Years,388
+,,65 Years or more,961
+,,No value,10 or fewer
+,,Total,1349
+,"HARFORD, MD",Less than 65 Years,389
+,,65 Years or more,918
+,,No value,10 or fewer
+,,Total,1307
+,"ROWAN, NC",Less than 65 Years,525
+,,65 Years or more,821
+,,No value,10 or fewer
+,,Total,1346
+,"HARRISON, MS",Less than 65 Years,634
+,,65 Years or more,656
+,,No value,10 or fewer
+,,Total,1290
+,"NEW YORK, NY",Less than 65 Years,514
+,,65 Years or more,820
+,,No value,10 or fewer
+,,Total,1334
+,"WASHINGTON, TN",Less than 65 Years,485
+,,65 Years or more,951
+,,No value,10 or fewer
+,,Total,1436
+,"ONONDAGA, NY",Less than 65 Years,384
+,,65 Years or more,880
+,,No value,10 or fewer
+,,Total,1264
+,"MERCER, NJ",Less than 65 Years,421
+,,65 Years or more,837
+,,No value,10 or fewer
+,,Total,1258
+,"NORFOLK, MA",Less than 65 Years,279
+,,65 Years or more,283
+,,No value,10 or fewer
+,,Total,562
+,"RANKIN, MS",Less than 65 Years,489
+,,65 Years or more,720
+,,No value,10 or fewer
+,,Total,1209
+,"YORK, ME",Less than 65 Years,346
+,,65 Years or more,871
+,,No value,10 or fewer
+,,Total,1217
+,"BURKE, NC",Less than 65 Years,425
+,,65 Years or more,751
+,,No value,10 or fewer
+,,Total,1176
+,"MCCRACKEN, KY",Less than 65 Years,569
+,,65 Years or more,781
+,,No value,10 or fewer
+,,Total,1350
+,"BUCHANAN, MO",Less than 65 Years,431
+,,65 Years or more,649
+,,No value,10 or fewer
+,,Total,1080
+,"HARDIN, KY",Less than 65 Years,566
+,,65 Years or more,651
+,,No value,10 or fewer
+,,Total,1218
+,"DAVIDSON, NC",Less than 65 Years,483
+,,65 Years or more,745
+,,No value,10 or fewer
+,,Total,1228
+,"GENESEE, MI",Less than 65 Years,627
+,,65 Years or more,494
+,,No value,10 or fewer
+,,Total,1121
+,"VAN BUREN, MI",Less than 65 Years,469
+,,65 Years or more,709
+,,No value,10 or fewer
+,,Total,1178
+,"LOWNDES, MS",Less than 65 Years,516
+,,65 Years or more,635
+,,No value,10 or fewer
+,,Total,1151
+,"EDGECOMBE, NC",Less than 65 Years,434
+,,65 Years or more,691
+,,No value,10 or fewer
+,,Total,1125
+,"WASHINGTON, MN",Less than 65 Years,392
+,,65 Years or more,784
+,,No value,10 or fewer
+,,Total,1176
+,"WARREN, NJ",Less than 65 Years,458
+,,65 Years or more,637
+,,No value,10 or fewer
+,,Total,1095
+,"SARPY, NE",Less than 65 Years,465
+,,65 Years or more,616
+,,No value,10 or fewer
+,,Total,1081
+,"ASCENSION, LA",Less than 65 Years,544
+,,65 Years or more,537
+,,No value,10 or fewer
+,,Total,1081
+,"BERGEN, NJ",Less than 65 Years,296
+,,65 Years or more,632
+,,No value,10 or fewer
+,,Total,928
+,"STEARNS, MN",Less than 65 Years,436
+,,65 Years or more,690
+,,No value,10 or fewer
+,,Total,1126
+,"LENAWEE, MI",Less than 65 Years,319
+,,65 Years or more,823
+,,No value,10 or fewer
+,,Total,1142
+,"HALIFAX, NC",Less than 65 Years,400
+,,65 Years or more,620
+,,No value,10 or fewer
+,,Total,1020
+,"MADISON, KY",Less than 65 Years,346
+,,65 Years or more,506
+,,No value,10 or fewer
+,,Total,852
+,"MONMOUTH, NJ",Less than 65 Years,308
+,,65 Years or more,436
+,,No value,10 or fewer
+,,Total,744
+,"SULLIVAN, NY",Less than 65 Years,521
+,,65 Years or more,526
+,,No value,10 or fewer
+,,Total,1047
+,"GALLATIN, MT",Less than 65 Years,499
+,,65 Years or more,476
+,,No value,10 or fewer
+,,Total,975
+,"MADISON, MS",Less than 65 Years,330
+,,65 Years or more,562
+,,No value,10 or fewer
+,,Total,892
+,"DUPLIN, NC",Less than 65 Years,363
+,,65 Years or more,538
+,,No value,10 or fewer
+,,Total,901
+,"NIAGARA, NY",Less than 65 Years,247
+,,65 Years or more,531
+,,No value,10 or fewer
+,,Total,778
+,"PIKE, KY",Less than 65 Years,439
+,,65 Years or more,409
+,,No value,10 or fewer
+,,Total,848
+,"ACADIA, LA",Less than 65 Years,554
+,,65 Years or more,444
+,,No value,10 or fewer
+,,Total,998
+,"CALDWELL, NC",Less than 65 Years,365
+,,65 Years or more,532
+,,No value,10 or fewer
+,,Total,897
+,"BEAUFORT, NC",Less than 65 Years,313
+,,65 Years or more,627
+,,No value,10 or fewer
+,,Total,940
+,"FORREST, MS",Less than 65 Years,343
+,,65 Years or more,525
+,,No value,10 or fewer
+,,Total,868
+,"HAWKINS, TN",Less than 65 Years,381
+,,65 Years or more,563
+,,No value,10 or fewer
+,,Total,944
+,"CLINTON, NY",Less than 65 Years,301
+,,65 Years or more,593
+,,No value,10 or fewer
+,,Total,894
+,"CHATHAM, NC",Less than 65 Years,158
+,,65 Years or more,583
+,,No value,10 or fewer
+,,Total,741
+,"GREENE, TN",Less than 65 Years,294
+,,65 Years or more,578
+,,No value,10 or fewer
+,,Total,872
+,"LAUDERDALE, MS",Less than 65 Years,337
+,,65 Years or more,281
+,,No value,10 or fewer
+,,Total,618
+,"DURHAM, NC",Less than 65 Years,409
+,,65 Years or more,452
+,,No value,10 or fewer
+,,Total,861
+,"ONTARIO, NY",Less than 65 Years,206
+,,65 Years or more,500
+,,No value,10 or fewer
+,,Total,706
+,"PEARL RIVER, MS",Less than 65 Years,339
+,,65 Years or more,478
+,,No value,10 or fewer
+,,Total,817
+,"STEUBEN, NY",Less than 65 Years,259
+,,65 Years or more,460
+,,No value,10 or fewer
+,,Total,719
+,"HILLSBOROUGH, NH",Less than 65 Years,198
+,,65 Years or more,536
+,,No value,10 or fewer
+,,Total,734
+,"ANOKA, MN",Less than 65 Years,397
+,,65 Years or more,423
+,,No value,10 or fewer
+,,Total,820
+,"OTTER TAIL, MN",Less than 65 Years,210
+,,65 Years or more,536
+,,No value,10 or fewer
+,,Total,746
+,"SARATOGA, NY",Less than 65 Years,104
+,,65 Years or more,271
+,,No value,10 or fewer
+,,Total,375
+,"WAYNE, NY",Less than 65 Years,210
+,,65 Years or more,453
+,,No value,10 or fewer
+,,Total,663
+,"CHARLES, MD",Less than 65 Years,239
+,,65 Years or more,354
+,,No value,10 or fewer
+,,Total,593
+,"SAINT MARTIN, LA",Less than 65 Years,371
+,,65 Years or more,340
+,,No value,10 or fewer
+,,Total,711
+,"UNION, NC",Less than 65 Years,232
+,,65 Years or more,464
+,,No value,10 or fewer
+,,Total,696
+,"ITASCA, MN",Less than 65 Years,267
+,,65 Years or more,476
+,,No value,10 or fewer
+,,Total,743
+,"PLATTE, MO",Less than 65 Years,186
+,,65 Years or more,427
+,,No value,10 or fewer
+,,Total,613
+,"PENOBSCOT, ME",Less than 65 Years,226
+,,65 Years or more,533
+,,No value,10 or fewer
+,,Total,759
+,"ST JOHN THE BAPTIST, LA",Less than 65 Years,362
+,,65 Years or more,312
+,,No value,10 or fewer
+,,Total,674
+,"BELTRAMI, MN",Less than 65 Years,282
+,,65 Years or more,416
+,,No value,10 or fewer
+,,Total,698
+,"LEE, MS",Less than 65 Years,68
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,131
+,"ALLEGAN, MI",Less than 65 Years,249
+,,65 Years or more,391
+,,No value,10 or fewer
+,,Total,640
+,"LINCOLN, NE",Less than 65 Years,330
+,,65 Years or more,406
+,,No value,10 or fewer
+,,Total,736
+,"CLAY, MO",Less than 65 Years,258
+,,65 Years or more,347
+,,No value,10 or fewer
+,,Total,605
+,"WESTCHESTER, NY",Less than 65 Years,244
+,,65 Years or more,396
+,,No value,10 or fewer
+,,Total,640
+,"TIPTON, TN",Less than 65 Years,241
+,,65 Years or more,276
+,,No value,10 or fewer
+,,Total,517
+,"HENDERSON, KY",Less than 65 Years,251
+,,65 Years or more,417
+,,No value,10 or fewer
+,,Total,668
+,"ANDROSCOGGIN, ME",Less than 65 Years,258
+,,65 Years or more,389
+,,No value,10 or fewer
+,,Total,647
+,"SHERBURNE, MN",Less than 65 Years,323
+,,65 Years or more,345
+,,No value,10 or fewer
+,,Total,668
+,"BULLITT, KY",Less than 65 Years,371
+,,65 Years or more,346
+,,No value,10 or fewer
+,,Total,717
+,"PHELPS, MO",Less than 65 Years,226
+,,65 Years or more,369
+,,No value,10 or fewer
+,,Total,595
+,"CARTER, TN",Less than 65 Years,241
+,,65 Years or more,376
+,,No value,10 or fewer
+,,Total,617
+,"WASHINGTON, LA",Less than 65 Years,350
+,,65 Years or more,275
+,,No value,10 or fewer
+,,Total,625
+,"CHESHIRE, NH",Less than 65 Years,142
+,,65 Years or more,390
+,,No value,10 or fewer
+,,Total,532
+,"SAINT LAWRENCE, NY",Less than 65 Years,193
+,,65 Years or more,418
+,,No value,10 or fewer
+,,Total,611
+,"SAINT MARY, LA",Less than 65 Years,321
+,,65 Years or more,277
+,,No value,10 or fewer
+,,Total,598
+,"OLDHAM, KY",Less than 65 Years,330
+,,65 Years or more,308
+,,No value,10 or fewer
+,,Total,638
+,"HERKIMER, NY",Less than 65 Years,222
+,,65 Years or more,391
+,,No value,10 or fewer
+,,Total,613
+,"IBERVILLE, LA",Less than 65 Years,337
+,,65 Years or more,280
+,,No value,10 or fewer
+,,Total,617
+,"BLADEN, NC",Less than 65 Years,242
+,,65 Years or more,367
+,,No value,10 or fewer
+,,Total,609
+,"CLAY, MN",Less than 65 Years,265
+,,65 Years or more,294
+,,No value,10 or fewer
+,,Total,559
+,"MADISON, TN",Less than 65 Years,13
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,28
+,"RANDOLPH, NC",Less than 65 Years,240
+,,65 Years or more,335
+,,No value,10 or fewer
+,,Total,575
+,"LAFOURCHE, LA",Less than 65 Years,345
+,,65 Years or more,267
+,,No value,10 or fewer
+,,Total,612
+,"BARRY, MI",Less than 65 Years,173
+,,65 Years or more,368
+,,No value,10 or fewer
+,,Total,541
+,"CROW WING, MN",Less than 65 Years,130
+,,65 Years or more,383
+,,No value,10 or fewer
+,,Total,513
+,"CHENANGO, NY",Less than 65 Years,259
+,,65 Years or more,325
+,,No value,10 or fewer
+,,Total,584
+,"FRANKLIN, NC",Less than 65 Years,216
+,,65 Years or more,307
+,,No value,10 or fewer
+,,Total,524
+,"BUNCOMBE, NC",Less than 65 Years,149
+,,65 Years or more,340
+,,No value,10 or fewer
+,,Total,489
+,"MONTCALM, MI",Less than 65 Years,197
+,,65 Years or more,337
+,,No value,10 or fewer
+,,Total,534
+,"CORTLAND, NY",Less than 65 Years,126
+,,65 Years or more,333
+,,No value,10 or fewer
+,,Total,459
+,"PASQUOTANK, NC",Less than 65 Years,165
+,,65 Years or more,388
+,,No value,10 or fewer
+,,Total,553
+,"CASCADE, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,20
+,"HANCOCK, MS",Less than 65 Years,257
+,,65 Years or more,238
+,,No value,10 or fewer
+,,Total,495
+,"VERMILION, LA",Less than 65 Years,291
+,,65 Years or more,277
+,,No value,10 or fewer
+,,Total,568
+,"DARE, NC",Less than 65 Years,156
+,,65 Years or more,319
+,,No value,10 or fewer
+,,Total,475
+,"BERTIE, NC",Less than 65 Years,234
+,,65 Years or more,283
+,,No value,10 or fewer
+,,Total,517
+,"NEWAYGO, MI",Less than 65 Years,176
+,,65 Years or more,302
+,,No value,10 or fewer
+,,Total,478
+,"WRIGHT, MN",Less than 65 Years,201
+,,65 Years or more,313
+,,No value,10 or fewer
+,,Total,514
+,"LIVINGSTON, NY",Less than 65 Years,147
+,,65 Years or more,285
+,,No value,10 or fewer
+,,Total,432
+,"CHISAGO, MN",Less than 65 Years,191
+,,65 Years or more,304
+,,No value,10 or fewer
+,,Total,495
+,"BECKER, MN",Less than 65 Years,178
+,,65 Years or more,298
+,,No value,10 or fewer
+,,Total,476
+,"STOKES, NC",Less than 65 Years,125
+,,65 Years or more,360
+,,No value,10 or fewer
+,,Total,485
+,"DELTA, MI",Less than 65 Years,196
+,,65 Years or more,337
+,,No value,10 or fewer
+,,Total,533
+,"DORCHESTER, MD",Less than 65 Years,180
+,,65 Years or more,263
+,,No value,10 or fewer
+,,Total,443
+,"HAMPDEN, MA",Less than 65 Years,65
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,118
+,"BRONX, NY",Less than 65 Years,341
+,,65 Years or more,144
+,,No value,10 or fewer
+,,Total,485
+,"CHOWAN, NC",Less than 65 Years,160
+,,65 Years or more,293
+,,No value,10 or fewer
+,,Total,453
+,"POLK, MN",Less than 65 Years,185
+,,65 Years or more,267
+,,No value,10 or fewer
+,,Total,452
+,"PENDER, NC",Less than 65 Years,12
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,56
+,"PIKE, MS",Less than 65 Years,173
+,,65 Years or more,196
+,,No value,10 or fewer
+,,Total,369
+,"OTSEGO, NY",Less than 65 Years,146
+,,65 Years or more,288
+,,No value,10 or fewer
+,,Total,434
+,"ESSEX, NY",Less than 65 Years,123
+,,65 Years or more,270
+,,No value,10 or fewer
+,,Total,393
+,"TIOGA, NY",Less than 65 Years,161
+,,65 Years or more,284
+,,No value,10 or fewer
+,,Total,445
+,"WORCESTER, MD",Less than 65 Years,134
+,,65 Years or more,275
+,,No value,10 or fewer
+,,Total,409
+,"JESSAMINE, KY",Less than 65 Years,197
+,,65 Years or more,242
+,,No value,10 or fewer
+,,Total,439
+,"SAINT TAMMANY, LA",Less than 65 Years,300
+,,65 Years or more,323
+,,No value,10 or fewer
+,,Total,623
+,"UNION, MS",Less than 65 Years,162
+,,65 Years or more,244
+,,No value,10 or fewer
+,,Total,406
+,"HERTFORD, NC",Less than 65 Years,152
+,,65 Years or more,271
+,,No value,10 or fewer
+,,Total,423
+,"WATAUGA, NC",Less than 65 Years,65
+,,65 Years or more,99
+,,No value,10 or fewer
+,,Total,164
+,"TALBOT, MD",Less than 65 Years,104
+,,65 Years or more,316
+,,No value,10 or fewer
+,,Total,420
+,"MARTIN, NC",Less than 65 Years,127
+,,65 Years or more,182
+,,No value,10 or fewer
+,,Total,309
+,"GENESEE, NY",Less than 65 Years,123
+,,65 Years or more,253
+,,No value,10 or fewer
+,,Total,376
+,"KNOX, ME",Less than 65 Years,110
+,,65 Years or more,328
+,,No value,10 or fewer
+,,Total,438
+,"QUEEN ANNES, MD",Less than 65 Years,140
+,,65 Years or more,233
+,,No value,10 or fewer
+,,Total,373
+,"ALLEGANY, NY",Less than 65 Years,165
+,,65 Years or more,289
+,,No value,10 or fewer
+,,Total,454
+,"OBION, TN",Less than 65 Years,151
+,,65 Years or more,207
+,,No value,10 or fewer
+,,Total,358
+,"MASON, MI",Less than 65 Years,110
+,,65 Years or more,273
+,,No value,10 or fewer
+,,Total,383
+,"CAPE GIRARDEAU, MO",Less than 65 Years,131
+,,65 Years or more,237
+,,No value,10 or fewer
+,,Total,368
+,"SAINT LANDRY, LA",Less than 65 Years,188
+,,65 Years or more,221
+,,No value,10 or fewer
+,,Total,409
+,"CHEMUNG, NY",Less than 65 Years,108
+,,65 Years or more,233
+,,No value,10 or fewer
+,,Total,341
+,"SOMERSET, MD",Less than 65 Years,188
+,,65 Years or more,243
+,,No value,10 or fewer
+,,Total,431
+,"CALCASIEU, LA",Less than 65 Years,69
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,109
+,"NORTHAMPTON, NC",Less than 65 Years,99
+,,65 Years or more,235
+,,No value,10 or fewer
+,,Total,334
+,"BRANCH, MI",Less than 65 Years,153
+,,65 Years or more,259
+,,No value,10 or fewer
+,,Total,412
+,"ADAMS, NE",Less than 65 Years,128
+,,65 Years or more,226
+,,No value,10 or fewer
+,,Total,354
+,"MARION, MS",Less than 65 Years,138
+,,65 Years or more,210
+,,No value,10 or fewer
+,,Total,348
+,"KANDIYOHI, MN",Less than 65 Years,133
+,,65 Years or more,241
+,,No value,10 or fewer
+,,Total,375
+,"CARROLL, TN",Less than 65 Years,89
+,,65 Years or more,193
+,,No value,10 or fewer
+,,Total,282
+,"CLAY, KY",Less than 65 Years,188
+,,65 Years or more,139
+,,No value,10 or fewer
+,,Total,327
+,"OCEANA, MI",Less than 65 Years,159
+,,65 Years or more,219
+,,No value,10 or fewer
+,,Total,378
+,"MONROE, MS",Less than 65 Years,51
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,101
+,"NOBLES, MN",Less than 65 Years,164
+,,65 Years or more,194
+,,No value,10 or fewer
+,,Total,358
+,"YAZOO, MS",Less than 65 Years,182
+,,65 Years or more,182
+,,No value,10 or fewer
+,,Total,364
+,"WHITLEY, KY",Less than 65 Years,126
+,,65 Years or more,168
+,,No value,10 or fewer
+,,Total,294
+,"LAMAR, MS",Less than 65 Years,145
+,,65 Years or more,225
+,,No value,10 or fewer
+,,Total,370
+,"CHAUTAUQUA, NY",Less than 65 Years,139
+,,65 Years or more,232
+,,No value,10 or fewer
+,,Total,371
+,"SAINT CHARLES, LA",Less than 65 Years,162
+,,65 Years or more,195
+,,No value,10 or fewer
+,,Total,357
+,"FRANKLIN, NY",Less than 65 Years,133
+,,65 Years or more,186
+,,No value,10 or fewer
+,,Total,319
+,"CARROLL, NH",Less than 65 Years,135
+,,65 Years or more,211
+,,No value,10 or fewer
+,,Total,346
+,"LINCOLN, ME",Less than 65 Years,92
+,,65 Years or more,245
+,,No value,10 or fewer
+,,Total,337
+,"FREDERICK, MD",Less than 65 Years,113
+,,65 Years or more,208
+,,No value,10 or fewer
+,,Total,321
+,"CAROLINE, MD",Less than 65 Years,134
+,,65 Years or more,202
+,,No value,10 or fewer
+,,Total,336
+,"MECOSTA, MI",Less than 65 Years,111
+,,65 Years or more,246
+,,No value,10 or fewer
+,,Total,357
+,"FRANKLIN, ME",Less than 65 Years,134
+,,65 Years or more,302
+,,No value,10 or fewer
+,,Total,436
+,"DELAWARE, NY",Less than 65 Years,91
+,,65 Years or more,205
+,,No value,10 or fewer
+,,Total,296
+,"WEST BATON ROUGE, LA",Less than 65 Years,213
+,,65 Years or more,129
+,,No value,10 or fewer
+,,Total,342
+,"ATTALA, MS",Less than 65 Years,141
+,,65 Years or more,234
+,,No value,10 or fewer
+,,Total,375
+,"GRENADA, MS",Less than 65 Years,162
+,,65 Years or more,177
+,,No value,10 or fewer
+,,Total,339
+,"CABARRUS, NC",Less than 65 Years,179
+,,65 Years or more,150
+,,No value,10 or fewer
+,,Total,329
+,"CASS, MI",Less than 65 Years,112
+,,65 Years or more,213
+,,No value,10 or fewer
+,,Total,325
+,"WILSON, NC",Less than 65 Years,143
+,,65 Years or more,151
+,,No value,10 or fewer
+,,Total,294
+,"CURRITUCK, NC",Less than 65 Years,103
+,,65 Years or more,209
+,,No value,10 or fewer
+,,Total,312
+,"WASHINGTON, VT",Less than 65 Years,95
+,,65 Years or more,216
+,,No value,10 or fewer
+,,Total,311
+,"GARRETT, MD",Less than 65 Years,104
+,,65 Years or more,117
+,,No value,10 or fewer
+,,Total,221
+,"SCOTT, MN",Less than 65 Years,140
+,,65 Years or more,179
+,,No value,10 or fewer
+,,Total,319
+,"HALL, NE",Less than 65 Years,104
+,,65 Years or more,154
+,,No value,10 or fewer
+,,Total,258
+,"OXFORD, ME",Less than 65 Years,125
+,,65 Years or more,213
+,,No value,10 or fewer
+,,Total,338
+,"SAMPSON, NC",Less than 65 Years,114
+,,65 Years or more,171
+,,No value,10 or fewer
+,,Total,285
+,"GREENE, NC",Less than 65 Years,130
+,,65 Years or more,151
+,,No value,10 or fewer
+,,Total,281
+,"IREDELL, NC",Less than 65 Years,122
+,,65 Years or more,188
+,,No value,10 or fewer
+,,Total,310
+,"UNION, KY",Less than 65 Years,140
+,,65 Years or more,156
+,,No value,10 or fewer
+,,Total,296
+,"DAVIE, NC",Less than 65 Years,68
+,,65 Years or more,221
+,,No value,10 or fewer
+,,Total,289
+,"PRENTISS, MS",Less than 65 Years,114
+,,65 Years or more,129
+,,No value,10 or fewer
+,,Total,243
+,"KOOCHICHING, MN",Less than 65 Years,95
+,,65 Years or more,214
+,,No value,10 or fewer
+,,Total,309
+,"GIBSON, TN",Less than 65 Years,17
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,44
+,"COLUMBIA, NY",Less than 65 Years,28
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,87
+,"IBERIA, LA",Less than 65 Years,144
+,,65 Years or more,144
+,,No value,10 or fewer
+,,Total,288
+,"CHAVES, NM",Less than 65 Years,242
+,,65 Years or more,168
+,,No value,10 or fewer
+,,Total,410
+,"HOKE, NC",Less than 65 Years,150
+,,65 Years or more,132
+,,No value,10 or fewer
+,,Total,282
+,"BENTON, MN",Less than 65 Years,117
+,,65 Years or more,172
+,,No value,10 or fewer
+,,Total,289
+,"MADISON, NE",Less than 65 Years,123
+,,65 Years or more,217
+,,No value,10 or fewer
+,,Total,340
+,"MARSHALL, MS",Less than 65 Years,60
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,161
+,"LEWIS AND CLARK, MT",Less than 65 Years,55
+,,65 Years or more,134
+,,No value,10 or fewer
+,,Total,189
+,"JEFFERSON DAVIS, LA",Less than 65 Years,104
+,,65 Years or more,125
+,,No value,10 or fewer
+,,Total,229
+,"ONSLOW, NC",Less than 65 Years,80
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,157
+,"IONIA, MI",Less than 65 Years,102
+,,65 Years or more,161
+,,No value,10 or fewer
+,,Total,263
+,"BARNSTABLE, MA",Less than 65 Years,68
+,,65 Years or more,148
+,,No value,10 or fewer
+,,Total,216
+,"YADKIN, NC",Less than 65 Years,78
+,,65 Years or more,167
+,,No value,10 or fewer
+,,Total,245
+,"GRAFTON, NH",Less than 65 Years,105
+,,65 Years or more,174
+,,No value,10 or fewer
+,,Total,279
+,"CASS, MN",Less than 65 Years,77
+,,65 Years or more,187
+,,No value,10 or fewer
+,,Total,264
+,"FAYETTE, TN",Less than 65 Years,81
+,,65 Years or more,146
+,,No value,10 or fewer
+,,Total,227
+,"SCOTT, MS",Less than 65 Years,161
+,,65 Years or more,146
+,,No value,10 or fewer
+,,Total,307
+,"CAPE MAY, NJ",Less than 65 Years,23
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,76
+,"PONTOTOC, MS",Less than 65 Years,58
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,108
+,"BRADLEY, TN",Less than 65 Years,128
+,,65 Years or more,89
+,,No value,10 or fewer
+,,Total,217
+,"LAFAYETTE, MS",Less than 65 Years,114
+,,65 Years or more,155
+,,No value,10 or fewer
+,,Total,269
+,"SANDOVAL, NM",Less than 65 Years,104
+,,65 Years or more,170
+,,No value,10 or fewer
+,,Total,274
+,"HOLMES, MS",Less than 65 Years,134
+,,65 Years or more,136
+,,No value,10 or fewer
+,,Total,270
+,"LEAKE, MS",Less than 65 Years,123
+,,65 Years or more,183
+,,No value,10 or fewer
+,,Total,306
+,"KENTON, KY",Less than 65 Years,155
+,,65 Years or more,112
+,,No value,10 or fewer
+,,Total,267
+,"MILLE LACS, MN",Less than 65 Years,115
+,,65 Years or more,170
+,,No value,10 or fewer
+,,Total,285
+,"COLUMBUS, NC",Less than 65 Years,99
+,,65 Years or more,120
+,,No value,10 or fewer
+,,Total,219
+,"CLARKE, MS",Less than 65 Years,106
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,212
+,"HUNTERDON, NJ",Less than 65 Years,84
+,,65 Years or more,163
+,,No value,10 or fewer
+,,Total,247
+,"NEWTON, MS",Less than 65 Years,109
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,219
+,"HOWARD, MD",Less than 65 Years,107
+,,65 Years or more,131
+,,No value,10 or fewer
+,,Total,238
+,"PERQUIMANS, NC",Less than 65 Years,84
+,,65 Years or more,152
+,,No value,10 or fewer
+,,Total,236
+,"CASS, MO",Less than 65 Years,53
+,,65 Years or more,171
+,,No value,10 or fewer
+,,Total,224
+,"ADDISON, VT",Less than 65 Years,52
+,,65 Years or more,177
+,,No value,10 or fewer
+,,Total,229
+,"SEQUATCHIE, TN",Less than 65 Years,103
+,,65 Years or more,139
+,,No value,10 or fewer
+,,Total,242
+,"INGHAM, MI",Less than 65 Years,106
+,,65 Years or more,159
+,,No value,10 or fewer
+,,Total,265
+,"NODAWAY, MO",Less than 65 Years,72
+,,65 Years or more,150
+,,No value,10 or fewer
+,,Total,222
+,"EAST FELICIANA, LA",Less than 65 Years,65
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,134
+,"CLARK, KY",Less than 65 Years,142
+,,65 Years or more,118
+,,No value,10 or fewer
+,,Total,260
+,"WALDO, ME",Less than 65 Years,59
+,,65 Years or more,159
+,,No value,10 or fewer
+,,Total,218
+,"UNICOI, TN",Less than 65 Years,80
+,,65 Years or more,147
+,,No value,10 or fewer
+,,Total,227
+,"GAGE, NE",Less than 65 Years,99
+,,65 Years or more,133
+,,No value,10 or fewer
+,,Total,232
+,"COTTONWOOD, MN",Less than 65 Years,77
+,,65 Years or more,154
+,,No value,10 or fewer
+,,Total,231
+,"ORLEANS, NY",Less than 65 Years,72
+,,65 Years or more,131
+,,No value,10 or fewer
+,,Total,203
+,"LINCOLN, NC",Less than 65 Years,64
+,,65 Years or more,166
+,,No value,10 or fewer
+,,Total,230
+,"CASS, NE",Less than 65 Years,86
+,,65 Years or more,137
+,,No value,10 or fewer
+,,Total,223
+,"KENT, MD",Less than 65 Years,40
+,,65 Years or more,115
+,,No value,10 or fewer
+,,Total,155
+,"ESTILL, KY",Less than 65 Years,105
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,199
+,"BLEDSOE, TN",Less than 65 Years,103
+,,65 Years or more,116
+,,No value,10 or fewer
+,,Total,219
+,"MARSHALL, KY",Less than 65 Years,83
+,,65 Years or more,133
+,,No value,10 or fewer
+,,Total,216
+,"SCHENECTADY, NY",Less than 65 Years,80
+,,65 Years or more,100
+,,No value,10 or fewer
+,,Total,180
+,"MORRIS, NJ",Less than 65 Years,50
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,131
+,"GRUNDY, MO",Less than 65 Years,79
+,,65 Years or more,125
+,,No value,10 or fewer
+,,Total,204
+,"PENNINGTON, MN",Less than 65 Years,49
+,,65 Years or more,140
+,,No value,10 or fewer
+,,Total,189
+,"SCOTT, KY",Less than 65 Years,81
+,,65 Years or more,119
+,,No value,10 or fewer
+,,Total,200
+,"ATLANTIC, NJ",Less than 65 Years,108
+,,65 Years or more,116
+,,No value,10 or fewer
+,,Total,224
+,"BOURBON, KY",Less than 65 Years,148
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,254
+,"GRAVES, KY",Less than 65 Years,89
+,,65 Years or more,119
+,,No value,10 or fewer
+,,Total,208
+,"CAMPBELL, KY",Less than 65 Years,89
+,,65 Years or more,108
+,,No value,10 or fewer
+,,Total,197
+,"SHELBY, KY",Less than 65 Years,133
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,221
+,"HILLSDALE, MI",Less than 65 Years,69
+,,65 Years or more,114
+,,No value,10 or fewer
+,,Total,183
+,"WINDSOR, VT",Less than 65 Years,86
+,,65 Years or more,118
+,,No value,10 or fewer
+,,Total,204
+,"WARREN, NY",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,30
+,"SAGADAHOC, ME",Less than 65 Years,34
+,,65 Years or more,118
+,,No value,10 or fewer
+,,Total,152
+,"CLAY, MS",Less than 65 Years,20
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,57
+,"WALTHALL, MS",Less than 65 Years,81
+,,65 Years or more,113
+,,No value,10 or fewer
+,,Total,194
+,"GREENE, NY",Less than 65 Years,15
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,59
+,"PLAQUEMINES, LA",Less than 65 Years,98
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,199
+,"LEE, NC",Less than 65 Years,85
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,173
+,"AVERY, NC",Less than 65 Years,26
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,83
+,"REDWOOD, MN",Less than 65 Years,86
+,,65 Years or more,137
+,,No value,10 or fewer
+,,Total,223
+,"ASSUMPTION, LA",Less than 65 Years,96
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,190
+,"DYER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"BOONE, KY",Less than 65 Years,102
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,184
+,"SCHOHARIE, NY",Less than 65 Years,51
+,,65 Years or more,114
+,,No value,10 or fewer
+,,Total,165
+,"MENOMINEE, MI",Less than 65 Years,72
+,,65 Years or more,124
+,,No value,10 or fewer
+,,Total,196
+,"SAINT CLAIR, MI",Less than 65 Years,48
+,,65 Years or more,126
+,,No value,10 or fewer
+,,Total,174
+,"WEAKLEY, TN",Less than 65 Years,17
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,62
+,"LAWRENCE, MS",Less than 65 Years,58
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,153
+,"RICHMOND, NY",Less than 65 Years,98
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,152
+,"PASSAIC, NJ",Less than 65 Years,58
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,135
+,"FLOYD, KY",Less than 65 Years,83
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,163
+,"HOPKINS, KY",Less than 65 Years,161
+,,65 Years or more,255
+,,No value,10 or fewer
+,,Total,416
+,"CASWELL, NC",Less than 65 Years,69
+,,65 Years or more,119
+,,No value,10 or fewer
+,,Total,188
+,"ROCK, MN",Less than 65 Years,65
+,,65 Years or more,117
+,,No value,10 or fewer
+,,Total,182
+,"GASTON, NC",Less than 65 Years,100
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,194
+,"JOHNSON, TN",Less than 65 Years,51
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,153
+,"HOUSTON, MN",Less than 65 Years,51
+,,65 Years or more,122
+,,No value,10 or fewer
+,,Total,173
+,"PINE, MN",Less than 65 Years,67
+,,65 Years or more,127
+,,No value,10 or fewer
+,,Total,194
+,"GATES, NC",Less than 65 Years,71
+,,65 Years or more,115
+,,No value,10 or fewer
+,,Total,186
+,"PULASKI, MO",Less than 65 Years,76
+,,65 Years or more,90
+,,No value,10 or fewer
+,,Total,166
+,"ANDREW, MO",Less than 65 Years,51
+,,65 Years or more,108
+,,No value,10 or fewer
+,,Total,159
+,"HENRY, KY",Less than 65 Years,84
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,153
+,"ITAWAMBA, MS",Less than 65 Years,14
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,29
+,"CARROLL, MD",Less than 65 Years,52
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,154
+,"POLK, NC",Less than 65 Years,19
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,110
+,"ALLEGANY, MD",Less than 65 Years,65
+,,65 Years or more,104
+,,No value,10 or fewer
+,,Total,169
+,"BUFFALO, NE",Less than 65 Years,18
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,38
+,"CRAVEN, NC",Less than 65 Years,72
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,173
+,"JACKSON, MN",Less than 65 Years,76
+,,65 Years or more,114
+,,No value,10 or fewer
+,,Total,190
+,"LAUREL, KY",Less than 65 Years,64
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,156
+,"SULLIVAN, NH",Less than 65 Years,58
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,146
+,"ROSEAU, MN",Less than 65 Years,54
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,138
+,"LIVINGSTON, MO",Less than 65 Years,52
+,,65 Years or more,104
+,,No value,10 or fewer
+,,Total,156
+,"WASHINGTON, NC",Less than 65 Years,57
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,168
+,"JONES, MS",Less than 65 Years,66
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,161
+,"CLEARWATER, MN",Less than 65 Years,77
+,,65 Years or more,108
+,,No value,10 or fewer
+,,Total,185
+,"CATAWBA, NC",Less than 65 Years,74
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,162
+,"NESHOBA, MS",Less than 65 Years,71
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,163
+,"ROCKINGHAM, NH",Less than 65 Years,58
+,,65 Years or more,87
+,,No value,10 or fewer
+,,Total,145
+,"PERRY, MS",Less than 65 Years,74
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,152
+,"FRANKLIN, KY",Less than 65 Years,88
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,149
+,"OSCEOLA, MI",Less than 65 Years,71
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,149
+,"CECIL, MD",Less than 65 Years,80
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,158
+,"TISHOMINGO, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TODD, MN",Less than 65 Years,49
+,,65 Years or more,108
+,,No value,10 or fewer
+,,Total,157
+,"CARLTON, MN",Less than 65 Years,63
+,,65 Years or more,100
+,,No value,10 or fewer
+,,Total,163
+,"CALHOUN, MS",Less than 65 Years,49
+,,65 Years or more,89
+,,No value,10 or fewer
+,,Total,138
+,"SAINT BERNARD, LA",Less than 65 Years,77
+,,65 Years or more,89
+,,No value,10 or fewer
+,,Total,166
+,"YELLOWSTONE, MT",Less than 65 Years,115
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,161
+,"TERREBONNE, LA",Less than 65 Years,102
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,156
+,"FARIBAULT, MN",Less than 65 Years,34
+,,65 Years or more,86
+,,No value,10 or fewer
+,,Total,120
+,"TOMPKINS, NY",Less than 65 Years,52
+,,65 Years or more,93
+,,No value,10 or fewer
+,,Total,145
+,"VALENCIA, NM",Less than 65 Years,64
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,159
+,"LARUE, KY",Less than 65 Years,58
+,,65 Years or more,90
+,,No value,10 or fewer
+,,Total,148
+,"MEADE, KY",Less than 65 Years,66
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,132
+,"PANOLA, MS",Less than 65 Years,36
+,,65 Years or more,86
+,,No value,10 or fewer
+,,Total,122
+,"LYON, NV",Less than 65 Years,63
+,,65 Years or more,89
+,,No value,10 or fewer
+,,Total,152
+,"MCDOWELL, NC",Less than 65 Years,46
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,121
+,"SALINE, NE",Less than 65 Years,43
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,125
+,"WASHINGTON, NY",Less than 65 Years,16
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,39
+,"NELSON, KY",Less than 65 Years,76
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,150
+,"SPENCER, KY",Less than 65 Years,95
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,169
+,"KNOX, KY",Less than 65 Years,66
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,141
+,"WEBSTER, MS",Less than 65 Years,15
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,27
+,"HARDEMAN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,19
+,"SAINT LOUIS, MO",Less than 65 Years,50
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,123
+,"OSWEGO, NY",Less than 65 Years,38
+,,65 Years or more,90
+,,No value,10 or fewer
+,,Total,128
+,"MURRAY, MN",Less than 65 Years,38
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,132
+,"MARION, TN",Less than 65 Years,43
+,,65 Years or more,72
+,,No value,10 or fewer
+,,Total,115
+,"STANLY, NC",Less than 65 Years,62
+,,65 Years or more,65
+,,No value,10 or fewer
+,,Total,127
+,"COPIAH, MS",Less than 65 Years,70
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,146
+,"TATE, MS",Less than 65 Years,48
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,100
+,"WOODFORD, KY",Less than 65 Years,55
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,129
+,"MERRIMACK, NH",Less than 65 Years,42
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,124
+,"ROCKLAND, NY",Less than 65 Years,49
+,,65 Years or more,68
+,,No value,10 or fewer
+,,Total,117
+,"POINTE COUPEE, LA",Less than 65 Years,46
+,,65 Years or more,72
+,,No value,10 or fewer
+,,Total,118
+,"RUTHERFORD, NC",Less than 65 Years,34
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,112
+,"MERRICK, NE",Less than 65 Years,38
+,,65 Years or more,93
+,,No value,10 or fewer
+,,Total,131
+,"KEMPER, MS",Less than 65 Years,54
+,,65 Years or more,65
+,,No value,10 or fewer
+,,Total,119
+,"WEBSTER, KY",Less than 65 Years,73
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,168
+,"SURRY, NC",Less than 65 Years,51
+,,65 Years or more,83
+,,No value,10 or fewer
+,,Total,134
+,"ULSTER, NY",Less than 65 Years,54
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,115
+,"MOREHOUSE, LA",Less than 65 Years,46
+,,65 Years or more,87
+,,No value,10 or fewer
+,,Total,133
+,"DAKOTA, NE",Less than 65 Years,59
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,121
+,"YALOBUSHA, MS",Less than 65 Years,51
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,125
+,"CAMDEN, NC",Less than 65 Years,40
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,114
+,"COVINGTON, MS",Less than 65 Years,43
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,106
+,"SCOTT, MO",Less than 65 Years,52
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,132
+,"AITKIN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,42
+,"CARVER, MN",Less than 65 Years,55
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,133
+,"SCOTTS BLUFF, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CHICKASAW, MS",Less than 65 Years,14
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,33
+,"BENTON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LAKE, MI",Less than 65 Years,52
+,,65 Years or more,65
+,,No value,10 or fewer
+,,Total,117
+,"CARTERET, NC",Less than 65 Years,41
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,116
+,"RICHLAND, MT",Less than 65 Years,37
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,103
+,"BALLARD, KY",Less than 65 Years,54
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,120
+,"SAINT JAMES, LA",Less than 65 Years,54
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,109
+,"DAVIDSON, TN",Less than 65 Years,69
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,106
+,"SIMPSON, MS",Less than 65 Years,54
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,99
+,"ANDERSON, KY",Less than 65 Years,53
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,104
+,"GARRARD, KY",Less than 65 Years,53
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,101
+,"ISANTI, MN",Less than 65 Years,60
+,,65 Years or more,68
+,,No value,10 or fewer
+,,Total,128
+,"KENNEBEC, ME",Less than 65 Years,42
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,99
+,"ASHE, NC",Less than 65 Years,15
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,39
+,"TIPPAH, MS",Less than 65 Years,42
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,86
+,"LIVINGSTON, KY",Less than 65 Years,34
+,,65 Years or more,64
+,,No value,10 or fewer
+,,Total,98
+,"MADISON, NY",Less than 65 Years,26
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,102
+,"EATON, MI",Less than 65 Years,47
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,105
+,"MARSHALL, MN",Less than 65 Years,26
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,88
+,"AMITE, MS",Less than 65 Years,26
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,63
+,"ORANGE, VT",Less than 65 Years,46
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,97
+,"CAYUGA, NY",Less than 65 Years,28
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,97
+,"LINCOLN, MS",Less than 65 Years,35
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,71
+,"LAPEER, MI",Less than 65 Years,23
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,74
+,"BENTON, MS",Less than 65 Years,42
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,89
+,"OKTIBBEHA, MS",Less than 65 Years,23
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,52
+,"KNOX, TN",Less than 65 Years,44
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,77
+,"MORRISON, MN",Less than 65 Years,20
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,71
+,"GRANVILLE, NC",Less than 65 Years,50
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,81
+,"LAUDERDALE, TN",Less than 65 Years,41
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,63
+,"NORMAN, MN",Less than 65 Years,27
+,,65 Years or more,68
+,,No value,10 or fewer
+,,Total,95
+,"GEORGE, MS",Less than 65 Years,53
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,93
+,"HANCOCK, TN",Less than 65 Years,51
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,98
+,"STONE, MS",Less than 65 Years,34
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,66
+,"RICHLAND, LA",Less than 65 Years,34
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,77
+,"WARREN, MS",Less than 65 Years,45
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,79
+,"FRANKLIN, VT",Less than 65 Years,29
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,74
+,"MOORE, NC",Less than 65 Years,39
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,75
+,"GRANT, MN",Less than 65 Years,26
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,84
+,"CLINTON, MO",Less than 65 Years,17
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,73
+,"MAHNOMEN, MN",Less than 65 Years,41
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,77
+,"CHESTER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYON, KY",Less than 65 Years,27
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,81
+,"PULASKI, KY",Less than 65 Years,48
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,87
+,"ALCORN, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,35
+,"JEFFERSON DAVIS, MS",Less than 65 Years,27
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,68
+,"CUMBERLAND, NJ",Less than 65 Years,41
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,72
+,"TRANSYLVANIA, NC",Less than 65 Years,15
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,74
+,"HUBBARD, MN",Less than 65 Years,30
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,76
+,"UNION, LA",Less than 65 Years,26
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,64
+,"FULTON, NY",Less than 65 Years,16
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,46
+,"TUNICA, MS",Less than 65 Years,49
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,69
+,"LYON, MN",Less than 65 Years,12
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,65
+,"TYRRELL, NC",Less than 65 Years,22
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,66
+,"SAINT MARYS, MD",Less than 65 Years,32
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,73
+,"MONTGOMERY, NY",Less than 65 Years,25
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,71
+,"NOXUBEE, MS",Less than 65 Years,31
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,55
+,"CARROLL, MS",Less than 65 Years,27
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,55
+,"CHEYENNE, NE",Less than 65 Years,21
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,58
+,"CROCKETT, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUTCHESS, NY",Less than 65 Years,39
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,72
+,"SALEM, NJ",Less than 65 Years,49
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,70
+,"SILVER BOW, MT",Less than 65 Years,41
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,67
+,"JACKSON, KY",Less than 65 Years,31
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,55
+,"SUSSEX, NJ",Less than 65 Years,36
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,61
+,"CLEVELAND, NC",Less than 65 Years,40
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,72
+,"WABASHA, MN",Less than 65 Years,18
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,62
+,"WEST FELICIANA, LA",Less than 65 Years,22
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,54
+,"BRECKINRIDGE, KY",Less than 65 Years,41
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,69
+,"KITTSON, MN",Less than 65 Years,11
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,49
+,"PERSON, NC",Less than 65 Years,23
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,66
+,"YELLOW MEDICINE, MN",Less than 65 Years,13
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,53
+,"RHEA, TN",Less than 65 Years,27
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,53
+,"SAINT HELENA, LA",Less than 65 Years,30
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,68
+,"GENTRY, MO",Less than 65 Years,23
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,55
+,"CARSON CITY, NV",Less than 65 Years,46
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,63
+,"LETCHER, KY",Less than 65 Years,30
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,56
+,"MEEKER, MN",Less than 65 Years,21
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,57
+,"CRAWFORD, MO",Less than 65 Years,23
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,52
+,"BOYLE, KY",Less than 65 Years,29
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,73
+,"VANCE, NC",Less than 65 Years,30
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,61
+,"HANCOCK, ME",Less than 65 Years,17
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,63
+,"WILKES, NC",Less than 65 Years,25
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,54
+,"WINONA, MN",Less than 65 Years,22
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,64
+,"STODDARD, MO",Less than 65 Years,19
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,63
+,"SENECA, NY",Less than 65 Years,27
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,62
+,"CALVERT, MD",Less than 65 Years,23
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,53
+,"CARLISLE, KY",Less than 65 Years,19
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,58
+,"EVANGELINE, LA",Less than 65 Years,32
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,71
+,"DOUGLAS, MN",Less than 65 Years,27
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,57
+,"LINCOLN, LA",Less than 65 Years,21
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,40
+,"SANTA FE, NM",Less than 65 Years,22
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,66
+,"WARREN, NC",Less than 65 Years,16
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,58
+,"DAVIESS, KY",Less than 65 Years,35
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,64
+,"WYOMING, NY",Less than 65 Years,18
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,53
+,"TRIMBLE, KY",Less than 65 Years,21
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,50
+,"CATTARAUGUS, NY",Less than 65 Years,26
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,60
+,"DEKALB, MO",Less than 65 Years,18
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,44
+,"BERKSHIRE, MA",Less than 65 Years,20
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,53
+,"LAKE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,25
+,"MERCER, KY",Less than 65 Years,17
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,53
+,"CADDO, LA",Less than 65 Years,29
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,41
+,"WADENA, MN",Less than 65 Years,14
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,45
+,"CHURCHILL, NV",Less than 65 Years,27
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,55
+,"FULTON, KY",Less than 65 Years,16
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,42
+,"LEE, KY",Less than 65 Years,23
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,51
+,"GRAYSON, KY",Less than 65 Years,23
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,52
+,"HAMPSHIRE, MA",Less than 65 Years,14
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,37
+,"MCCREARY, KY",Less than 65 Years,21
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,52
+,"DOUGLAS, NV",Less than 65 Years,13
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,52
+,"MARIES, MO",Less than 65 Years,21
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,48
+,"RAPIDES, LA",Less than 65 Years,26
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,57
+,"SWIFT, MN",Less than 65 Years,11
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,39
+,"BOLLINGER, MO",Less than 65 Years,27
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,52
+,"HUMPHREYS, MS",Less than 65 Years,27
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,50
+,"CALDWELL, KY",Less than 65 Years,15
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,52
+,"DENT, MO",Less than 65 Years,16
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,40
+,"HYDE, NC",Less than 65 Years,13
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,41
+,"POWELL, KY",Less than 65 Years,27
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,52
+,"GRUNDY, TN",Less than 65 Years,23
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,42
+,"BATH, KY",Less than 65 Years,23
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,50
+,"RENVILLE, MN",Less than 65 Years,24
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,54
+,"POLK, TN",Less than 65 Years,15
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,31
+,"RUTLAND, VT",Less than 65 Years,18
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,41
+,"CHEROKEE, NC",Less than 65 Years,11
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,38
+,"FILLMORE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,41
+,"JASPER, MS",Less than 65 Years,19
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,34
+,"SAINT CHARLES, MO",Less than 65 Years,17
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,44
+,"JOHNSON, MO",Less than 65 Years,19
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,50
+,"SCHUYLER, NY",Less than 65 Years,20
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,44
+,"DUNKLIN, MO",Less than 65 Years,11
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,35
+,"WINDHAM, VT",Less than 65 Years,16
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,44
+,"SMITH, MS",Less than 65 Years,16
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,37
+,"GRAND ISLE, VT",Less than 65 Years,11
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,40
+,"HOLT, MO",Less than 65 Years,15
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,42
+,"MONTGOMERY, KY",Less than 65 Years,16
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,36
+,"RICE, MN",Less than 65 Years,18
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,38
+,"HENDERSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, MS",Less than 65 Years,15
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,32
+,"ELKO, NV",Less than 65 Years,20
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,48
+,"WEST CARROLL, LA",Less than 65 Years,12
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,40
+,"GREENE, MS",Less than 65 Years,19
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,45
+,"YATES, NY",Less than 65 Years,14
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,38
+,"SAGINAW, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,47
+,"WILKIN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,38
+,"DODGE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,42
+,"NYE, NV",Less than 65 Years,15
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,37
+,"OLMSTED, MN",Less than 65 Years,25
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,49
+,"WILLIAMSON, TN",Less than 65 Years,24
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,46
+,"CALLOWAY, KY",Less than 65 Years,19
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,36
+,"RED LAKE, MN",Less than 65 Years,15
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,45
+,"BEAUREGARD, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"STRAFFORD, NH",Less than 65 Years,18
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,44
+,"ADAMS, MS",Less than 65 Years,19
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,46
+,"FRANKLIN, LA",Less than 65 Years,15
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,36
+,"GREENE, MO",Less than 65 Years,20
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,33
+,"RUTHERFORD, TN",Less than 65 Years,17
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,36
+,"SHIAWASSEE, MI",Less than 65 Years,24
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,43
+,"HAMILTON, NE",Less than 65 Years,15
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,36
+,"HAYWOOD, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"LAFAYETTE, MO",Less than 65 Years,15
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,37
+,"LAMOILLE, VT",Less than 65 Years,14
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,37
+,"SAUNDERS, NE",Less than 65 Years,14
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,32
+,"TETON, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, NY",Less than 65 Years,15
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,30
+,"LINCOLN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,30
+,"MADISON, NC",Less than 65 Years,14
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,33
+,"HARLAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,32
+,"HENRY, TN",Less than 65 Years,11
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,25
+,"CARROLL, KY",Less than 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,34
+,"CLAY, NE",Less than 65 Years,18
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,39
+,"GRAND TRAVERSE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,37
+,"SEWARD, NE",Less than 65 Years,15
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,36
+,"TRAVERSE, MN",Less than 65 Years,11
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,40
+,"JOHNSON, KY",Less than 65 Years,12
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,29
+,"MONTGOMERY, TN",Less than 65 Years,15
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,34
+,"MERCER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,28
+,"ROCKCASTLE, KY",Less than 65 Years,14
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,34
+,"LEFLORE, MS",Less than 65 Years,18
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,32
+,"SOMERSET, ME",Less than 65 Years,14
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,31
+,"CUMBERLAND, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,32
+,"MCNAIRY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOYD, KY",Less than 65 Years,16
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,36
+,"SCOTLAND, NC",Less than 65 Years,20
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,37
+,"WASHINGTON, MS",Less than 65 Years,12
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,29
+,"WINSTON, MS",Less than 65 Years,16
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,34
+,"HARRISON, KY",Less than 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"CASEY, KY",Less than 65 Years,17
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,35
+,"CRITTENDEN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,32
+,"FLEMING, KY",Less than 65 Years,14
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,38
+,"HAYWOOD, NC",Less than 65 Years,14
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,35
+,"MCMINN, TN",Less than 65 Years,12
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,29
+,"PARK, MT",Less than 65 Years,15
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,37
+,"SUMNER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,28
+,"WASHINGTON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,31
+,"BREATHITT, KY",Less than 65 Years,12
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,30
+,"AVOYELLES, LA",Less than 65 Years,23
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,45
+,"JEFFERSON, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,27
+,"MARTIN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,27
+,"KANABEC, MN",Less than 65 Years,13
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,31
+,"TEXAS, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,33
+,"DAVIESS, MO",Less than 65 Years,13
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,31
+,"HAMBLEN, TN",Less than 65 Years,16
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,36
+,"JONES, NC",Less than 65 Years,11
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,39
+,"MAGOFFIN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,22
+,"PIERCE, NE",Less than 65 Years,14
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,30
+,"HART, KY",Less than 65 Years,22
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"CHOCTAW, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CLINTON, MI",Less than 65 Years,13
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,37
+,"WAYNE, MS",Less than 65 Years,19
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,37
+,"PIPESTONE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,28
+,"ALLEN, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"CHOUTEAU, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ISABELLA, MI",Less than 65 Years,17
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,38
+,"CUSTER, MT",Less than 65 Years,20
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,34
+,"PEMISCOT, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"WILKINSON, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CONCORDIA, LA",Less than 65 Years,14
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,30
+,"TALLAHATCHIE, MS",Less than 65 Years,18
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,36
+,"CALDWELL, LA",Less than 65 Years,12
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,29
+,"GRANT, KY",Less than 65 Years,14
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,26
+,"TUSCOLA, MI",Less than 65 Years,14
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,25
+,"BOONE, MO",Less than 65 Years,15
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,26
+,"DIXON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,29
+,"DONA ANA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"MACON, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,23
+,"BELL, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,24
+,"MANISTEE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,28
+,"MASON, KY",Less than 65 Years,12
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,30
+,"VERNON, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,21
+,"CAMPBELL, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,20
+,"FRANKLIN, MA",Less than 65 Years,11
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,26
+,"JACKSON, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,23
+,"BAY, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,21
+,"BOLIVAR, MS",Less than 65 Years,16
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,28
+,"BOSSIER, LA",Less than 65 Years,18
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,36
+,"MCLEOD, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,24
+,"WARREN, KY",Less than 65 Years,13
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,28
+,"CHRISTIAN, KY",Less than 65 Years,29
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,46
+,"GREENUP, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,24
+,"MISSOULA, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"WEBSTER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,23
+,"CALDWELL, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,23
+,"KNOTT, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"TAYLOR, KY",Less than 65 Years,15
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,34
+,"BLOUNT, TN",Less than 65 Years,12
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,28
+,"BLUE EARTH, MN",Less than 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"SEVIER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,21
+,"BIG STONE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,26
+,"MEIGS, TN",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"SAINT LOUIS CITY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"ADAIR, KY",Less than 65 Years,13
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,27
+,"BELKNAP, NH",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"DAWSON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"PERRY, KY",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"COAHOMA, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,20
+,"DECATUR, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,15
+,"SANILAC, MI",Less than 65 Years,12
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,29
+,"CALEDONIA, VT",Less than 65 Years,11
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,23
+,"COOS, NH",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,21
+,"RICHMOND, NC",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"TORRANCE, NM",Less than 65 Years,13
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,29
+,"CARTER, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"LESLIE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MUHLENBERG, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,34
+,"SUNFLOWER, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"COCKE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"MITCHELL, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SAINT FRANCOIS, MO",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"CLINTON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,22
+,"WILSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"ANSON, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"BENNINGTON, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"BROWN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"GREEN, KY",Less than 65 Years,11
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,23
+,"OTOE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,23
+,"PENDLETON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"PUTNAM, NY",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"CLAIBORNE, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"FLATHEAD, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"MAURY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"PLATTE, NE",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"VAN BUREN, TN",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"WAYNE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HICKMAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,25
+,"KEITH, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"MARQUETTE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"NEW MADRID, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,22
+,"RAY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CEDAR, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,20
+,"JASPER, MO",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"JEFFERSON, NE",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"MARION, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"FRANKLIN, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"LINN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,20
+,"MIDLAND, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,21
+,"NANCE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,20
+,"ALEXANDER, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"BATES, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CLAY, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"GOODHUE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,22
+,"JACKSON, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"QUITMAN, MS",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"LEWIS, NY",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,19
+,"PAMLICO, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"ANDERSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"AROOSTOOK, ME",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,17
+,"CHIPPEWA, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,21
+,"PUTNAM, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"STANTON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,19
+,"MADISON, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"RUSSELL, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"HENRY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,24
+,"MISSISSIPPI, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"CLARE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,19
+,"LE SUEUR, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MADISON, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"ROWAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"MARTIN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"HURON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,20
+,"ORLEANS, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"ROSCOMMON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,22
+,"IOSCO, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"OWEN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"OWSLEY, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"WORTH, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"BRACKEN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"GRAINGER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LOUDON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MCKINLEY, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"YANCEY, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WAYNE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,21
+,"BUTLER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"EMMET, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,14
+,"SAN JUAN, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CAMDEN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CIBOLA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"WEXFORD, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"ANTELOPE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CHEBOYGAN, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"FRONTIER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"GASCONADE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"GLACIER, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE OF THE WOODS, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MONROE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"ROBERTSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"WASHINGTON, ME",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BARREN, KY",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CURRY, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MONTGOMERY, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"NICHOLAS, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CARROLL, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CHIPPEWA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"DICKINSON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"HARRISON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"NATCHITOCHES, LA",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"PISCATAQUIS, ME",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"SIBLEY, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDDY, NM",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"FRANKLIN, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRIGG, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"YORK, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CHRISTIAN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"TANEY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CHARLEVOIX, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,14
+,"FRANKLIN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMBOLDT, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCLEAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"MENIFEE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SHARKEY, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BENTON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMING, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"QUAY, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEGHANY, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOK, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"GRATIOT, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"MONTMORENCY, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NICOLLET, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THURSTON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUKES, MA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREEBORN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HILL, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"OTERO, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POPE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALPENA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANTRIM, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLIOTT, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAC QUI PARLE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OHIO, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALLATIN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA SALLE, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGEMAW, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STONE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOLFE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIG HORN, MT",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CATAHOULA, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOOKER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOX BUTTE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROADWATER, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLFAX, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLFAX, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEUEL, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAST CARROLL, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRESQUE ISLE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIO ARRIBA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TENSAS, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLADWIN, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LACLEDE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHELPS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RAVALLI, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RED WILLOW, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLIVAN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARENAC, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENZIE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOLT, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMPHREYS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KALKASKA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NANTUCKET, MA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NUCKOLLS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PETTIS, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PONDERA, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROOSEVELT, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STOREY, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALGER, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAIBORNE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDMONSON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"JOHNSON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEELANAU, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MISSAUKEE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRILL, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THOMAS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VERNON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOS ALAMOS, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOWER, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTSEGO, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEELE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWAIN, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAOS, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALCONA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FERGUS, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDONALD, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIPLEY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SABINE, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CLAIR, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOCORRO, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WATONWAN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATCHISON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARRY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMERON, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARBON, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEER LODGE, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUGHTON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINERAL, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN MIGUEL, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOPER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWSON, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FILLMORE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FURNAS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANDER, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTSON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINTE GENEVIEVE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERMAN, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STILLWATER, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAIR, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVERHEAD, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIENVILLE, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHASE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEMAHA, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSCODA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERSHING, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE PINE, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURT, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHERRY, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, NY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEARNEY, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAWNEE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROSEBUD, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEATHAM, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALLAS, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWES, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FENTRESS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HICKORY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERKINS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHOOLCRAFT, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIMPSON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOOLE, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINN, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAHAM, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREELEY, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWELL, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUDITH BASIN, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUCE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSAGE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OVERTON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROOSEVELT, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASECA, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOYD, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARTER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUNA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACKINAC, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"METCALFE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OREGON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHARDSON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUDRAIN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARTON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAIBORNE, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEAGHER, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHILLIPS, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 65 Years,4862
+,,65 Years or more,7272
+,,No value,10 or fewer
+,,Total,12134
+,Total,Less than 65 Years,171838
+,,65 Years or more,263809
+,,No value,10 or fewer
+,,Total,435650
+Jan 1 – Dec 31 2024,"WAYNE, MI",Less than 65 Years,6086
+,,65 Years or more,8863
+,,No value,10 or fewer
+,,Total,14949
+,"WAKE, NC",Less than 65 Years,4511
+,,65 Years or more,7560
+,,No value,10 or fewer
+,,Total,12071
+,"MIDDLESEX, MA",Less than 65 Years,3372
+,,65 Years or more,7614
+,,No value,10 or fewer
+,,Total,10986
+,"MONROE, NY",Less than 65 Years,2435
+,,65 Years or more,5641
+,,No value,10 or fewer
+,,Total,8076
+,"JEFFERSON, KY",Less than 65 Years,3488
+,,65 Years or more,3838
+,,No value,10 or fewer
+,,Total,7326
+,"KENT, MI",Less than 65 Years,2654
+,,65 Years or more,4607
+,,No value,10 or fewer
+,,Total,7261
+,"KINGS, NY",Less than 65 Years,3597
+,,65 Years or more,3215
+,,No value,10 or fewer
+,,Total,6812
+,"HENNEPIN, MN",Less than 65 Years,2516
+,,65 Years or more,4135
+,,No value,10 or fewer
+,,Total,6651
+,"SUFFOLK, NY",Less than 65 Years,2260
+,,65 Years or more,4201
+,,No value,10 or fewer
+,,Total,6461
+,"OAKLAND, MI",Less than 65 Years,1635
+,,65 Years or more,4805
+,,No value,10 or fewer
+,,Total,6440
+,"WORCESTER, MA",Less than 65 Years,2433
+,,65 Years or more,3999
+,,No value,10 or fewer
+,,Total,6432
+,"GUILFORD, NC",Less than 65 Years,2094
+,,65 Years or more,3924
+,,No value,10 or fewer
+,,Total,6018
+,"MECKLENBURG, NC",Less than 65 Years,2319
+,,65 Years or more,3665
+,,No value,10 or fewer
+,,Total,5984
+,"MACOMB, MI",Less than 65 Years,1706
+,,65 Years or more,4116
+,,No value,10 or fewer
+,,Total,5822
+,"NASSAU, NY",Less than 65 Years,1714
+,,65 Years or more,3851
+,,No value,10 or fewer
+,,Total,5565
+,"CAMDEN, NJ",Less than 65 Years,2305
+,,65 Years or more,3233
+,,No value,10 or fewer
+,,Total,5538
+,"ERIE, NY",Less than 65 Years,1918
+,,65 Years or more,3251
+,,No value,10 or fewer
+,,Total,5169
+,"SHELBY, TN",Less than 65 Years,1910
+,,65 Years or more,2498
+,,No value,10 or fewer
+,,Total,4408
+,"EAST BATON ROUGE, LA",Less than 65 Years,2422
+,,65 Years or more,2565
+,,No value,10 or fewer
+,,Total,4987
+,"CLARK, NV",Less than 65 Years,2278
+,,65 Years or more,2398
+,,No value,10 or fewer
+,,Total,4676
+,"QUEENS, NY",Less than 65 Years,2267
+,,65 Years or more,2185
+,,No value,10 or fewer
+,,Total,4452
+,"FORSYTH, NC",Less than 65 Years,1354
+,,65 Years or more,2993
+,,No value,10 or fewer
+,,Total,4347
+,"JEFFERSON, LA",Less than 65 Years,1939
+,,65 Years or more,2369
+,,No value,10 or fewer
+,,Total,4308
+,"OCEAN, NJ",Less than 65 Years,1344
+,,65 Years or more,3630
+,,No value,10 or fewer
+,,Total,4974
+,"ESSEX, NJ",Less than 65 Years,2699
+,,65 Years or more,2716
+,,No value,10 or fewer
+,,Total,5415
+,"ESSEX, MA",Less than 65 Years,1031
+,,65 Years or more,2974
+,,No value,10 or fewer
+,,Total,4005
+,"SUFFOLK, MA",Less than 65 Years,2257
+,,65 Years or more,1898
+,,No value,10 or fewer
+,,Total,4155
+,"BRISTOL, MA",Less than 65 Years,1503
+,,65 Years or more,2630
+,,No value,10 or fewer
+,,Total,4133
+,"LAFAYETTE, LA",Less than 65 Years,1951
+,,65 Years or more,1939
+,,No value,10 or fewer
+,,Total,3890
+,"CUMBERLAND, NC",Less than 65 Years,1651
+,,65 Years or more,2106
+,,No value,10 or fewer
+,,Total,3757
+,"BURLINGTON, NJ",Less than 65 Years,1268
+,,65 Years or more,2532
+,,No value,10 or fewer
+,,Total,3800
+,"JACKSON, MI",Less than 65 Years,1369
+,,65 Years or more,2161
+,,No value,10 or fewer
+,,Total,3530
+,"MIDDLESEX, NJ",Less than 65 Years,1329
+,,65 Years or more,2113
+,,No value,10 or fewer
+,,Total,3442
+,"JACKSON, MO",Less than 65 Years,1202
+,,65 Years or more,2158
+,,No value,10 or fewer
+,,Total,3360
+,"WASHOE, NV",Less than 65 Years,1252
+,,65 Years or more,2017
+,,No value,10 or fewer
+,,Total,3269
+,"ALBANY, NY",Less than 65 Years,1211
+,,65 Years or more,2312
+,,No value,10 or fewer
+,,Total,3523
+,"FAYETTE, KY",Less than 65 Years,1559
+,,65 Years or more,1744
+,,No value,10 or fewer
+,,Total,3303
+,"WASHTENAW, MI",Less than 65 Years,911
+,,65 Years or more,2338
+,,No value,10 or fewer
+,,Total,3249
+,"JOHNSTON, NC",Less than 65 Years,1245
+,,65 Years or more,1872
+,,No value,10 or fewer
+,,Total,3117
+,"KALAMAZOO, MI",Less than 65 Years,1064
+,,65 Years or more,1871
+,,No value,10 or fewer
+,,Total,2935
+,"LANCASTER, NE",Less than 65 Years,1045
+,,65 Years or more,1748
+,,No value,10 or fewer
+,,Total,2793
+,"SULLIVAN, TN",Less than 65 Years,1033
+,,65 Years or more,1795
+,,No value,10 or fewer
+,,Total,2828
+,"WASHINGTON, MD",Less than 65 Years,1022
+,,65 Years or more,2020
+,,No value,10 or fewer
+,,Total,3042
+,"MUSKEGON, MI",Less than 65 Years,941
+,,65 Years or more,1820
+,,No value,10 or fewer
+,,Total,2761
+,"HINDS, MS",Less than 65 Years,1346
+,,65 Years or more,1345
+,,No value,10 or fewer
+,,Total,2691
+,"PITT, NC",Less than 65 Years,1094
+,,65 Years or more,1579
+,,No value,10 or fewer
+,,Total,2673
+,"ALAMANCE, NC",Less than 65 Years,978
+,,65 Years or more,1735
+,,No value,10 or fewer
+,,Total,2713
+,"HAMILTON, TN",Less than 65 Years,1086
+,,65 Years or more,1419
+,,No value,10 or fewer
+,,Total,2505
+,"ORLEANS, LA",Less than 65 Years,1222
+,,65 Years or more,1327
+,,No value,10 or fewer
+,,Total,2549
+,"WAYNE, NC",Less than 65 Years,1003
+,,65 Years or more,1394
+,,No value,10 or fewer
+,,Total,2397
+,"JACKSON, MS",Less than 65 Years,988
+,,65 Years or more,1475
+,,No value,10 or fewer
+,,Total,2463
+,"LIVINGSTON, LA",Less than 65 Years,1259
+,,65 Years or more,1236
+,,No value,10 or fewer
+,,Total,2495
+,"BROOME, NY",Less than 65 Years,934
+,,65 Years or more,1414
+,,No value,10 or fewer
+,,Total,2348
+,"DAKOTA, MN",Less than 65 Years,844
+,,65 Years or more,1601
+,,No value,10 or fewer
+,,Total,2445
+,"LIVINGSTON, MI",Less than 65 Years,535
+,,65 Years or more,1673
+,,No value,10 or fewer
+,,Total,2208
+,"BERRIEN, MI",Less than 65 Years,810
+,,65 Years or more,1456
+,,No value,10 or fewer
+,,Total,2266
+,"PRINCE GEORGES, MD",Less than 65 Years,1117
+,,65 Years or more,1262
+,,No value,10 or fewer
+,,Total,2379
+,"HUDSON, NJ",Less than 65 Years,1596
+,,65 Years or more,985
+,,No value,10 or fewer
+,,Total,2581
+,"BALTIMORE, MD",Less than 65 Years,770
+,,65 Years or more,1425
+,,No value,10 or fewer
+,,Total,2195
+,"BRUNSWICK, NC",Less than 65 Years,646
+,,65 Years or more,1681
+,,No value,10 or fewer
+,,Total,2327
+,"TANGIPAHOA, LA",Less than 65 Years,1048
+,,65 Years or more,1098
+,,No value,10 or fewer
+,,Total,2146
+,"ANNE ARUNDEL, MD",Less than 65 Years,878
+,,65 Years or more,1266
+,,No value,10 or fewer
+,,Total,2144
+,"ORANGE, NY",Less than 65 Years,819
+,,65 Years or more,1241
+,,No value,10 or fewer
+,,Total,2060
+,"RAMSEY, MN",Less than 65 Years,699
+,,65 Years or more,1368
+,,No value,10 or fewer
+,,Total,2067
+,"MONTGOMERY, MD",Less than 65 Years,850
+,,65 Years or more,1272
+,,No value,10 or fewer
+,,Total,2122
+,"ROBESON, NC",Less than 65 Years,888
+,,65 Years or more,1174
+,,No value,10 or fewer
+,,Total,2062
+,"SOMERSET, NJ",Less than 65 Years,681
+,,65 Years or more,1442
+,,No value,10 or fewer
+,,Total,2123
+,"SAINT LOUIS, MN",Less than 65 Years,737
+,,65 Years or more,1275
+,,No value,10 or fewer
+,,Total,2012
+,"ONEIDA, NY",Less than 65 Years,629
+,,65 Years or more,1195
+,,No value,10 or fewer
+,,Total,1824
+,"BALTIMORE CITY, MD",Less than 65 Years,1242
+,,65 Years or more,771
+,,No value,10 or fewer
+,,Total,2013
+,"OUACHITA, LA",Less than 65 Years,739
+,,65 Years or more,1287
+,,No value,10 or fewer
+,,Total,2026
+,"CALHOUN, MI",Less than 65 Years,657
+,,65 Years or more,1157
+,,No value,10 or fewer
+,,Total,1814
+,"DOUGLAS, NE",Less than 65 Years,973
+,,65 Years or more,873
+,,No value,10 or fewer
+,,Total,1846
+,"NASH, NC",Less than 65 Years,651
+,,65 Years or more,1241
+,,No value,10 or fewer
+,,Total,1892
+,"CHITTENDEN, VT",Less than 65 Years,567
+,,65 Years or more,1303
+,,No value,10 or fewer
+,,Total,1870
+,"RENSSELAER, NY",Less than 65 Years,729
+,,65 Years or more,1135
+,,No value,10 or fewer
+,,Total,1864
+,"WICOMICO, MD",Less than 65 Years,705
+,,65 Years or more,1021
+,,No value,10 or fewer
+,,Total,1726
+,"MONROE, MI",Less than 65 Years,626
+,,65 Years or more,1080
+,,No value,10 or fewer
+,,Total,1706
+,"BERNALILLO, NM",Less than 65 Years,647
+,,65 Years or more,1089
+,,No value,10 or fewer
+,,Total,1736
+,"NEW HANOVER, NC",Less than 65 Years,717
+,,65 Years or more,1635
+,,No value,10 or fewer
+,,Total,2352
+,"HENDERSON, NC",Less than 65 Years,427
+,,65 Years or more,1395
+,,No value,10 or fewer
+,,Total,1822
+,"UNION, NJ",Less than 65 Years,877
+,,65 Years or more,806
+,,No value,10 or fewer
+,,Total,1683
+,"HARNETT, NC",Less than 65 Years,676
+,,65 Years or more,987
+,,No value,10 or fewer
+,,Total,1663
+,"GLOUCESTER, NJ",Less than 65 Years,531
+,,65 Years or more,1171
+,,No value,10 or fewer
+,,Total,1702
+,"ROCKINGHAM, NC",Less than 65 Years,602
+,,65 Years or more,1072
+,,No value,10 or fewer
+,,Total,1674
+,"PLYMOUTH, MA",Less than 65 Years,475
+,,65 Years or more,968
+,,No value,10 or fewer
+,,Total,1443
+,"LENOIR, NC",Less than 65 Years,661
+,,65 Years or more,926
+,,No value,10 or fewer
+,,Total,1587
+,"DESOTO, MS",Less than 65 Years,580
+,,65 Years or more,890
+,,No value,10 or fewer
+,,Total,1470
+,"CUMBERLAND, ME",Less than 65 Years,449
+,,65 Years or more,1117
+,,No value,10 or fewer
+,,Total,1566
+,"ORANGE, NC",Less than 65 Years,505
+,,65 Years or more,1046
+,,No value,10 or fewer
+,,Total,1551
+,"OTTAWA, MI",Less than 65 Years,419
+,,65 Years or more,1170
+,,No value,10 or fewer
+,,Total,1589
+,"HARFORD, MD",Less than 65 Years,462
+,,65 Years or more,1012
+,,No value,10 or fewer
+,,Total,1474
+,"ROWAN, NC",Less than 65 Years,594
+,,65 Years or more,874
+,,No value,10 or fewer
+,,Total,1468
+,"HARRISON, MS",Less than 65 Years,727
+,,65 Years or more,872
+,,No value,10 or fewer
+,,Total,1599
+,"NEW YORK, NY",Less than 65 Years,588
+,,65 Years or more,939
+,,No value,10 or fewer
+,,Total,1527
+,"WASHINGTON, TN",Less than 65 Years,511
+,,65 Years or more,958
+,,No value,10 or fewer
+,,Total,1469
+,"ONONDAGA, NY",Less than 65 Years,520
+,,65 Years or more,967
+,,No value,10 or fewer
+,,Total,1487
+,"MERCER, NJ",Less than 65 Years,531
+,,65 Years or more,962
+,,No value,10 or fewer
+,,Total,1493
+,"NORFOLK, MA",Less than 65 Years,518
+,,65 Years or more,750
+,,No value,10 or fewer
+,,Total,1268
+,"RANKIN, MS",Less than 65 Years,545
+,,65 Years or more,900
+,,No value,10 or fewer
+,,Total,1445
+,"YORK, ME",Less than 65 Years,423
+,,65 Years or more,981
+,,No value,10 or fewer
+,,Total,1404
+,"BURKE, NC",Less than 65 Years,480
+,,65 Years or more,855
+,,No value,10 or fewer
+,,Total,1335
+,"MCCRACKEN, KY",Less than 65 Years,538
+,,65 Years or more,782
+,,No value,10 or fewer
+,,Total,1320
+,"BUCHANAN, MO",Less than 65 Years,558
+,,65 Years or more,877
+,,No value,10 or fewer
+,,Total,1435
+,"HARDIN, KY",Less than 65 Years,570
+,,65 Years or more,652
+,,No value,10 or fewer
+,,Total,1222
+,"DAVIDSON, NC",Less than 65 Years,531
+,,65 Years or more,755
+,,No value,10 or fewer
+,,Total,1286
+,"GENESEE, MI",Less than 65 Years,709
+,,65 Years or more,651
+,,No value,10 or fewer
+,,Total,1360
+,"VAN BUREN, MI",Less than 65 Years,482
+,,65 Years or more,802
+,,No value,10 or fewer
+,,Total,1284
+,"LOWNDES, MS",Less than 65 Years,608
+,,65 Years or more,689
+,,No value,10 or fewer
+,,Total,1297
+,"EDGECOMBE, NC",Less than 65 Years,523
+,,65 Years or more,777
+,,No value,10 or fewer
+,,Total,1300
+,"WASHINGTON, MN",Less than 65 Years,377
+,,65 Years or more,879
+,,No value,10 or fewer
+,,Total,1256
+,"WARREN, NJ",Less than 65 Years,475
+,,65 Years or more,747
+,,No value,10 or fewer
+,,Total,1222
+,"SARPY, NE",Less than 65 Years,498
+,,65 Years or more,755
+,,No value,10 or fewer
+,,Total,1253
+,"ASCENSION, LA",Less than 65 Years,616
+,,65 Years or more,607
+,,No value,10 or fewer
+,,Total,1223
+,"BERGEN, NJ",Less than 65 Years,435
+,,65 Years or more,831
+,,No value,10 or fewer
+,,Total,1266
+,"STEARNS, MN",Less than 65 Years,395
+,,65 Years or more,732
+,,No value,10 or fewer
+,,Total,1127
+,"LENAWEE, MI",Less than 65 Years,285
+,,65 Years or more,758
+,,No value,10 or fewer
+,,Total,1043
+,"HALIFAX, NC",Less than 65 Years,394
+,,65 Years or more,708
+,,No value,10 or fewer
+,,Total,1103
+,"MADISON, KY",Less than 65 Years,502
+,,65 Years or more,653
+,,No value,10 or fewer
+,,Total,1155
+,"MONMOUTH, NJ",Less than 65 Years,499
+,,65 Years or more,750
+,,No value,10 or fewer
+,,Total,1249
+,"SULLIVAN, NY",Less than 65 Years,502
+,,65 Years or more,525
+,,No value,10 or fewer
+,,Total,1027
+,"GALLATIN, MT",Less than 65 Years,450
+,,65 Years or more,606
+,,No value,10 or fewer
+,,Total,1056
+,"MADISON, MS",Less than 65 Years,339
+,,65 Years or more,774
+,,No value,10 or fewer
+,,Total,1113
+,"DUPLIN, NC",Less than 65 Years,518
+,,65 Years or more,578
+,,No value,10 or fewer
+,,Total,1096
+,"NIAGARA, NY",Less than 65 Years,365
+,,65 Years or more,754
+,,No value,10 or fewer
+,,Total,1119
+,"PIKE, KY",Less than 65 Years,501
+,,65 Years or more,536
+,,No value,10 or fewer
+,,Total,1037
+,"ACADIA, LA",Less than 65 Years,563
+,,65 Years or more,494
+,,No value,10 or fewer
+,,Total,1057
+,"CALDWELL, NC",Less than 65 Years,380
+,,65 Years or more,622
+,,No value,10 or fewer
+,,Total,1002
+,"BEAUFORT, NC",Less than 65 Years,338
+,,65 Years or more,699
+,,No value,10 or fewer
+,,Total,1037
+,"FORREST, MS",Less than 65 Years,422
+,,65 Years or more,668
+,,No value,10 or fewer
+,,Total,1090
+,"HAWKINS, TN",Less than 65 Years,369
+,,65 Years or more,623
+,,No value,10 or fewer
+,,Total,992
+,"CLINTON, NY",Less than 65 Years,324
+,,65 Years or more,666
+,,No value,10 or fewer
+,,Total,990
+,"CHATHAM, NC",Less than 65 Years,242
+,,65 Years or more,751
+,,No value,10 or fewer
+,,Total,993
+,"GREENE, TN",Less than 65 Years,370
+,,65 Years or more,575
+,,No value,10 or fewer
+,,Total,945
+,"LAUDERDALE, MS",Less than 65 Years,497
+,,65 Years or more,509
+,,No value,10 or fewer
+,,Total,1006
+,"DURHAM, NC",Less than 65 Years,451
+,,65 Years or more,492
+,,No value,10 or fewer
+,,Total,943
+,"ONTARIO, NY",Less than 65 Years,250
+,,65 Years or more,669
+,,No value,10 or fewer
+,,Total,919
+,"PEARL RIVER, MS",Less than 65 Years,348
+,,65 Years or more,496
+,,No value,10 or fewer
+,,Total,844
+,"STEUBEN, NY",Less than 65 Years,370
+,,65 Years or more,526
+,,No value,10 or fewer
+,,Total,896
+,"HILLSBOROUGH, NH",Less than 65 Years,239
+,,65 Years or more,629
+,,No value,10 or fewer
+,,Total,868
+,"ANOKA, MN",Less than 65 Years,337
+,,65 Years or more,481
+,,No value,10 or fewer
+,,Total,818
+,"OTTER TAIL, MN",Less than 65 Years,257
+,,65 Years or more,626
+,,No value,10 or fewer
+,,Total,883
+,"SARATOGA, NY",Less than 65 Years,210
+,,65 Years or more,485
+,,No value,10 or fewer
+,,Total,695
+,"WAYNE, NY",Less than 65 Years,291
+,,65 Years or more,617
+,,No value,10 or fewer
+,,Total,908
+,"CHARLES, MD",Less than 65 Years,377
+,,65 Years or more,500
+,,No value,10 or fewer
+,,Total,877
+,"SAINT MARTIN, LA",Less than 65 Years,409
+,,65 Years or more,336
+,,No value,10 or fewer
+,,Total,745
+,"UNION, NC",Less than 65 Years,302
+,,65 Years or more,519
+,,No value,10 or fewer
+,,Total,821
+,"ITASCA, MN",Less than 65 Years,284
+,,65 Years or more,495
+,,No value,10 or fewer
+,,Total,779
+,"PLATTE, MO",Less than 65 Years,275
+,,65 Years or more,516
+,,No value,10 or fewer
+,,Total,791
+,"PENOBSCOT, ME",Less than 65 Years,211
+,,65 Years or more,497
+,,No value,10 or fewer
+,,Total,708
+,"ST JOHN THE BAPTIST, LA",Less than 65 Years,386
+,,65 Years or more,406
+,,No value,10 or fewer
+,,Total,792
+,"BELTRAMI, MN",Less than 65 Years,287
+,,65 Years or more,456
+,,No value,10 or fewer
+,,Total,743
+,"LEE, MS",Less than 65 Years,433
+,,65 Years or more,483
+,,No value,10 or fewer
+,,Total,916
+,"ALLEGAN, MI",Less than 65 Years,240
+,,65 Years or more,482
+,,No value,10 or fewer
+,,Total,722
+,"LINCOLN, NE",Less than 65 Years,290
+,,65 Years or more,373
+,,No value,10 or fewer
+,,Total,663
+,"CLAY, MO",Less than 65 Years,336
+,,65 Years or more,402
+,,No value,10 or fewer
+,,Total,738
+,"WESTCHESTER, NY",Less than 65 Years,266
+,,65 Years or more,416
+,,No value,10 or fewer
+,,Total,682
+,"TIPTON, TN",Less than 65 Years,344
+,,65 Years or more,387
+,,No value,10 or fewer
+,,Total,731
+,"HENDERSON, KY",Less than 65 Years,266
+,,65 Years or more,393
+,,No value,10 or fewer
+,,Total,659
+,"ANDROSCOGGIN, ME",Less than 65 Years,304
+,,65 Years or more,409
+,,No value,10 or fewer
+,,Total,713
+,"SHERBURNE, MN",Less than 65 Years,292
+,,65 Years or more,379
+,,No value,10 or fewer
+,,Total,671
+,"BULLITT, KY",Less than 65 Years,329
+,,65 Years or more,315
+,,No value,10 or fewer
+,,Total,644
+,"PHELPS, MO",Less than 65 Years,246
+,,65 Years or more,437
+,,No value,10 or fewer
+,,Total,683
+,"CARTER, TN",Less than 65 Years,268
+,,65 Years or more,423
+,,No value,10 or fewer
+,,Total,691
+,"WASHINGTON, LA",Less than 65 Years,353
+,,65 Years or more,317
+,,No value,10 or fewer
+,,Total,670
+,"CHESHIRE, NH",Less than 65 Years,172
+,,65 Years or more,478
+,,No value,10 or fewer
+,,Total,650
+,"SAINT LAWRENCE, NY",Less than 65 Years,235
+,,65 Years or more,375
+,,No value,10 or fewer
+,,Total,610
+,"SAINT MARY, LA",Less than 65 Years,340
+,,65 Years or more,314
+,,No value,10 or fewer
+,,Total,654
+,"OLDHAM, KY",Less than 65 Years,294
+,,65 Years or more,295
+,,No value,10 or fewer
+,,Total,589
+,"HERKIMER, NY",Less than 65 Years,218
+,,65 Years or more,382
+,,No value,10 or fewer
+,,Total,600
+,"IBERVILLE, LA",Less than 65 Years,310
+,,65 Years or more,301
+,,No value,10 or fewer
+,,Total,611
+,"BLADEN, NC",Less than 65 Years,224
+,,65 Years or more,404
+,,No value,10 or fewer
+,,Total,628
+,"CLAY, MN",Less than 65 Years,276
+,,65 Years or more,370
+,,No value,10 or fewer
+,,Total,646
+,"MADISON, TN",Less than 65 Years,214
+,,65 Years or more,258
+,,No value,10 or fewer
+,,Total,472
+,"RANDOLPH, NC",Less than 65 Years,252
+,,65 Years or more,357
+,,No value,10 or fewer
+,,Total,609
+,"LAFOURCHE, LA",Less than 65 Years,287
+,,65 Years or more,270
+,,No value,10 or fewer
+,,Total,557
+,"BARRY, MI",Less than 65 Years,184
+,,65 Years or more,417
+,,No value,10 or fewer
+,,Total,601
+,"CROW WING, MN",Less than 65 Years,156
+,,65 Years or more,450
+,,No value,10 or fewer
+,,Total,606
+,"CHENANGO, NY",Less than 65 Years,249
+,,65 Years or more,338
+,,No value,10 or fewer
+,,Total,587
+,"FRANKLIN, NC",Less than 65 Years,231
+,,65 Years or more,362
+,,No value,10 or fewer
+,,Total,593
+,"BUNCOMBE, NC",Less than 65 Years,176
+,,65 Years or more,487
+,,No value,10 or fewer
+,,Total,663
+,"MONTCALM, MI",Less than 65 Years,226
+,,65 Years or more,379
+,,No value,10 or fewer
+,,Total,605
+,"CORTLAND, NY",Less than 65 Years,233
+,,65 Years or more,385
+,,No value,10 or fewer
+,,Total,618
+,"PASQUOTANK, NC",Less than 65 Years,199
+,,65 Years or more,383
+,,No value,10 or fewer
+,,Total,582
+,"CASCADE, MT",Less than 65 Years,285
+,,65 Years or more,468
+,,No value,10 or fewer
+,,Total,753
+,"HANCOCK, MS",Less than 65 Years,306
+,,65 Years or more,269
+,,No value,10 or fewer
+,,Total,575
+,"VERMILION, LA",Less than 65 Years,241
+,,65 Years or more,251
+,,No value,10 or fewer
+,,Total,492
+,"DARE, NC",Less than 65 Years,164
+,,65 Years or more,415
+,,No value,10 or fewer
+,,Total,579
+,"BERTIE, NC",Less than 65 Years,229
+,,65 Years or more,332
+,,No value,10 or fewer
+,,Total,561
+,"NEWAYGO, MI",Less than 65 Years,199
+,,65 Years or more,352
+,,No value,10 or fewer
+,,Total,551
+,"WRIGHT, MN",Less than 65 Years,191
+,,65 Years or more,352
+,,No value,10 or fewer
+,,Total,543
+,"LIVINGSTON, NY",Less than 65 Years,168
+,,65 Years or more,368
+,,No value,10 or fewer
+,,Total,536
+,"CHISAGO, MN",Less than 65 Years,184
+,,65 Years or more,326
+,,No value,10 or fewer
+,,Total,510
+,"BECKER, MN",Less than 65 Years,181
+,,65 Years or more,321
+,,No value,10 or fewer
+,,Total,502
+,"STOKES, NC",Less than 65 Years,139
+,,65 Years or more,398
+,,No value,10 or fewer
+,,Total,537
+,"DELTA, MI",Less than 65 Years,189
+,,65 Years or more,305
+,,No value,10 or fewer
+,,Total,494
+,"DORCHESTER, MD",Less than 65 Years,196
+,,65 Years or more,309
+,,No value,10 or fewer
+,,Total,505
+,"HAMPDEN, MA",Less than 65 Years,136
+,,65 Years or more,238
+,,No value,10 or fewer
+,,Total,374
+,"BRONX, NY",Less than 65 Years,346
+,,65 Years or more,170
+,,No value,10 or fewer
+,,Total,516
+,"CHOWAN, NC",Less than 65 Years,176
+,,65 Years or more,329
+,,No value,10 or fewer
+,,Total,505
+,"POLK, MN",Less than 65 Years,169
+,,65 Years or more,312
+,,No value,10 or fewer
+,,Total,481
+,"PENDER, NC",Less than 65 Years,236
+,,65 Years or more,408
+,,No value,10 or fewer
+,,Total,644
+,"PIKE, MS",Less than 65 Years,240
+,,65 Years or more,271
+,,No value,10 or fewer
+,,Total,511
+,"OTSEGO, NY",Less than 65 Years,136
+,,65 Years or more,335
+,,No value,10 or fewer
+,,Total,471
+,"ESSEX, NY",Less than 65 Years,147
+,,65 Years or more,345
+,,No value,10 or fewer
+,,Total,492
+,"TIOGA, NY",Less than 65 Years,159
+,,65 Years or more,288
+,,No value,10 or fewer
+,,Total,447
+,"WORCESTER, MD",Less than 65 Years,149
+,,65 Years or more,344
+,,No value,10 or fewer
+,,Total,493
+,"JESSAMINE, KY",Less than 65 Years,196
+,,65 Years or more,274
+,,No value,10 or fewer
+,,Total,470
+,"SAINT TAMMANY, LA",Less than 65 Years,171
+,,65 Years or more,186
+,,No value,10 or fewer
+,,Total,357
+,"UNION, MS",Less than 65 Years,221
+,,65 Years or more,235
+,,No value,10 or fewer
+,,Total,456
+,"HERTFORD, NC",Less than 65 Years,179
+,,65 Years or more,277
+,,No value,10 or fewer
+,,Total,456
+,"WATAUGA, NC",Less than 65 Years,229
+,,65 Years or more,405
+,,No value,10 or fewer
+,,Total,634
+,"TALBOT, MD",Less than 65 Years,101
+,,65 Years or more,332
+,,No value,10 or fewer
+,,Total,433
+,"MARTIN, NC",Less than 65 Years,199
+,,65 Years or more,320
+,,No value,10 or fewer
+,,Total,519
+,"GENESEE, NY",Less than 65 Years,144
+,,65 Years or more,313
+,,No value,10 or fewer
+,,Total,457
+,"KNOX, ME",Less than 65 Years,99
+,,65 Years or more,351
+,,No value,10 or fewer
+,,Total,450
+,"QUEEN ANNES, MD",Less than 65 Years,145
+,,65 Years or more,303
+,,No value,10 or fewer
+,,Total,448
+,"ALLEGANY, NY",Less than 65 Years,156
+,,65 Years or more,271
+,,No value,10 or fewer
+,,Total,427
+,"OBION, TN",Less than 65 Years,131
+,,65 Years or more,258
+,,No value,10 or fewer
+,,Total,389
+,"MASON, MI",Less than 65 Years,122
+,,65 Years or more,323
+,,No value,10 or fewer
+,,Total,445
+,"CAPE GIRARDEAU, MO",Less than 65 Years,138
+,,65 Years or more,294
+,,No value,10 or fewer
+,,Total,432
+,"SAINT LANDRY, LA",Less than 65 Years,208
+,,65 Years or more,214
+,,No value,10 or fewer
+,,Total,422
+,"CHEMUNG, NY",Less than 65 Years,142
+,,65 Years or more,289
+,,No value,10 or fewer
+,,Total,431
+,"SOMERSET, MD",Less than 65 Years,166
+,,65 Years or more,209
+,,No value,10 or fewer
+,,Total,375
+,"CALCASIEU, LA",Less than 65 Years,163
+,,65 Years or more,171
+,,No value,10 or fewer
+,,Total,334
+,"NORTHAMPTON, NC",Less than 65 Years,139
+,,65 Years or more,302
+,,No value,10 or fewer
+,,Total,441
+,"BRANCH, MI",Less than 65 Years,147
+,,65 Years or more,224
+,,No value,10 or fewer
+,,Total,371
+,"ADAMS, NE",Less than 65 Years,158
+,,65 Years or more,259
+,,No value,10 or fewer
+,,Total,417
+,"MARION, MS",Less than 65 Years,154
+,,65 Years or more,282
+,,No value,10 or fewer
+,,Total,436
+,"KANDIYOHI, MN",Less than 65 Years,141
+,,65 Years or more,264
+,,No value,10 or fewer
+,,Total,405
+,"CARROLL, TN",Less than 65 Years,133
+,,65 Years or more,231
+,,No value,10 or fewer
+,,Total,364
+,"CLAY, KY",Less than 65 Years,254
+,,65 Years or more,161
+,,No value,10 or fewer
+,,Total,415
+,"OCEANA, MI",Less than 65 Years,138
+,,65 Years or more,241
+,,No value,10 or fewer
+,,Total,379
+,"MONROE, MS",Less than 65 Years,218
+,,65 Years or more,309
+,,No value,10 or fewer
+,,Total,527
+,"NOBLES, MN",Less than 65 Years,155
+,,65 Years or more,246
+,,No value,10 or fewer
+,,Total,401
+,"YAZOO, MS",Less than 65 Years,209
+,,65 Years or more,184
+,,No value,10 or fewer
+,,Total,393
+,"WHITLEY, KY",Less than 65 Years,172
+,,65 Years or more,258
+,,No value,10 or fewer
+,,Total,430
+,"LAMAR, MS",Less than 65 Years,123
+,,65 Years or more,251
+,,No value,10 or fewer
+,,Total,374
+,"CHAUTAUQUA, NY",Less than 65 Years,151
+,,65 Years or more,212
+,,No value,10 or fewer
+,,Total,363
+,"SAINT CHARLES, LA",Less than 65 Years,158
+,,65 Years or more,229
+,,No value,10 or fewer
+,,Total,387
+,"FRANKLIN, NY",Less than 65 Years,187
+,,65 Years or more,267
+,,No value,10 or fewer
+,,Total,454
+,"CARROLL, NH",Less than 65 Years,129
+,,65 Years or more,250
+,,No value,10 or fewer
+,,Total,379
+,"LINCOLN, ME",Less than 65 Years,105
+,,65 Years or more,283
+,,No value,10 or fewer
+,,Total,388
+,"FREDERICK, MD",Less than 65 Years,172
+,,65 Years or more,222
+,,No value,10 or fewer
+,,Total,394
+,"CAROLINE, MD",Less than 65 Years,143
+,,65 Years or more,225
+,,No value,10 or fewer
+,,Total,368
+,"MECOSTA, MI",Less than 65 Years,116
+,,65 Years or more,267
+,,No value,10 or fewer
+,,Total,383
+,"FRANKLIN, ME",Less than 65 Years,86
+,,65 Years or more,207
+,,No value,10 or fewer
+,,Total,293
+,"DELAWARE, NY",Less than 65 Years,121
+,,65 Years or more,260
+,,No value,10 or fewer
+,,Total,381
+,"WEST BATON ROUGE, LA",Less than 65 Years,193
+,,65 Years or more,179
+,,No value,10 or fewer
+,,Total,372
+,"ATTALA, MS",Less than 65 Years,124
+,,65 Years or more,184
+,,No value,10 or fewer
+,,Total,308
+,"GRENADA, MS",Less than 65 Years,156
+,,65 Years or more,225
+,,No value,10 or fewer
+,,Total,381
+,"CABARRUS, NC",Less than 65 Years,178
+,,65 Years or more,189
+,,No value,10 or fewer
+,,Total,367
+,"CASS, MI",Less than 65 Years,138
+,,65 Years or more,213
+,,No value,10 or fewer
+,,Total,351
+,"WILSON, NC",Less than 65 Years,168
+,,65 Years or more,215
+,,No value,10 or fewer
+,,Total,383
+,"CURRITUCK, NC",Less than 65 Years,115
+,,65 Years or more,263
+,,No value,10 or fewer
+,,Total,378
+,"WASHINGTON, VT",Less than 65 Years,91
+,,65 Years or more,255
+,,No value,10 or fewer
+,,Total,346
+,"GARRETT, MD",Less than 65 Years,172
+,,65 Years or more,263
+,,No value,10 or fewer
+,,Total,435
+,"SCOTT, MN",Less than 65 Years,142
+,,65 Years or more,218
+,,No value,10 or fewer
+,,Total,360
+,"HALL, NE",Less than 65 Years,157
+,,65 Years or more,228
+,,No value,10 or fewer
+,,Total,385
+,"OXFORD, ME",Less than 65 Years,128
+,,65 Years or more,196
+,,No value,10 or fewer
+,,Total,324
+,"SAMPSON, NC",Less than 65 Years,137
+,,65 Years or more,211
+,,No value,10 or fewer
+,,Total,348
+,"GREENE, NC",Less than 65 Years,158
+,,65 Years or more,199
+,,No value,10 or fewer
+,,Total,357
+,"IREDELL, NC",Less than 65 Years,118
+,,65 Years or more,226
+,,No value,10 or fewer
+,,Total,344
+,"UNION, KY",Less than 65 Years,147
+,,65 Years or more,169
+,,No value,10 or fewer
+,,Total,316
+,"DAVIE, NC",Less than 65 Years,73
+,,65 Years or more,256
+,,No value,10 or fewer
+,,Total,329
+,"PRENTISS, MS",Less than 65 Years,193
+,,65 Years or more,215
+,,No value,10 or fewer
+,,Total,408
+,"KOOCHICHING, MN",Less than 65 Years,91
+,,65 Years or more,199
+,,No value,10 or fewer
+,,Total,290
+,"GIBSON, TN",Less than 65 Years,85
+,,65 Years or more,141
+,,No value,10 or fewer
+,,Total,226
+,"COLUMBIA, NY",Less than 65 Years,86
+,,65 Years or more,181
+,,No value,10 or fewer
+,,Total,267
+,"IBERIA, LA",Less than 65 Years,161
+,,65 Years or more,158
+,,No value,10 or fewer
+,,Total,319
+,"CHAVES, NM",Less than 65 Years,176
+,,65 Years or more,115
+,,No value,10 or fewer
+,,Total,291
+,"HOKE, NC",Less than 65 Years,174
+,,65 Years or more,130
+,,No value,10 or fewer
+,,Total,304
+,"BENTON, MN",Less than 65 Years,126
+,,65 Years or more,182
+,,No value,10 or fewer
+,,Total,308
+,"MADISON, NE",Less than 65 Years,96
+,,65 Years or more,188
+,,No value,10 or fewer
+,,Total,284
+,"MARSHALL, MS",Less than 65 Years,113
+,,65 Years or more,155
+,,No value,10 or fewer
+,,Total,268
+,"LEWIS AND CLARK, MT",Less than 65 Years,115
+,,65 Years or more,246
+,,No value,10 or fewer
+,,Total,361
+,"JEFFERSON DAVIS, LA",Less than 65 Years,140
+,,65 Years or more,154
+,,No value,10 or fewer
+,,Total,294
+,"ONSLOW, NC",Less than 65 Years,166
+,,65 Years or more,187
+,,No value,10 or fewer
+,,Total,353
+,"IONIA, MI",Less than 65 Years,100
+,,65 Years or more,218
+,,No value,10 or fewer
+,,Total,318
+,"BARNSTABLE, MA",Less than 65 Years,103
+,,65 Years or more,218
+,,No value,10 or fewer
+,,Total,321
+,"YADKIN, NC",Less than 65 Years,90
+,,65 Years or more,231
+,,No value,10 or fewer
+,,Total,321
+,"GRAFTON, NH",Less than 65 Years,96
+,,65 Years or more,191
+,,No value,10 or fewer
+,,Total,287
+,"CASS, MN",Less than 65 Years,103
+,,65 Years or more,204
+,,No value,10 or fewer
+,,Total,307
+,"FAYETTE, TN",Less than 65 Years,90
+,,65 Years or more,197
+,,No value,10 or fewer
+,,Total,287
+,"SCOTT, MS",Less than 65 Years,137
+,,65 Years or more,148
+,,No value,10 or fewer
+,,Total,285
+,"CAPE MAY, NJ",Less than 65 Years,78
+,,65 Years or more,184
+,,No value,10 or fewer
+,,Total,262
+,"PONTOTOC, MS",Less than 65 Years,163
+,,65 Years or more,191
+,,No value,10 or fewer
+,,Total,354
+,"BRADLEY, TN",Less than 65 Years,122
+,,65 Years or more,136
+,,No value,10 or fewer
+,,Total,258
+,"LAFAYETTE, MS",Less than 65 Years,105
+,,65 Years or more,156
+,,No value,10 or fewer
+,,Total,261
+,"SANDOVAL, NM",Less than 65 Years,111
+,,65 Years or more,180
+,,No value,10 or fewer
+,,Total,291
+,"HOLMES, MS",Less than 65 Years,135
+,,65 Years or more,153
+,,No value,10 or fewer
+,,Total,288
+,"LEAKE, MS",Less than 65 Years,102
+,,65 Years or more,142
+,,No value,10 or fewer
+,,Total,244
+,"KENTON, KY",Less than 65 Years,142
+,,65 Years or more,129
+,,No value,10 or fewer
+,,Total,271
+,"MILLE LACS, MN",Less than 65 Years,109
+,,65 Years or more,186
+,,No value,10 or fewer
+,,Total,295
+,"COLUMBUS, NC",Less than 65 Years,128
+,,65 Years or more,170
+,,No value,10 or fewer
+,,Total,298
+,"CLARKE, MS",Less than 65 Years,143
+,,65 Years or more,171
+,,No value,10 or fewer
+,,Total,314
+,"HUNTERDON, NJ",Less than 65 Years,101
+,,65 Years or more,186
+,,No value,10 or fewer
+,,Total,287
+,"NEWTON, MS",Less than 65 Years,142
+,,65 Years or more,136
+,,No value,10 or fewer
+,,Total,278
+,"HOWARD, MD",Less than 65 Years,160
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,270
+,"PERQUIMANS, NC",Less than 65 Years,82
+,,65 Years or more,205
+,,No value,10 or fewer
+,,Total,287
+,"CASS, MO",Less than 65 Years,91
+,,65 Years or more,198
+,,No value,10 or fewer
+,,Total,289
+,"ADDISON, VT",Less than 65 Years,75
+,,65 Years or more,196
+,,No value,10 or fewer
+,,Total,271
+,"SEQUATCHIE, TN",Less than 65 Years,106
+,,65 Years or more,161
+,,No value,10 or fewer
+,,Total,267
+,"INGHAM, MI",Less than 65 Years,100
+,,65 Years or more,146
+,,No value,10 or fewer
+,,Total,246
+,"NODAWAY, MO",Less than 65 Years,74
+,,65 Years or more,184
+,,No value,10 or fewer
+,,Total,258
+,"EAST FELICIANA, LA",Less than 65 Years,122
+,,65 Years or more,175
+,,No value,10 or fewer
+,,Total,297
+,"CLARK, KY",Less than 65 Years,110
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,221
+,"WALDO, ME",Less than 65 Years,85
+,,65 Years or more,184
+,,No value,10 or fewer
+,,Total,269
+,"UNICOI, TN",Less than 65 Years,87
+,,65 Years or more,181
+,,No value,10 or fewer
+,,Total,268
+,"GAGE, NE",Less than 65 Years,94
+,,65 Years or more,150
+,,No value,10 or fewer
+,,Total,244
+,"COTTONWOOD, MN",Less than 65 Years,78
+,,65 Years or more,177
+,,No value,10 or fewer
+,,Total,255
+,"ORLEANS, NY",Less than 65 Years,93
+,,65 Years or more,154
+,,No value,10 or fewer
+,,Total,247
+,"LINCOLN, NC",Less than 65 Years,57
+,,65 Years or more,197
+,,No value,10 or fewer
+,,Total,254
+,"CASS, NE",Less than 65 Years,86
+,,65 Years or more,157
+,,No value,10 or fewer
+,,Total,243
+,"KENT, MD",Less than 65 Years,83
+,,65 Years or more,193
+,,No value,10 or fewer
+,,Total,276
+,"ESTILL, KY",Less than 65 Years,111
+,,65 Years or more,132
+,,No value,10 or fewer
+,,Total,243
+,"BLEDSOE, TN",Less than 65 Years,97
+,,65 Years or more,135
+,,No value,10 or fewer
+,,Total,232
+,"MARSHALL, KY",Less than 65 Years,67
+,,65 Years or more,166
+,,No value,10 or fewer
+,,Total,233
+,"SCHENECTADY, NY",Less than 65 Years,104
+,,65 Years or more,154
+,,No value,10 or fewer
+,,Total,258
+,"MORRIS, NJ",Less than 65 Years,116
+,,65 Years or more,149
+,,No value,10 or fewer
+,,Total,265
+,"GRUNDY, MO",Less than 65 Years,92
+,,65 Years or more,155
+,,No value,10 or fewer
+,,Total,247
+,"PENNINGTON, MN",Less than 65 Years,85
+,,65 Years or more,166
+,,No value,10 or fewer
+,,Total,251
+,"SCOTT, KY",Less than 65 Years,107
+,,65 Years or more,118
+,,No value,10 or fewer
+,,Total,225
+,"ATLANTIC, NJ",Less than 65 Years,79
+,,65 Years or more,136
+,,No value,10 or fewer
+,,Total,215
+,"BOURBON, KY",Less than 65 Years,94
+,,65 Years or more,104
+,,No value,10 or fewer
+,,Total,198
+,"GRAVES, KY",Less than 65 Years,97
+,,65 Years or more,134
+,,No value,10 or fewer
+,,Total,231
+,"CAMPBELL, KY",Less than 65 Years,120
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,230
+,"SHELBY, KY",Less than 65 Years,152
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,232
+,"HILLSDALE, MI",Less than 65 Years,93
+,,65 Years or more,159
+,,No value,10 or fewer
+,,Total,252
+,"WINDSOR, VT",Less than 65 Years,83
+,,65 Years or more,145
+,,No value,10 or fewer
+,,Total,228
+,"WARREN, NY",Less than 65 Years,42
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,153
+,"SAGADAHOC, ME",Less than 65 Years,61
+,,65 Years or more,178
+,,No value,10 or fewer
+,,Total,239
+,"CLAY, MS",Less than 65 Years,128
+,,65 Years or more,161
+,,No value,10 or fewer
+,,Total,289
+,"WALTHALL, MS",Less than 65 Years,97
+,,65 Years or more,120
+,,No value,10 or fewer
+,,Total,217
+,"GREENE, NY",Less than 65 Years,67
+,,65 Years or more,133
+,,No value,10 or fewer
+,,Total,200
+,"PLAQUEMINES, LA",Less than 65 Years,123
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,217
+,"LEE, NC",Less than 65 Years,91
+,,65 Years or more,123
+,,No value,10 or fewer
+,,Total,214
+,"AVERY, NC",Less than 65 Years,65
+,,65 Years or more,202
+,,No value,10 or fewer
+,,Total,267
+,"REDWOOD, MN",Less than 65 Years,72
+,,65 Years or more,112
+,,No value,10 or fewer
+,,Total,184
+,"ASSUMPTION, LA",Less than 65 Years,119
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,213
+,"DYER, TN",Less than 65 Years,53
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,148
+,"BOONE, KY",Less than 65 Years,104
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,206
+,"SCHOHARIE, NY",Less than 65 Years,62
+,,65 Years or more,154
+,,No value,10 or fewer
+,,Total,216
+,"MENOMINEE, MI",Less than 65 Years,55
+,,65 Years or more,145
+,,No value,10 or fewer
+,,Total,200
+,"SAINT CLAIR, MI",Less than 65 Years,78
+,,65 Years or more,129
+,,No value,10 or fewer
+,,Total,207
+,"WEAKLEY, TN",Less than 65 Years,64
+,,65 Years or more,105
+,,No value,10 or fewer
+,,Total,169
+,"LAWRENCE, MS",Less than 65 Years,103
+,,65 Years or more,164
+,,No value,10 or fewer
+,,Total,267
+,"RICHMOND, NY",Less than 65 Years,122
+,,65 Years or more,107
+,,No value,10 or fewer
+,,Total,229
+,"PASSAIC, NJ",Less than 65 Years,115
+,,65 Years or more,87
+,,No value,10 or fewer
+,,Total,202
+,"FLOYD, KY",Less than 65 Years,99
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,209
+,"HOPKINS, KY",Less than 65 Years,28
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,52
+,"CASWELL, NC",Less than 65 Years,74
+,,65 Years or more,126
+,,No value,10 or fewer
+,,Total,200
+,"ROCK, MN",Less than 65 Years,61
+,,65 Years or more,139
+,,No value,10 or fewer
+,,Total,200
+,"GASTON, NC",Less than 65 Years,102
+,,65 Years or more,103
+,,No value,10 or fewer
+,,Total,205
+,"JOHNSON, TN",Less than 65 Years,86
+,,65 Years or more,129
+,,No value,10 or fewer
+,,Total,215
+,"HOUSTON, MN",Less than 65 Years,52
+,,65 Years or more,154
+,,No value,10 or fewer
+,,Total,206
+,"PINE, MN",Less than 65 Years,64
+,,65 Years or more,140
+,,No value,10 or fewer
+,,Total,204
+,"GATES, NC",Less than 65 Years,67
+,,65 Years or more,130
+,,No value,10 or fewer
+,,Total,197
+,"PULASKI, MO",Less than 65 Years,96
+,,65 Years or more,116
+,,No value,10 or fewer
+,,Total,212
+,"ANDREW, MO",Less than 65 Years,71
+,,65 Years or more,136
+,,No value,10 or fewer
+,,Total,207
+,"HENRY, KY",Less than 65 Years,115
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,194
+,"ITAWAMBA, MS",Less than 65 Years,106
+,,65 Years or more,129
+,,No value,10 or fewer
+,,Total,235
+,"CARROLL, MD",Less than 65 Years,81
+,,65 Years or more,114
+,,No value,10 or fewer
+,,Total,195
+,"POLK, NC",Less than 65 Years,25
+,,65 Years or more,99
+,,No value,10 or fewer
+,,Total,124
+,"ALLEGANY, MD",Less than 65 Years,86
+,,65 Years or more,119
+,,No value,10 or fewer
+,,Total,205
+,"BUFFALO, NE",Less than 65 Years,67
+,,65 Years or more,172
+,,No value,10 or fewer
+,,Total,239
+,"CRAVEN, NC",Less than 65 Years,76
+,,65 Years or more,98
+,,No value,10 or fewer
+,,Total,174
+,"JACKSON, MN",Less than 65 Years,64
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,174
+,"LAUREL, KY",Less than 65 Years,94
+,,65 Years or more,104
+,,No value,10 or fewer
+,,Total,198
+,"SULLIVAN, NH",Less than 65 Years,62
+,,65 Years or more,138
+,,No value,10 or fewer
+,,Total,200
+,"ROSEAU, MN",Less than 65 Years,64
+,,65 Years or more,118
+,,No value,10 or fewer
+,,Total,182
+,"LIVINGSTON, MO",Less than 65 Years,59
+,,65 Years or more,123
+,,No value,10 or fewer
+,,Total,182
+,"WASHINGTON, NC",Less than 65 Years,68
+,,65 Years or more,109
+,,No value,10 or fewer
+,,Total,177
+,"JONES, MS",Less than 65 Years,75
+,,65 Years or more,108
+,,No value,10 or fewer
+,,Total,183
+,"CLEARWATER, MN",Less than 65 Years,60
+,,65 Years or more,103
+,,No value,10 or fewer
+,,Total,163
+,"CATAWBA, NC",Less than 65 Years,87
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,182
+,"NESHOBA, MS",Less than 65 Years,88
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,170
+,"ROCKINGHAM, NH",Less than 65 Years,77
+,,65 Years or more,98
+,,No value,10 or fewer
+,,Total,175
+,"PERRY, MS",Less than 65 Years,79
+,,65 Years or more,99
+,,No value,10 or fewer
+,,Total,178
+,"FRANKLIN, KY",Less than 65 Years,80
+,,65 Years or more,105
+,,No value,10 or fewer
+,,Total,185
+,"OSCEOLA, MI",Less than 65 Years,57
+,,65 Years or more,123
+,,No value,10 or fewer
+,,Total,180
+,"CECIL, MD",Less than 65 Years,95
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,141
+,"TISHOMINGO, MS",Less than 65 Years,86
+,,65 Years or more,163
+,,No value,10 or fewer
+,,Total,249
+,"TODD, MN",Less than 65 Years,48
+,,65 Years or more,125
+,,No value,10 or fewer
+,,Total,173
+,"CARLTON, MN",Less than 65 Years,48
+,,65 Years or more,118
+,,No value,10 or fewer
+,,Total,166
+,"CALHOUN, MS",Less than 65 Years,81
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,175
+,"SAINT BERNARD, LA",Less than 65 Years,87
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,168
+,"YELLOWSTONE, MT",Less than 65 Years,104
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,163
+,"TERREBONNE, LA",Less than 65 Years,100
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,162
+,"FARIBAULT, MN",Less than 65 Years,55
+,,65 Years or more,123
+,,No value,10 or fewer
+,,Total,178
+,"TOMPKINS, NY",Less than 65 Years,68
+,,65 Years or more,114
+,,No value,10 or fewer
+,,Total,182
+,"VALENCIA, NM",Less than 65 Years,48
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,149
+,"LARUE, KY",Less than 65 Years,62
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,156
+,"MEADE, KY",Less than 65 Years,67
+,,65 Years or more,87
+,,No value,10 or fewer
+,,Total,154
+,"PANOLA, MS",Less than 65 Years,64
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,148
+,"LYON, NV",Less than 65 Years,64
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,141
+,"MCDOWELL, NC",Less than 65 Years,53
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,154
+,"SALINE, NE",Less than 65 Years,69
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,153
+,"WASHINGTON, NY",Less than 65 Years,33
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,114
+,"NELSON, KY",Less than 65 Years,76
+,,65 Years or more,85
+,,No value,10 or fewer
+,,Total,161
+,"SPENCER, KY",Less than 65 Years,56
+,,65 Years or more,67
+,,No value,10 or fewer
+,,Total,123
+,"KNOX, KY",Less than 65 Years,48
+,,65 Years or more,86
+,,No value,10 or fewer
+,,Total,134
+,"WEBSTER, MS",Less than 65 Years,83
+,,65 Years or more,108
+,,No value,10 or fewer
+,,Total,191
+,"HARDEMAN, TN",Less than 65 Years,42
+,,65 Years or more,72
+,,No value,10 or fewer
+,,Total,114
+,"SAINT LOUIS, MO",Less than 65 Years,58
+,,65 Years or more,103
+,,No value,10 or fewer
+,,Total,161
+,"OSWEGO, NY",Less than 65 Years,58
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,160
+,"MURRAY, MN",Less than 65 Years,38
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,149
+,"MARION, TN",Less than 65 Years,61
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,141
+,"STANLY, NC",Less than 65 Years,61
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,132
+,"COPIAH, MS",Less than 65 Years,62
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,137
+,"TATE, MS",Less than 65 Years,51
+,,65 Years or more,93
+,,No value,10 or fewer
+,,Total,144
+,"WOODFORD, KY",Less than 65 Years,53
+,,65 Years or more,85
+,,No value,10 or fewer
+,,Total,138
+,"MERRIMACK, NH",Less than 65 Years,48
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,139
+,"ROCKLAND, NY",Less than 65 Years,60
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,137
+,"POINTE COUPEE, LA",Less than 65 Years,62
+,,65 Years or more,87
+,,No value,10 or fewer
+,,Total,149
+,"RUTHERFORD, NC",Less than 65 Years,41
+,,65 Years or more,83
+,,No value,10 or fewer
+,,Total,124
+,"MERRICK, NE",Less than 65 Years,45
+,,65 Years or more,85
+,,No value,10 or fewer
+,,Total,130
+,"KEMPER, MS",Less than 65 Years,51
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,122
+,"WEBSTER, KY",Less than 65 Years,51
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,108
+,"SURRY, NC",Less than 65 Years,39
+,,65 Years or more,87
+,,No value,10 or fewer
+,,Total,126
+,"ULSTER, NY",Less than 65 Years,60
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,126
+,"MOREHOUSE, LA",Less than 65 Years,36
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,130
+,"DAKOTA, NE",Less than 65 Years,59
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,120
+,"YALOBUSHA, MS",Less than 65 Years,42
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,121
+,"CAMDEN, NC",Less than 65 Years,52
+,,65 Years or more,86
+,,No value,10 or fewer
+,,Total,138
+,"COVINGTON, MS",Less than 65 Years,53
+,,65 Years or more,72
+,,No value,10 or fewer
+,,Total,125
+,"SCOTT, MO",Less than 65 Years,52
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,113
+,"AITKIN, MN",Less than 65 Years,52
+,,65 Years or more,138
+,,No value,10 or fewer
+,,Total,190
+,"CARVER, MN",Less than 65 Years,33
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,112
+,"SCOTTS BLUFF, NE",Less than 65 Years,27
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,101
+,"CHICKASAW, MS",Less than 65 Years,63
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,158
+,"BENTON, TN",Less than 65 Years,39
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,83
+,"LAKE, MI",Less than 65 Years,38
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,117
+,"CARTERET, NC",Less than 65 Years,23
+,,65 Years or more,85
+,,No value,10 or fewer
+,,Total,108
+,"RICHLAND, MT",Less than 65 Years,50
+,,65 Years or more,67
+,,No value,10 or fewer
+,,Total,117
+,"BALLARD, KY",Less than 65 Years,39
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,100
+,"SAINT JAMES, LA",Less than 65 Years,51
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,96
+,"DAVIDSON, TN",Less than 65 Years,66
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,119
+,"SIMPSON, MS",Less than 65 Years,56
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,114
+,"ANDERSON, KY",Less than 65 Years,50
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,108
+,"GARRARD, KY",Less than 65 Years,50
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,106
+,"ISANTI, MN",Less than 65 Years,38
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,87
+,"KENNEBEC, ME",Less than 65 Years,39
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,119
+,"ASHE, NC",Less than 65 Years,51
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,148
+,"TIPPAH, MS",Less than 65 Years,66
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,117
+,"LIVINGSTON, KY",Less than 65 Years,47
+,,65 Years or more,68
+,,No value,10 or fewer
+,,Total,115
+,"MADISON, NY",Less than 65 Years,39
+,,65 Years or more,68
+,,No value,10 or fewer
+,,Total,107
+,"EATON, MI",Less than 65 Years,28
+,,65 Years or more,67
+,,No value,10 or fewer
+,,Total,95
+,"MARSHALL, MN",Less than 65 Years,49
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,112
+,"AMITE, MS",Less than 65 Years,47
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,120
+,"ORANGE, VT",Less than 65 Years,44
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,93
+,"CAYUGA, NY",Less than 65 Years,45
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,104
+,"LINCOLN, MS",Less than 65 Years,50
+,,65 Years or more,83
+,,No value,10 or fewer
+,,Total,133
+,"LAPEER, MI",Less than 65 Years,38
+,,65 Years or more,65
+,,No value,10 or fewer
+,,Total,103
+,"BENTON, MS",Less than 65 Years,44
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,89
+,"OKTIBBEHA, MS",Less than 65 Years,74
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,130
+,"KNOX, TN",Less than 65 Years,45
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,100
+,"MORRISON, MN",Less than 65 Years,35
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,105
+,"GRANVILLE, NC",Less than 65 Years,44
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,101
+,"LAUDERDALE, TN",Less than 65 Years,45
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,89
+,"NORMAN, MN",Less than 65 Years,30
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,90
+,"GEORGE, MS",Less than 65 Years,36
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,69
+,"HANCOCK, TN",Less than 65 Years,45
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,90
+,"STONE, MS",Less than 65 Years,55
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,112
+,"RICHLAND, LA",Less than 65 Years,32
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,95
+,"WARREN, MS",Less than 65 Years,27
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,85
+,"FRANKLIN, VT",Less than 65 Years,32
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,93
+,"MOORE, NC",Less than 65 Years,32
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,83
+,"GRANT, MN",Less than 65 Years,32
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,88
+,"CLINTON, MO",Less than 65 Years,34
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,92
+,"MAHNOMEN, MN",Less than 65 Years,30
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,79
+,"CHESTER, TN",Less than 65 Years,21
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,66
+,"LYON, KY",Less than 65 Years,33
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,87
+,"PULASKI, KY",Less than 65 Years,40
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,93
+,"ALCORN, MS",Less than 65 Years,48
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,103
+,"JEFFERSON DAVIS, MS",Less than 65 Years,36
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,90
+,"CUMBERLAND, NJ",Less than 65 Years,43
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,74
+,"TRANSYLVANIA, NC",Less than 65 Years,17
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,76
+,"HUBBARD, MN",Less than 65 Years,26
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,76
+,"UNION, LA",Less than 65 Years,27
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,87
+,"FULTON, NY",Less than 65 Years,37
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,91
+,"TUNICA, MS",Less than 65 Years,43
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,76
+,"LYON, MN",Less than 65 Years,23
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,81
+,"TYRRELL, NC",Less than 65 Years,40
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,92
+,"SAINT MARYS, MD",Less than 65 Years,32
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,73
+,"MONTGOMERY, NY",Less than 65 Years,25
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,74
+,"NOXUBEE, MS",Less than 65 Years,44
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,82
+,"CARROLL, MS",Less than 65 Years,38
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,83
+,"CHEYENNE, NE",Less than 65 Years,19
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,64
+,"CROCKETT, TN",Less than 65 Years,31
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,66
+,"DUTCHESS, NY",Less than 65 Years,35
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,74
+,"SALEM, NJ",Less than 65 Years,51
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,76
+,"SILVER BOW, MT",Less than 65 Years,40
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,74
+,"JACKSON, KY",Less than 65 Years,39
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,93
+,"SUSSEX, NJ",Less than 65 Years,40
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,81
+,"CLEVELAND, NC",Less than 65 Years,45
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,73
+,"WABASHA, MN",Less than 65 Years,21
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,76
+,"WEST FELICIANA, LA",Less than 65 Years,38
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,88
+,"BRECKINRIDGE, KY",Less than 65 Years,37
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,74
+,"KITTSON, MN",Less than 65 Years,24
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,83
+,"PERSON, NC",Less than 65 Years,34
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,66
+,"YELLOW MEDICINE, MN",Less than 65 Years,20
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,90
+,"RHEA, TN",Less than 65 Years,41
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,78
+,"SAINT HELENA, LA",Less than 65 Years,22
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,65
+,"GENTRY, MO",Less than 65 Years,24
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,63
+,"CARSON CITY, NV",Less than 65 Years,39
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,67
+,"LETCHER, KY",Less than 65 Years,26
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,65
+,"MEEKER, MN",Less than 65 Years,29
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,73
+,"CRAWFORD, MO",Less than 65 Years,32
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,76
+,"BOYLE, KY",Less than 65 Years,22
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,55
+,"VANCE, NC",Less than 65 Years,35
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,68
+,"HANCOCK, ME",Less than 65 Years,15
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,66
+,"WILKES, NC",Less than 65 Years,28
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,67
+,"WINONA, MN",Less than 65 Years,24
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,58
+,"STODDARD, MO",Less than 65 Years,24
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,62
+,"SENECA, NY",Less than 65 Years,28
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,65
+,"CALVERT, MD",Less than 65 Years,31
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,58
+,"CARLISLE, KY",Less than 65 Years,23
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,59
+,"EVANGELINE, LA",Less than 65 Years,26
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,53
+,"DOUGLAS, MN",Less than 65 Years,25
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,65
+,"LINCOLN, LA",Less than 65 Years,26
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,73
+,"SANTA FE, NM",Less than 65 Years,14
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,48
+,"WARREN, NC",Less than 65 Years,27
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,60
+,"DAVIESS, KY",Less than 65 Years,32
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,63
+,"WYOMING, NY",Less than 65 Years,19
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,60
+,"TRIMBLE, KY",Less than 65 Years,21
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,45
+,"CATTARAUGUS, NY",Less than 65 Years,24
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,58
+,"DEKALB, MO",Less than 65 Years,21
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,57
+,"BERKSHIRE, MA",Less than 65 Years,24
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,59
+,"LAKE, TN",Less than 65 Years,17
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,48
+,"MERCER, KY",Less than 65 Years,23
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,54
+,"CADDO, LA",Less than 65 Years,44
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,68
+,"WADENA, MN",Less than 65 Years,25
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,64
+,"CHURCHILL, NV",Less than 65 Years,13
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,48
+,"FULTON, KY",Less than 65 Years,18
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,46
+,"LEE, KY",Less than 65 Years,35
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,57
+,"GRAYSON, KY",Less than 65 Years,18
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,59
+,"HAMPSHIRE, MA",Less than 65 Years,21
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,54
+,"MCCREARY, KY",Less than 65 Years,22
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,49
+,"DOUGLAS, NV",Less than 65 Years,14
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,45
+,"MARIES, MO",Less than 65 Years,22
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,48
+,"RAPIDES, LA",Less than 65 Years,29
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,50
+,"SWIFT, MN",Less than 65 Years,19
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,61
+,"BOLLINGER, MO",Less than 65 Years,22
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,44
+,"HUMPHREYS, MS",Less than 65 Years,31
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,55
+,"CALDWELL, KY",Less than 65 Years,15
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,52
+,"DENT, MO",Less than 65 Years,13
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,58
+,"HYDE, NC",Less than 65 Years,29
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,53
+,"POWELL, KY",Less than 65 Years,31
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,48
+,"GRUNDY, TN",Less than 65 Years,16
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,51
+,"BATH, KY",Less than 65 Years,21
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,45
+,"RENVILLE, MN",Less than 65 Years,16
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,38
+,"POLK, TN",Less than 65 Years,15
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,33
+,"RUTLAND, VT",Less than 65 Years,17
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,46
+,"CHEROKEE, NC",Less than 65 Years,15
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,39
+,"FILLMORE, MN",Less than 65 Years,15
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,57
+,"JASPER, MS",Less than 65 Years,24
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,50
+,"SAINT CHARLES, MO",Less than 65 Years,18
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,46
+,"JOHNSON, MO",Less than 65 Years,11
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,41
+,"SCHUYLER, NY",Less than 65 Years,14
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,45
+,"DUNKLIN, MO",Less than 65 Years,18
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,43
+,"WINDHAM, VT",Less than 65 Years,17
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,45
+,"SMITH, MS",Less than 65 Years,21
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,45
+,"GRAND ISLE, VT",Less than 65 Years,14
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,48
+,"HOLT, MO",Less than 65 Years,20
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,49
+,"MONTGOMERY, KY",Less than 65 Years,29
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,54
+,"RICE, MN",Less than 65 Years,15
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,48
+,"HENDERSON, TN",Less than 65 Years,16
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,34
+,"MONTGOMERY, MS",Less than 65 Years,20
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,52
+,"ELKO, NV",Less than 65 Years,19
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,40
+,"WEST CARROLL, LA",Less than 65 Years,13
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,49
+,"GREENE, MS",Less than 65 Years,17
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,45
+,"YATES, NY",Less than 65 Years,19
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,52
+,"SAGINAW, MI",Less than 65 Years,17
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,39
+,"WILKIN, MN",Less than 65 Years,13
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,47
+,"DODGE, NE",Less than 65 Years,14
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,40
+,"NYE, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,37
+,"OLMSTED, MN",Less than 65 Years,14
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,32
+,"WILLIAMSON, TN",Less than 65 Years,14
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,38
+,"CALLOWAY, KY",Less than 65 Years,22
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,45
+,"RED LAKE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,33
+,"BEAUREGARD, LA",Less than 65 Years,16
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,35
+,"STRAFFORD, NH",Less than 65 Years,15
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,39
+,"ADAMS, MS",Less than 65 Years,17
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,40
+,"FRANKLIN, LA",Less than 65 Years,19
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,41
+,"GREENE, MO",Less than 65 Years,26
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,46
+,"RUTHERFORD, TN",Less than 65 Years,25
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,46
+,"SHIAWASSEE, MI",Less than 65 Years,16
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,38
+,"HAMILTON, NE",Less than 65 Years,18
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,39
+,"HAYWOOD, TN",Less than 65 Years,18
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,36
+,"LAFAYETTE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,37
+,"LAMOILLE, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,37
+,"SAUNDERS, NE",Less than 65 Years,12
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,41
+,"TETON, MT",Less than 65 Years,12
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,60
+,"JEFFERSON, NY",Less than 65 Years,18
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,47
+,"LINCOLN, KY",Less than 65 Years,18
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,43
+,"MADISON, NC",Less than 65 Years,15
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,46
+,"HARLAN, KY",Less than 65 Years,22
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,45
+,"HENRY, TN",Less than 65 Years,15
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,32
+,"CARROLL, KY",Less than 65 Years,20
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,37
+,"CLAY, NE",Less than 65 Years,15
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,41
+,"GRAND TRAVERSE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,36
+,"SEWARD, NE",Less than 65 Years,15
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,37
+,"TRAVERSE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,41
+,"JOHNSON, KY",Less than 65 Years,14
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,45
+,"MONTGOMERY, TN",Less than 65 Years,21
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,34
+,"MERCER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,42
+,"ROCKCASTLE, KY",Less than 65 Years,18
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,38
+,"LEFLORE, MS",Less than 65 Years,19
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,39
+,"SOMERSET, ME",Less than 65 Years,13
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,38
+,"CUMBERLAND, TN",Less than 65 Years,15
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,35
+,"MCNAIRY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,25
+,"BOYD, KY",Less than 65 Years,14
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,31
+,"SCOTLAND, NC",Less than 65 Years,13
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,32
+,"WASHINGTON, MS",Less than 65 Years,18
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,40
+,"WINSTON, MS",Less than 65 Years,13
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,28
+,"HARRISON, KY",Less than 65 Years,12
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,40
+,"CASEY, KY",Less than 65 Years,16
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,32
+,"CRITTENDEN, KY",Less than 65 Years,11
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,35
+,"FLEMING, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,26
+,"HAYWOOD, NC",Less than 65 Years,13
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,31
+,"MCMINN, TN",Less than 65 Years,17
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,38
+,"PARK, MT",Less than 65 Years,11
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,33
+,"SUMNER, TN",Less than 65 Years,19
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,39
+,"WASHINGTON, NE",Less than 65 Years,12
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,33
+,"BREATHITT, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,33
+,"AVOYELLES, LA",Less than 65 Years,12
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,30
+,"JEFFERSON, MT",Less than 65 Years,22
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,38
+,"MARTIN, MN",Less than 65 Years,12
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,35
+,"KANABEC, MN",Less than 65 Years,13
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,38
+,"TEXAS, MO",Less than 65 Years,14
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,29
+,"DAVIESS, MO",Less than 65 Years,11
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,27
+,"HAMBLEN, TN",Less than 65 Years,14
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,26
+,"JONES, NC",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"MAGOFFIN, KY",Less than 65 Years,17
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,38
+,"PIERCE, NE",Less than 65 Years,13
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,37
+,"HART, KY",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"CHOCTAW, MS",Less than 65 Years,17
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,47
+,"CLINTON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,31
+,"WAYNE, MS",Less than 65 Years,13
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,35
+,"PIPESTONE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,33
+,"ALLEN, LA",Less than 65 Years,13
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,34
+,"CHOUTEAU, MT",Less than 65 Years,18
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,45
+,"ISABELLA, MI",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"CUSTER, MT",Less than 65 Years,16
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,30
+,"PEMISCOT, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,25
+,"WILKINSON, MS",Less than 65 Years,13
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,35
+,"CONCORDIA, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,24
+,"TALLAHATCHIE, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"CALDWELL, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,22
+,"GRANT, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,24
+,"TUSCOLA, MI",Less than 65 Years,19
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,32
+,"BOONE, MO",Less than 65 Years,15
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,35
+,"DIXON, NE",Less than 65 Years,13
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,28
+,"DONA ANA, NM",Less than 65 Years,14
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,28
+,"MACON, NC",Less than 65 Years,12
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,26
+,"BELL, KY",Less than 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"MANISTEE, MI",Less than 65 Years,12
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,25
+,"MASON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,25
+,"VERNON, LA",Less than 65 Years,15
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,28
+,"CAMPBELL, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,31
+,"FRANKLIN, MA",Less than 65 Years,11
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,26
+,"JACKSON, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,30
+,"BAY, MI",Less than 65 Years,13
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,33
+,"BOLIVAR, MS",Less than 65 Years,11
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,24
+,"BOSSIER, LA",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"MCLEOD, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,30
+,"WARREN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,22
+,"CHRISTIAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"GREENUP, KY",Less than 65 Years,11
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,26
+,"MISSOULA, MT",Less than 65 Years,13
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,26
+,"WEBSTER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,26
+,"CALDWELL, MO",Less than 65 Years,12
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,24
+,"KNOTT, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,30
+,"TAYLOR, KY",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"BLOUNT, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"BLUE EARTH, MN",Less than 65 Years,12
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,29
+,"SEVIER, TN",Less than 65 Years,13
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,26
+,"BIG STONE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,28
+,"MEIGS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,21
+,"SAINT LOUIS CITY, MO",Less than 65 Years,12
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,28
+,"ADAIR, KY",Less than 65 Years,11
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,22
+,"BELKNAP, NH",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"DAWSON, NE",Less than 65 Years,12
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,29
+,"PERRY, KY",Less than 65 Years,15
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,33
+,"COAHOMA, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"DECATUR, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,18
+,"JEFFERSON, MO",Less than 65 Years,14
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,31
+,"SANILAC, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,23
+,"CALEDONIA, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,22
+,"COOS, NH",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"RICHMOND, NC",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"TORRANCE, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,18
+,"CARTER, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,26
+,"LESLIE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,27
+,"MUHLENBERG, KY",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"SUNFLOWER, MS",Less than 65 Years,13
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,31
+,"COCKE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,24
+,"MITCHELL, NC",Less than 65 Years,11
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,31
+,"SAINT FRANCOIS, MO",Less than 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"CLINTON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"WILSON, TN",Less than 65 Years,11
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,24
+,"ANSON, NC",Less than 65 Years,12
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,24
+,"BENNINGTON, VT",Less than 65 Years,11
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,27
+,"BROWN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,22
+,"GREEN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"OTOE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,23
+,"PENDLETON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,21
+,"PUTNAM, NY",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,21
+,"CLAIBORNE, MS",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"FLATHEAD, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,23
+,"MAURY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,23
+,"PLATTE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"VAN BUREN, TN",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"WAYNE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,29
+,"HICKMAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,15
+,"KEITH, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,21
+,"MARQUETTE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"NEW MADRID, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,18
+,"RAY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CEDAR, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,20
+,"JASPER, MO",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"JEFFERSON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,19
+,"MARION, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,21
+,"FRANKLIN, MS",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"LINN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,24
+,"MIDLAND, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"NANCE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,21
+,"ALEXANDER, NC",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"BATES, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,26
+,"CLAY, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,21
+,"GOODHUE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,20
+,"JACKSON, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"QUITMAN, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,16
+,"LEWIS, NY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"PAMLICO, NC",Less than 65 Years,11
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,27
+,"ANDERSON, TN",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"AROOSTOOK, ME",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"CHIPPEWA, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"PUTNAM, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,17
+,"STANTON, NE",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"MADISON, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"RUSSELL, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,21
+,"HENRY, MO",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MISSISSIPPI, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"CLARE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"LE SUEUR, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,21
+,"MADISON, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"ROWAN, KY",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"WASHINGTON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"MARTIN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,15
+,"HURON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"ORLEANS, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"ROSCOMMON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,19
+,"FRANKLIN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IOSCO, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,17
+,"OWEN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"OWSLEY, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"WORTH, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"BRACKEN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"GRAINGER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"LOUDON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"MCKINLEY, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"YANCEY, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,20
+,"WAYNE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"EMMET, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,15
+,"SAN JUAN, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CAMDEN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CIBOLA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WEXFORD, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ANTELOPE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEBOYGAN, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRONTIER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"GASCONADE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"GLACIER, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE OF THE WOODS, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"LEWIS, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MONROE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WASHINGTON, ME",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARREN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CURRY, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,13
+,"HARDIN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"JEFFERSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"KNOX, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MONTGOMERY, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"NICHOLAS, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"STEVENS, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,14
+,"CARROLL, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CHIPPEWA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKINSON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"LAKE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"NATCHITOCHES, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"PISCATAQUIS, ME",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIBLEY, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"EDDY, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"FRANKLIN, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,16
+,"JEFFERSON, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"TRIGG, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,13
+,"YORK, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CHRISTIAN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"PERRY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TANEY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CHARLEVOIX, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HUMBOLDT, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CUSTER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MCLEAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENIFEE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHARKEY, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"CUMING, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,18
+,"LEA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"QUAY, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ALLEGHANY, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOK, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRATIOT, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTMORENCY, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"NICOLLET, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THURSTON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"DUKES, MA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREEBORN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HILL, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"LOGAN, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTERO, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"POPE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WAYNE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALPENA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,11
+,"ANTRIM, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,13
+,"ELLIOTT, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAC QUI PARLE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"OHIO, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"GALLATIN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA SALLE, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGEMAW, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"POLK, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"STONE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOLFE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIG HORN, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CATAHOULA, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOOKER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOX BUTTE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROADWATER, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"COLFAX, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLFAX, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"DEUEL, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAST CARROLL, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRESQUE ISLE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIO ARRIBA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ROANE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TENSAS, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLADWIN, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"LACLEDE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHELPS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RAVALLI, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RED WILLOW, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLIVAN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"ARENAC, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENZIE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOLT, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMPHREYS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KALKASKA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NANTUCKET, MA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NUCKOLLS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PETTIS, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PONDERA, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROOSEVELT, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STOREY, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALGER, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAIBORNE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDMONSON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEELANAU, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MISSAUKEE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRILL, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THOMAS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VERNON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOS ALAMOS, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOWER, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTSEGO, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"STEELE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWAIN, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAOS, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALCONA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FERGUS, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDONALD, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIPLEY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SABINE, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CLAIR, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOCORRO, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WATONWAN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATCHISON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARRY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMERON, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARBON, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEER LODGE, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUGHTON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINERAL, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN MIGUEL, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOPER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWSON, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FILLMORE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FURNAS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANDER, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTSON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINTE GENEVIEVE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERMAN, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STILLWATER, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAIR, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVERHEAD, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIENVILLE, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHASE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEMAHA, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSCODA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERSHING, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE PINE, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURT, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHERRY, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, NY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEARNEY, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAWNEE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROSEBUD, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEATHAM, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALLAS, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWES, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FENTRESS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HICKORY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERKINS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHOOLCRAFT, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIMPSON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOOLE, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINN, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAHAM, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREELEY, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWELL, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUDITH BASIN, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUCE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSAGE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OVERTON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROOSEVELT, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASECA, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOYD, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARTER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUNA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACKINAC, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"METCALFE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OREGON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHARDSON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUDRAIN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARTON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAIBORNE, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEAGHER, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHILLIPS, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 65 Years,6433
+,,65 Years or more,9556
+,,No value,10 or fewer
+,,Total,15989
+,Total,Less than 65 Years,201784
+,,65 Years or more,317065
+,,No value,10 or fewer
+,,Total,518850
+Jan 1 – Jul 17 2025,"WAYNE, MI",Less than 65 Years,4508
+,,65 Years or more,6031
+,,No value,10 or fewer
+,,Total,10539
+,"WAKE, NC",Less than 65 Years,2555
+,,65 Years or more,4297
+,,No value,10 or fewer
+,,Total,6852
+,"MIDDLESEX, MA",Less than 65 Years,2041
+,,65 Years or more,4408
+,,No value,10 or fewer
+,,Total,6449
+,"MONROE, NY",Less than 65 Years,1465
+,,65 Years or more,3391
+,,No value,10 or fewer
+,,Total,4856
+,"JEFFERSON, KY",Less than 65 Years,2202
+,,65 Years or more,2086
+,,No value,10 or fewer
+,,Total,4288
+,"KENT, MI",Less than 65 Years,1424
+,,65 Years or more,2650
+,,No value,10 or fewer
+,,Total,4074
+,"KINGS, NY",Less than 65 Years,2072
+,,65 Years or more,1879
+,,No value,10 or fewer
+,,Total,3951
+,"HENNEPIN, MN",Less than 65 Years,1373
+,,65 Years or more,2358
+,,No value,10 or fewer
+,,Total,3731
+,"SUFFOLK, NY",Less than 65 Years,1293
+,,65 Years or more,2373
+,,No value,10 or fewer
+,,Total,3666
+,"OAKLAND, MI",Less than 65 Years,1282
+,,65 Years or more,3287
+,,No value,10 or fewer
+,,Total,4569
+,"WORCESTER, MA",Less than 65 Years,1509
+,,65 Years or more,2359
+,,No value,10 or fewer
+,,Total,3868
+,"GUILFORD, NC",Less than 65 Years,1058
+,,65 Years or more,2136
+,,No value,10 or fewer
+,,Total,3194
+,"MECKLENBURG, NC",Less than 65 Years,1331
+,,65 Years or more,2037
+,,No value,10 or fewer
+,,Total,3368
+,"MACOMB, MI",Less than 65 Years,1193
+,,65 Years or more,2705
+,,No value,10 or fewer
+,,Total,3898
+,"NASSAU, NY",Less than 65 Years,967
+,,65 Years or more,2328
+,,No value,10 or fewer
+,,Total,3295
+,"CAMDEN, NJ",Less than 65 Years,1263
+,,65 Years or more,1846
+,,No value,10 or fewer
+,,Total,3109
+,"ERIE, NY",Less than 65 Years,1118
+,,65 Years or more,1806
+,,No value,10 or fewer
+,,Total,2924
+,"SHELBY, TN",Less than 65 Years,2253
+,,65 Years or more,2751
+,,No value,10 or fewer
+,,Total,5004
+,"EAST BATON ROUGE, LA",Less than 65 Years,1403
+,,65 Years or more,1589
+,,No value,10 or fewer
+,,Total,2992
+,"CLARK, NV",Less than 65 Years,1502
+,,65 Years or more,1456
+,,No value,10 or fewer
+,,Total,2958
+,"QUEENS, NY",Less than 65 Years,1234
+,,65 Years or more,1287
+,,No value,10 or fewer
+,,Total,2521
+,"FORSYTH, NC",Less than 65 Years,776
+,,65 Years or more,1657
+,,No value,10 or fewer
+,,Total,2433
+,"JEFFERSON, LA",Less than 65 Years,991
+,,65 Years or more,1338
+,,No value,10 or fewer
+,,Total,2329
+,"OCEAN, NJ",Less than 65 Years,718
+,,65 Years or more,1953
+,,No value,10 or fewer
+,,Total,2671
+,"ESSEX, NJ",Less than 65 Years,1802
+,,65 Years or more,1615
+,,No value,10 or fewer
+,,Total,3417
+,"ESSEX, MA",Less than 65 Years,709
+,,65 Years or more,1846
+,,No value,10 or fewer
+,,Total,2555
+,"SUFFOLK, MA",Less than 65 Years,1515
+,,65 Years or more,1285
+,,No value,10 or fewer
+,,Total,2800
+,"BRISTOL, MA",Less than 65 Years,784
+,,65 Years or more,1337
+,,No value,10 or fewer
+,,Total,2121
+,"LAFAYETTE, LA",Less than 65 Years,1028
+,,65 Years or more,1046
+,,No value,10 or fewer
+,,Total,2074
+,"CUMBERLAND, NC",Less than 65 Years,998
+,,65 Years or more,1167
+,,No value,10 or fewer
+,,Total,2165
+,"BURLINGTON, NJ",Less than 65 Years,726
+,,65 Years or more,1504
+,,No value,10 or fewer
+,,Total,2230
+,"JACKSON, MI",Less than 65 Years,825
+,,65 Years or more,1233
+,,No value,10 or fewer
+,,Total,2058
+,"MIDDLESEX, NJ",Less than 65 Years,898
+,,65 Years or more,1254
+,,No value,10 or fewer
+,,Total,2152
+,"JACKSON, MO",Less than 65 Years,736
+,,65 Years or more,1219
+,,No value,10 or fewer
+,,Total,1955
+,"WASHOE, NV",Less than 65 Years,751
+,,65 Years or more,1120
+,,No value,10 or fewer
+,,Total,1871
+,"ALBANY, NY",Less than 65 Years,843
+,,65 Years or more,1515
+,,No value,10 or fewer
+,,Total,2358
+,"FAYETTE, KY",Less than 65 Years,993
+,,65 Years or more,1013
+,,No value,10 or fewer
+,,Total,2006
+,"WASHTENAW, MI",Less than 65 Years,583
+,,65 Years or more,1299
+,,No value,10 or fewer
+,,Total,1882
+,"JOHNSTON, NC",Less than 65 Years,699
+,,65 Years or more,1142
+,,No value,10 or fewer
+,,Total,1841
+,"KALAMAZOO, MI",Less than 65 Years,634
+,,65 Years or more,1112
+,,No value,10 or fewer
+,,Total,1746
+,"LANCASTER, NE",Less than 65 Years,680
+,,65 Years or more,1175
+,,No value,10 or fewer
+,,Total,1855
+,"SULLIVAN, TN",Less than 65 Years,505
+,,65 Years or more,961
+,,No value,10 or fewer
+,,Total,1466
+,"WASHINGTON, MD",Less than 65 Years,464
+,,65 Years or more,1058
+,,No value,10 or fewer
+,,Total,1522
+,"MUSKEGON, MI",Less than 65 Years,567
+,,65 Years or more,908
+,,No value,10 or fewer
+,,Total,1475
+,"HINDS, MS",Less than 65 Years,710
+,,65 Years or more,759
+,,No value,10 or fewer
+,,Total,1469
+,"PITT, NC",Less than 65 Years,685
+,,65 Years or more,850
+,,No value,10 or fewer
+,,Total,1535
+,"ALAMANCE, NC",Less than 65 Years,491
+,,65 Years or more,937
+,,No value,10 or fewer
+,,Total,1428
+,"HAMILTON, TN",Less than 65 Years,630
+,,65 Years or more,878
+,,No value,10 or fewer
+,,Total,1508
+,"ORLEANS, LA",Less than 65 Years,615
+,,65 Years or more,772
+,,No value,10 or fewer
+,,Total,1387
+,"WAYNE, NC",Less than 65 Years,585
+,,65 Years or more,788
+,,No value,10 or fewer
+,,Total,1373
+,"JACKSON, MS",Less than 65 Years,585
+,,65 Years or more,924
+,,No value,10 or fewer
+,,Total,1509
+,"LIVINGSTON, LA",Less than 65 Years,732
+,,65 Years or more,683
+,,No value,10 or fewer
+,,Total,1415
+,"BROOME, NY",Less than 65 Years,486
+,,65 Years or more,727
+,,No value,10 or fewer
+,,Total,1213
+,"DAKOTA, MN",Less than 65 Years,440
+,,65 Years or more,884
+,,No value,10 or fewer
+,,Total,1324
+,"LIVINGSTON, MI",Less than 65 Years,390
+,,65 Years or more,1067
+,,No value,10 or fewer
+,,Total,1457
+,"BERRIEN, MI",Less than 65 Years,475
+,,65 Years or more,1004
+,,No value,10 or fewer
+,,Total,1479
+,"PRINCE GEORGES, MD",Less than 65 Years,625
+,,65 Years or more,689
+,,No value,10 or fewer
+,,Total,1314
+,"HUDSON, NJ",Less than 65 Years,1087
+,,65 Years or more,661
+,,No value,10 or fewer
+,,Total,1748
+,"BALTIMORE, MD",Less than 65 Years,439
+,,65 Years or more,823
+,,No value,10 or fewer
+,,Total,1262
+,"BRUNSWICK, NC",Less than 65 Years,396
+,,65 Years or more,1235
+,,No value,10 or fewer
+,,Total,1631
+,"TANGIPAHOA, LA",Less than 65 Years,452
+,,65 Years or more,623
+,,No value,10 or fewer
+,,Total,1075
+,"ANNE ARUNDEL, MD",Less than 65 Years,508
+,,65 Years or more,780
+,,No value,10 or fewer
+,,Total,1288
+,"ORANGE, NY",Less than 65 Years,481
+,,65 Years or more,701
+,,No value,10 or fewer
+,,Total,1182
+,"RAMSEY, MN",Less than 65 Years,373
+,,65 Years or more,761
+,,No value,10 or fewer
+,,Total,1134
+,"MONTGOMERY, MD",Less than 65 Years,476
+,,65 Years or more,620
+,,No value,10 or fewer
+,,Total,1096
+,"ROBESON, NC",Less than 65 Years,444
+,,65 Years or more,624
+,,No value,10 or fewer
+,,Total,1068
+,"SOMERSET, NJ",Less than 65 Years,382
+,,65 Years or more,825
+,,No value,10 or fewer
+,,Total,1207
+,"SAINT LOUIS, MN",Less than 65 Years,413
+,,65 Years or more,711
+,,No value,10 or fewer
+,,Total,1124
+,"ONEIDA, NY",Less than 65 Years,434
+,,65 Years or more,858
+,,No value,10 or fewer
+,,Total,1292
+,"BALTIMORE CITY, MD",Less than 65 Years,811
+,,65 Years or more,509
+,,No value,10 or fewer
+,,Total,1320
+,"OUACHITA, LA",Less than 65 Years,390
+,,65 Years or more,700
+,,No value,10 or fewer
+,,Total,1090
+,"CALHOUN, MI",Less than 65 Years,425
+,,65 Years or more,622
+,,No value,10 or fewer
+,,Total,1047
+,"DOUGLAS, NE",Less than 65 Years,518
+,,65 Years or more,472
+,,No value,10 or fewer
+,,Total,990
+,"NASH, NC",Less than 65 Years,392
+,,65 Years or more,616
+,,No value,10 or fewer
+,,Total,1008
+,"CHITTENDEN, VT",Less than 65 Years,300
+,,65 Years or more,690
+,,No value,10 or fewer
+,,Total,990
+,"RENSSELAER, NY",Less than 65 Years,457
+,,65 Years or more,658
+,,No value,10 or fewer
+,,Total,1115
+,"WICOMICO, MD",Less than 65 Years,399
+,,65 Years or more,625
+,,No value,10 or fewer
+,,Total,1024
+,"MONROE, MI",Less than 65 Years,462
+,,65 Years or more,719
+,,No value,10 or fewer
+,,Total,1181
+,"BERNALILLO, NM",Less than 65 Years,330
+,,65 Years or more,602
+,,No value,10 or fewer
+,,Total,932
+,"NEW HANOVER, NC",Less than 65 Years,568
+,,65 Years or more,1261
+,,No value,10 or fewer
+,,Total,1829
+,"HENDERSON, NC",Less than 65 Years,274
+,,65 Years or more,758
+,,No value,10 or fewer
+,,Total,1032
+,"UNION, NJ",Less than 65 Years,919
+,,65 Years or more,686
+,,No value,10 or fewer
+,,Total,1605
+,"HARNETT, NC",Less than 65 Years,339
+,,65 Years or more,608
+,,No value,10 or fewer
+,,Total,947
+,"GLOUCESTER, NJ",Less than 65 Years,313
+,,65 Years or more,702
+,,No value,10 or fewer
+,,Total,1015
+,"ROCKINGHAM, NC",Less than 65 Years,345
+,,65 Years or more,574
+,,No value,10 or fewer
+,,Total,919
+,"PLYMOUTH, MA",Less than 65 Years,423
+,,65 Years or more,1250
+,,No value,10 or fewer
+,,Total,1673
+,"LENOIR, NC",Less than 65 Years,375
+,,65 Years or more,544
+,,No value,10 or fewer
+,,Total,919
+,"DESOTO, MS",Less than 65 Years,603
+,,65 Years or more,723
+,,No value,10 or fewer
+,,Total,1326
+,"CUMBERLAND, ME",Less than 65 Years,243
+,,65 Years or more,551
+,,No value,10 or fewer
+,,Total,794
+,"ORANGE, NC",Less than 65 Years,268
+,,65 Years or more,598
+,,No value,10 or fewer
+,,Total,866
+,"OTTAWA, MI",Less than 65 Years,241
+,,65 Years or more,621
+,,No value,10 or fewer
+,,Total,862
+,"HARFORD, MD",Less than 65 Years,304
+,,65 Years or more,663
+,,No value,10 or fewer
+,,Total,967
+,"ROWAN, NC",Less than 65 Years,371
+,,65 Years or more,550
+,,No value,10 or fewer
+,,Total,921
+,"HARRISON, MS",Less than 65 Years,399
+,,65 Years or more,433
+,,No value,10 or fewer
+,,Total,832
+,"NEW YORK, NY",Less than 65 Years,367
+,,65 Years or more,487
+,,No value,10 or fewer
+,,Total,854
+,"WASHINGTON, TN",Less than 65 Years,257
+,,65 Years or more,478
+,,No value,10 or fewer
+,,Total,735
+,"ONONDAGA, NY",Less than 65 Years,313
+,,65 Years or more,510
+,,No value,10 or fewer
+,,Total,823
+,"MERCER, NJ",Less than 65 Years,281
+,,65 Years or more,520
+,,No value,10 or fewer
+,,Total,801
+,"NORFOLK, MA",Less than 65 Years,470
+,,65 Years or more,1162
+,,No value,10 or fewer
+,,Total,1632
+,"RANKIN, MS",Less than 65 Years,296
+,,65 Years or more,488
+,,No value,10 or fewer
+,,Total,784
+,"YORK, ME",Less than 65 Years,207
+,,65 Years or more,597
+,,No value,10 or fewer
+,,Total,804
+,"BURKE, NC",Less than 65 Years,327
+,,65 Years or more,568
+,,No value,10 or fewer
+,,Total,895
+,"MCCRACKEN, KY",Less than 65 Years,320
+,,65 Years or more,409
+,,No value,10 or fewer
+,,Total,729
+,"BUCHANAN, MO",Less than 65 Years,352
+,,65 Years or more,486
+,,No value,10 or fewer
+,,Total,838
+,"HARDIN, KY",Less than 65 Years,347
+,,65 Years or more,432
+,,No value,10 or fewer
+,,Total,779
+,"DAVIDSON, NC",Less than 65 Years,266
+,,65 Years or more,429
+,,No value,10 or fewer
+,,Total,695
+,"GENESEE, MI",Less than 65 Years,382
+,,65 Years or more,332
+,,No value,10 or fewer
+,,Total,714
+,"VAN BUREN, MI",Less than 65 Years,268
+,,65 Years or more,463
+,,No value,10 or fewer
+,,Total,731
+,"LOWNDES, MS",Less than 65 Years,354
+,,65 Years or more,367
+,,No value,10 or fewer
+,,Total,721
+,"EDGECOMBE, NC",Less than 65 Years,300
+,,65 Years or more,438
+,,No value,10 or fewer
+,,Total,738
+,"WASHINGTON, MN",Less than 65 Years,246
+,,65 Years or more,477
+,,No value,10 or fewer
+,,Total,723
+,"WARREN, NJ",Less than 65 Years,288
+,,65 Years or more,456
+,,No value,10 or fewer
+,,Total,744
+,"SARPY, NE",Less than 65 Years,278
+,,65 Years or more,395
+,,No value,10 or fewer
+,,Total,673
+,"ASCENSION, LA",Less than 65 Years,303
+,,65 Years or more,338
+,,No value,10 or fewer
+,,Total,641
+,"BERGEN, NJ",Less than 65 Years,245
+,,65 Years or more,488
+,,No value,10 or fewer
+,,Total,733
+,"STEARNS, MN",Less than 65 Years,215
+,,65 Years or more,457
+,,No value,10 or fewer
+,,Total,672
+,"LENAWEE, MI",Less than 65 Years,220
+,,65 Years or more,463
+,,No value,10 or fewer
+,,Total,683
+,"HALIFAX, NC",Less than 65 Years,217
+,,65 Years or more,434
+,,No value,10 or fewer
+,,Total,651
+,"MADISON, KY",Less than 65 Years,373
+,,65 Years or more,371
+,,No value,10 or fewer
+,,Total,744
+,"MONMOUTH, NJ",Less than 65 Years,303
+,,65 Years or more,406
+,,No value,10 or fewer
+,,Total,709
+,"SULLIVAN, NY",Less than 65 Years,266
+,,65 Years or more,306
+,,No value,10 or fewer
+,,Total,572
+,"GALLATIN, MT",Less than 65 Years,282
+,,65 Years or more,324
+,,No value,10 or fewer
+,,Total,606
+,"MADISON, MS",Less than 65 Years,221
+,,65 Years or more,396
+,,No value,10 or fewer
+,,Total,617
+,"DUPLIN, NC",Less than 65 Years,269
+,,65 Years or more,346
+,,No value,10 or fewer
+,,Total,615
+,"NIAGARA, NY",Less than 65 Years,212
+,,65 Years or more,438
+,,No value,10 or fewer
+,,Total,650
+,"PIKE, KY",Less than 65 Years,273
+,,65 Years or more,388
+,,No value,10 or fewer
+,,Total,661
+,"ACADIA, LA",Less than 65 Years,248
+,,65 Years or more,242
+,,No value,10 or fewer
+,,Total,490
+,"CALDWELL, NC",Less than 65 Years,257
+,,65 Years or more,386
+,,No value,10 or fewer
+,,Total,643
+,"BEAUFORT, NC",Less than 65 Years,177
+,,65 Years or more,335
+,,No value,10 or fewer
+,,Total,512
+,"FORREST, MS",Less than 65 Years,205
+,,65 Years or more,326
+,,No value,10 or fewer
+,,Total,531
+,"HAWKINS, TN",Less than 65 Years,232
+,,65 Years or more,306
+,,No value,10 or fewer
+,,Total,538
+,"CLINTON, NY",Less than 65 Years,165
+,,65 Years or more,395
+,,No value,10 or fewer
+,,Total,560
+,"CHATHAM, NC",Less than 65 Years,157
+,,65 Years or more,496
+,,No value,10 or fewer
+,,Total,653
+,"GREENE, TN",Less than 65 Years,205
+,,65 Years or more,347
+,,No value,10 or fewer
+,,Total,552
+,"LAUDERDALE, MS",Less than 65 Years,326
+,,65 Years or more,377
+,,No value,10 or fewer
+,,Total,703
+,"DURHAM, NC",Less than 65 Years,251
+,,65 Years or more,260
+,,No value,10 or fewer
+,,Total,511
+,"ONTARIO, NY",Less than 65 Years,165
+,,65 Years or more,421
+,,No value,10 or fewer
+,,Total,586
+,"PEARL RIVER, MS",Less than 65 Years,183
+,,65 Years or more,299
+,,No value,10 or fewer
+,,Total,482
+,"STEUBEN, NY",Less than 65 Years,186
+,,65 Years or more,341
+,,No value,10 or fewer
+,,Total,527
+,"HILLSBOROUGH, NH",Less than 65 Years,112
+,,65 Years or more,387
+,,No value,10 or fewer
+,,Total,499
+,"ANOKA, MN",Less than 65 Years,185
+,,65 Years or more,264
+,,No value,10 or fewer
+,,Total,449
+,"OTTER TAIL, MN",Less than 65 Years,134
+,,65 Years or more,299
+,,No value,10 or fewer
+,,Total,433
+,"SARATOGA, NY",Less than 65 Years,283
+,,65 Years or more,705
+,,No value,10 or fewer
+,,Total,988
+,"WAYNE, NY",Less than 65 Years,146
+,,65 Years or more,314
+,,No value,10 or fewer
+,,Total,460
+,"CHARLES, MD",Less than 65 Years,249
+,,65 Years or more,305
+,,No value,10 or fewer
+,,Total,554
+,"SAINT MARTIN, LA",Less than 65 Years,261
+,,65 Years or more,257
+,,No value,10 or fewer
+,,Total,518
+,"UNION, NC",Less than 65 Years,147
+,,65 Years or more,289
+,,No value,10 or fewer
+,,Total,436
+,"ITASCA, MN",Less than 65 Years,152
+,,65 Years or more,265
+,,No value,10 or fewer
+,,Total,417
+,"PLATTE, MO",Less than 65 Years,192
+,,65 Years or more,323
+,,No value,10 or fewer
+,,Total,515
+,"PENOBSCOT, ME",Less than 65 Years,122
+,,65 Years or more,284
+,,No value,10 or fewer
+,,Total,406
+,"ST JOHN THE BAPTIST, LA",Less than 65 Years,196
+,,65 Years or more,184
+,,No value,10 or fewer
+,,Total,380
+,"BELTRAMI, MN",Less than 65 Years,154
+,,65 Years or more,207
+,,No value,10 or fewer
+,,Total,361
+,"LEE, MS",Less than 65 Years,301
+,,65 Years or more,415
+,,No value,10 or fewer
+,,Total,716
+,"ALLEGAN, MI",Less than 65 Years,172
+,,65 Years or more,226
+,,No value,10 or fewer
+,,Total,398
+,"LINCOLN, NE",Less than 65 Years,139
+,,65 Years or more,220
+,,No value,10 or fewer
+,,Total,359
+,"CLAY, MO",Less than 65 Years,176
+,,65 Years or more,227
+,,No value,10 or fewer
+,,Total,403
+,"WESTCHESTER, NY",Less than 65 Years,179
+,,65 Years or more,244
+,,No value,10 or fewer
+,,Total,423
+,"TIPTON, TN",Less than 65 Years,234
+,,65 Years or more,239
+,,No value,10 or fewer
+,,Total,473
+,"HENDERSON, KY",Less than 65 Years,166
+,,65 Years or more,227
+,,No value,10 or fewer
+,,Total,393
+,"ANDROSCOGGIN, ME",Less than 65 Years,138
+,,65 Years or more,211
+,,No value,10 or fewer
+,,Total,349
+,"SHERBURNE, MN",Less than 65 Years,145
+,,65 Years or more,220
+,,No value,10 or fewer
+,,Total,365
+,"BULLITT, KY",Less than 65 Years,178
+,,65 Years or more,151
+,,No value,10 or fewer
+,,Total,329
+,"PHELPS, MO",Less than 65 Years,149
+,,65 Years or more,244
+,,No value,10 or fewer
+,,Total,393
+,"CARTER, TN",Less than 65 Years,147
+,,65 Years or more,191
+,,No value,10 or fewer
+,,Total,338
+,"WASHINGTON, LA",Less than 65 Years,172
+,,65 Years or more,169
+,,No value,10 or fewer
+,,Total,341
+,"CHESHIRE, NH",Less than 65 Years,131
+,,65 Years or more,298
+,,No value,10 or fewer
+,,Total,429
+,"SAINT LAWRENCE, NY",Less than 65 Years,141
+,,65 Years or more,234
+,,No value,10 or fewer
+,,Total,375
+,"SAINT MARY, LA",Less than 65 Years,164
+,,65 Years or more,179
+,,No value,10 or fewer
+,,Total,343
+,"OLDHAM, KY",Less than 65 Years,193
+,,65 Years or more,174
+,,No value,10 or fewer
+,,Total,367
+,"HERKIMER, NY",Less than 65 Years,122
+,,65 Years or more,252
+,,No value,10 or fewer
+,,Total,374
+,"IBERVILLE, LA",Less than 65 Years,165
+,,65 Years or more,174
+,,No value,10 or fewer
+,,Total,339
+,"BLADEN, NC",Less than 65 Years,97
+,,65 Years or more,223
+,,No value,10 or fewer
+,,Total,320
+,"CLAY, MN",Less than 65 Years,160
+,,65 Years or more,176
+,,No value,10 or fewer
+,,Total,336
+,"MADISON, TN",Less than 65 Years,426
+,,65 Years or more,594
+,,No value,10 or fewer
+,,Total,1020
+,"RANDOLPH, NC",Less than 65 Years,145
+,,65 Years or more,188
+,,No value,10 or fewer
+,,Total,333
+,"LAFOURCHE, LA",Less than 65 Years,176
+,,65 Years or more,151
+,,No value,10 or fewer
+,,Total,327
+,"BARRY, MI",Less than 65 Years,93
+,,65 Years or more,260
+,,No value,10 or fewer
+,,Total,353
+,"CROW WING, MN",Less than 65 Years,103
+,,65 Years or more,266
+,,No value,10 or fewer
+,,Total,369
+,"CHENANGO, NY",Less than 65 Years,138
+,,65 Years or more,167
+,,No value,10 or fewer
+,,Total,305
+,"FRANKLIN, NC",Less than 65 Years,133
+,,65 Years or more,214
+,,No value,10 or fewer
+,,Total,347
+,"BUNCOMBE, NC",Less than 65 Years,89
+,,65 Years or more,217
+,,No value,10 or fewer
+,,Total,306
+,"MONTCALM, MI",Less than 65 Years,105
+,,65 Years or more,201
+,,No value,10 or fewer
+,,Total,306
+,"CORTLAND, NY",Less than 65 Years,127
+,,65 Years or more,224
+,,No value,10 or fewer
+,,Total,351
+,"PASQUOTANK, NC",Less than 65 Years,100
+,,65 Years or more,191
+,,No value,10 or fewer
+,,Total,291
+,"CASCADE, MT",Less than 65 Years,258
+,,65 Years or more,394
+,,No value,10 or fewer
+,,Total,652
+,"HANCOCK, MS",Less than 65 Years,161
+,,65 Years or more,166
+,,No value,10 or fewer
+,,Total,327
+,"VERMILION, LA",Less than 65 Years,152
+,,65 Years or more,163
+,,No value,10 or fewer
+,,Total,315
+,"DARE, NC",Less than 65 Years,103
+,,65 Years or more,213
+,,No value,10 or fewer
+,,Total,316
+,"BERTIE, NC",Less than 65 Years,102
+,,65 Years or more,176
+,,No value,10 or fewer
+,,Total,278
+,"NEWAYGO, MI",Less than 65 Years,110
+,,65 Years or more,183
+,,No value,10 or fewer
+,,Total,293
+,"WRIGHT, MN",Less than 65 Years,95
+,,65 Years or more,163
+,,No value,10 or fewer
+,,Total,258
+,"LIVINGSTON, NY",Less than 65 Years,102
+,,65 Years or more,244
+,,No value,10 or fewer
+,,Total,346
+,"CHISAGO, MN",Less than 65 Years,108
+,,65 Years or more,190
+,,No value,10 or fewer
+,,Total,298
+,"BECKER, MN",Less than 65 Years,108
+,,65 Years or more,211
+,,No value,10 or fewer
+,,Total,319
+,"STOKES, NC",Less than 65 Years,65
+,,65 Years or more,209
+,,No value,10 or fewer
+,,Total,274
+,"DELTA, MI",Less than 65 Years,101
+,,65 Years or more,152
+,,No value,10 or fewer
+,,Total,253
+,"DORCHESTER, MD",Less than 65 Years,159
+,,65 Years or more,167
+,,No value,10 or fewer
+,,Total,326
+,"HAMPDEN, MA",Less than 65 Years,275
+,,65 Years or more,492
+,,No value,10 or fewer
+,,Total,767
+,"BRONX, NY",Less than 65 Years,162
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,254
+,"CHOWAN, NC",Less than 65 Years,97
+,,65 Years or more,169
+,,No value,10 or fewer
+,,Total,266
+,"POLK, MN",Less than 65 Years,111
+,,65 Years or more,166
+,,No value,10 or fewer
+,,Total,277
+,"PENDER, NC",Less than 65 Years,181
+,,65 Years or more,322
+,,No value,10 or fewer
+,,Total,503
+,"PIKE, MS",Less than 65 Years,145
+,,65 Years or more,170
+,,No value,10 or fewer
+,,Total,315
+,"OTSEGO, NY",Less than 65 Years,90
+,,65 Years or more,191
+,,No value,10 or fewer
+,,Total,281
+,"ESSEX, NY",Less than 65 Years,84
+,,65 Years or more,207
+,,No value,10 or fewer
+,,Total,291
+,"TIOGA, NY",Less than 65 Years,90
+,,65 Years or more,188
+,,No value,10 or fewer
+,,Total,278
+,"WORCESTER, MD",Less than 65 Years,83
+,,65 Years or more,185
+,,No value,10 or fewer
+,,Total,268
+,"JESSAMINE, KY",Less than 65 Years,110
+,,65 Years or more,137
+,,No value,10 or fewer
+,,Total,247
+,"SAINT TAMMANY, LA",Less than 65 Years,84
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,172
+,"UNION, MS",Less than 65 Years,136
+,,65 Years or more,143
+,,No value,10 or fewer
+,,Total,279
+,"HERTFORD, NC",Less than 65 Years,99
+,,65 Years or more,162
+,,No value,10 or fewer
+,,Total,261
+,"WATAUGA, NC",Less than 65 Years,111
+,,65 Years or more,226
+,,No value,10 or fewer
+,,Total,337
+,"TALBOT, MD",Less than 65 Years,68
+,,65 Years or more,196
+,,No value,10 or fewer
+,,Total,264
+,"MARTIN, NC",Less than 65 Years,106
+,,65 Years or more,179
+,,No value,10 or fewer
+,,Total,285
+,"GENESEE, NY",Less than 65 Years,82
+,,65 Years or more,185
+,,No value,10 or fewer
+,,Total,267
+,"KNOX, ME",Less than 65 Years,56
+,,65 Years or more,156
+,,No value,10 or fewer
+,,Total,212
+,"QUEEN ANNES, MD",Less than 65 Years,84
+,,65 Years or more,188
+,,No value,10 or fewer
+,,Total,272
+,"ALLEGANY, NY",Less than 65 Years,69
+,,65 Years or more,125
+,,No value,10 or fewer
+,,Total,194
+,"OBION, TN",Less than 65 Years,117
+,,65 Years or more,209
+,,No value,10 or fewer
+,,Total,326
+,"MASON, MI",Less than 65 Years,67
+,,65 Years or more,167
+,,No value,10 or fewer
+,,Total,234
+,"CAPE GIRARDEAU, MO",Less than 65 Years,88
+,,65 Years or more,171
+,,No value,10 or fewer
+,,Total,259
+,"SAINT LANDRY, LA",Less than 65 Years,104
+,,65 Years or more,119
+,,No value,10 or fewer
+,,Total,223
+,"CHEMUNG, NY",Less than 65 Years,86
+,,65 Years or more,189
+,,No value,10 or fewer
+,,Total,275
+,"SOMERSET, MD",Less than 65 Years,116
+,,65 Years or more,125
+,,No value,10 or fewer
+,,Total,241
+,"CALCASIEU, LA",Less than 65 Years,262
+,,65 Years or more,334
+,,No value,10 or fewer
+,,Total,596
+,"NORTHAMPTON, NC",Less than 65 Years,81
+,,65 Years or more,167
+,,No value,10 or fewer
+,,Total,248
+,"BRANCH, MI",Less than 65 Years,101
+,,65 Years or more,138
+,,No value,10 or fewer
+,,Total,239
+,"ADAMS, NE",Less than 65 Years,100
+,,65 Years or more,150
+,,No value,10 or fewer
+,,Total,250
+,"MARION, MS",Less than 65 Years,83
+,,65 Years or more,152
+,,No value,10 or fewer
+,,Total,235
+,"KANDIYOHI, MN",Less than 65 Years,67
+,,65 Years or more,170
+,,No value,10 or fewer
+,,Total,237
+,"CARROLL, TN",Less than 65 Years,134
+,,65 Years or more,230
+,,No value,10 or fewer
+,,Total,364
+,"CLAY, KY",Less than 65 Years,140
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,251
+,"OCEANA, MI",Less than 65 Years,85
+,,65 Years or more,147
+,,No value,10 or fewer
+,,Total,232
+,"MONROE, MS",Less than 65 Years,158
+,,65 Years or more,194
+,,No value,10 or fewer
+,,Total,352
+,"NOBLES, MN",Less than 65 Years,79
+,,65 Years or more,141
+,,No value,10 or fewer
+,,Total,220
+,"YAZOO, MS",Less than 65 Years,113
+,,65 Years or more,108
+,,No value,10 or fewer
+,,Total,221
+,"WHITLEY, KY",Less than 65 Years,122
+,,65 Years or more,124
+,,No value,10 or fewer
+,,Total,246
+,"LAMAR, MS",Less than 65 Years,81
+,,65 Years or more,140
+,,No value,10 or fewer
+,,Total,221
+,"CHAUTAUQUA, NY",Less than 65 Years,100
+,,65 Years or more,127
+,,No value,10 or fewer
+,,Total,227
+,"SAINT CHARLES, LA",Less than 65 Years,83
+,,65 Years or more,134
+,,No value,10 or fewer
+,,Total,217
+,"FRANKLIN, NY",Less than 65 Years,81
+,,65 Years or more,104
+,,No value,10 or fewer
+,,Total,185
+,"CARROLL, NH",Less than 65 Years,84
+,,65 Years or more,148
+,,No value,10 or fewer
+,,Total,232
+,"LINCOLN, ME",Less than 65 Years,76
+,,65 Years or more,152
+,,No value,10 or fewer
+,,Total,228
+,"FREDERICK, MD",Less than 65 Years,92
+,,65 Years or more,134
+,,No value,10 or fewer
+,,Total,226
+,"CAROLINE, MD",Less than 65 Years,101
+,,65 Years or more,135
+,,No value,10 or fewer
+,,Total,236
+,"MECOSTA, MI",Less than 65 Years,62
+,,65 Years or more,127
+,,No value,10 or fewer
+,,Total,189
+,"FRANKLIN, ME",Less than 65 Years,59
+,,65 Years or more,125
+,,No value,10 or fewer
+,,Total,184
+,"DELAWARE, NY",Less than 65 Years,75
+,,65 Years or more,160
+,,No value,10 or fewer
+,,Total,235
+,"WEST BATON ROUGE, LA",Less than 65 Years,96
+,,65 Years or more,99
+,,No value,10 or fewer
+,,Total,195
+,"ATTALA, MS",Less than 65 Years,85
+,,65 Years or more,140
+,,No value,10 or fewer
+,,Total,225
+,"GRENADA, MS",Less than 65 Years,76
+,,65 Years or more,108
+,,No value,10 or fewer
+,,Total,184
+,"CABARRUS, NC",Less than 65 Years,101
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,203
+,"CASS, MI",Less than 65 Years,76
+,,65 Years or more,142
+,,No value,10 or fewer
+,,Total,218
+,"WILSON, NC",Less than 65 Years,100
+,,65 Years or more,114
+,,No value,10 or fewer
+,,Total,214
+,"CURRITUCK, NC",Less than 65 Years,69
+,,65 Years or more,124
+,,No value,10 or fewer
+,,Total,193
+,"WASHINGTON, VT",Less than 65 Years,73
+,,65 Years or more,150
+,,No value,10 or fewer
+,,Total,223
+,"GARRETT, MD",Less than 65 Years,93
+,,65 Years or more,128
+,,No value,10 or fewer
+,,Total,221
+,"SCOTT, MN",Less than 65 Years,76
+,,65 Years or more,105
+,,No value,10 or fewer
+,,Total,181
+,"HALL, NE",Less than 65 Years,83
+,,65 Years or more,131
+,,No value,10 or fewer
+,,Total,214
+,"OXFORD, ME",Less than 65 Years,77
+,,65 Years or more,115
+,,No value,10 or fewer
+,,Total,192
+,"SAMPSON, NC",Less than 65 Years,100
+,,65 Years or more,116
+,,No value,10 or fewer
+,,Total,216
+,"GREENE, NC",Less than 65 Years,98
+,,65 Years or more,109
+,,No value,10 or fewer
+,,Total,207
+,"IREDELL, NC",Less than 65 Years,64
+,,65 Years or more,100
+,,No value,10 or fewer
+,,Total,164
+,"UNION, KY",Less than 65 Years,102
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,203
+,"DAVIE, NC",Less than 65 Years,47
+,,65 Years or more,148
+,,No value,10 or fewer
+,,Total,195
+,"PRENTISS, MS",Less than 65 Years,65
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,160
+,"KOOCHICHING, MN",Less than 65 Years,75
+,,65 Years or more,131
+,,No value,10 or fewer
+,,Total,206
+,"GIBSON, TN",Less than 65 Years,213
+,,65 Years or more,317
+,,No value,10 or fewer
+,,Total,530
+,"COLUMBIA, NY",Less than 65 Years,124
+,,65 Years or more,309
+,,No value,10 or fewer
+,,Total,433
+,"IBERIA, LA",Less than 65 Years,84
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,175
+,"CHAVES, NM",Less than 65 Years,37
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,79
+,"HOKE, NC",Less than 65 Years,90
+,,65 Years or more,103
+,,No value,10 or fewer
+,,Total,193
+,"BENTON, MN",Less than 65 Years,58
+,,65 Years or more,114
+,,No value,10 or fewer
+,,Total,172
+,"MADISON, NE",Less than 65 Years,52
+,,65 Years or more,93
+,,No value,10 or fewer
+,,Total,145
+,"MARSHALL, MS",Less than 65 Years,170
+,,65 Years or more,170
+,,No value,10 or fewer
+,,Total,340
+,"LEWIS AND CLARK, MT",Less than 65 Years,64
+,,65 Years or more,149
+,,No value,10 or fewer
+,,Total,213
+,"JEFFERSON DAVIS, LA",Less than 65 Years,113
+,,65 Years or more,124
+,,No value,10 or fewer
+,,Total,237
+,"ONSLOW, NC",Less than 65 Years,125
+,,65 Years or more,124
+,,No value,10 or fewer
+,,Total,249
+,"IONIA, MI",Less than 65 Years,65
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,171
+,"BARNSTABLE, MA",Less than 65 Years,49
+,,65 Years or more,160
+,,No value,10 or fewer
+,,Total,209
+,"YADKIN, NC",Less than 65 Years,54
+,,65 Years or more,119
+,,No value,10 or fewer
+,,Total,173
+,"GRAFTON, NH",Less than 65 Years,55
+,,65 Years or more,117
+,,No value,10 or fewer
+,,Total,172
+,"CASS, MN",Less than 65 Years,45
+,,65 Years or more,118
+,,No value,10 or fewer
+,,Total,163
+,"FAYETTE, TN",Less than 65 Years,76
+,,65 Years or more,142
+,,No value,10 or fewer
+,,Total,218
+,"SCOTT, MS",Less than 65 Years,69
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,139
+,"CAPE MAY, NJ",Less than 65 Years,119
+,,65 Years or more,269
+,,No value,10 or fewer
+,,Total,388
+,"PONTOTOC, MS",Less than 65 Years,107
+,,65 Years or more,148
+,,No value,10 or fewer
+,,Total,255
+,"BRADLEY, TN",Less than 65 Years,105
+,,65 Years or more,135
+,,No value,10 or fewer
+,,Total,240
+,"LAFAYETTE, MS",Less than 65 Years,82
+,,65 Years or more,103
+,,No value,10 or fewer
+,,Total,185
+,"SANDOVAL, NM",Less than 65 Years,54
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,146
+,"HOLMES, MS",Less than 65 Years,67
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,151
+,"LEAKE, MS",Less than 65 Years,62
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,153
+,"KENTON, KY",Less than 65 Years,88
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,164
+,"MILLE LACS, MN",Less than 65 Years,42
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,121
+,"COLUMBUS, NC",Less than 65 Years,67
+,,65 Years or more,112
+,,No value,10 or fewer
+,,Total,179
+,"CLARKE, MS",Less than 65 Years,74
+,,65 Years or more,93
+,,No value,10 or fewer
+,,Total,167
+,"HUNTERDON, NJ",Less than 65 Years,58
+,,65 Years or more,99
+,,No value,10 or fewer
+,,Total,157
+,"NEWTON, MS",Less than 65 Years,95
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,192
+,"HOWARD, MD",Less than 65 Years,99
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,180
+,"PERQUIMANS, NC",Less than 65 Years,61
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,162
+,"CASS, MO",Less than 65 Years,40
+,,65 Years or more,109
+,,No value,10 or fewer
+,,Total,149
+,"ADDISON, VT",Less than 65 Years,36
+,,65 Years or more,117
+,,No value,10 or fewer
+,,Total,153
+,"SEQUATCHIE, TN",Less than 65 Years,67
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,142
+,"INGHAM, MI",Less than 65 Years,61
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,135
+,"NODAWAY, MO",Less than 65 Years,44
+,,65 Years or more,116
+,,No value,10 or fewer
+,,Total,160
+,"EAST FELICIANA, LA",Less than 65 Years,59
+,,65 Years or more,137
+,,No value,10 or fewer
+,,Total,196
+,"CLARK, KY",Less than 65 Years,87
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,145
+,"WALDO, ME",Less than 65 Years,41
+,,65 Years or more,96
+,,No value,10 or fewer
+,,Total,137
+,"UNICOI, TN",Less than 65 Years,37
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,121
+,"GAGE, NE",Less than 65 Years,50
+,,65 Years or more,89
+,,No value,10 or fewer
+,,Total,139
+,"COTTONWOOD, MN",Less than 65 Years,38
+,,65 Years or more,86
+,,No value,10 or fewer
+,,Total,124
+,"ORLEANS, NY",Less than 65 Years,61
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,158
+,"LINCOLN, NC",Less than 65 Years,34
+,,65 Years or more,86
+,,No value,10 or fewer
+,,Total,120
+,"CASS, NE",Less than 65 Years,49
+,,65 Years or more,85
+,,No value,10 or fewer
+,,Total,134
+,"KENT, MD",Less than 65 Years,46
+,,65 Years or more,119
+,,No value,10 or fewer
+,,Total,165
+,"ESTILL, KY",Less than 65 Years,59
+,,65 Years or more,90
+,,No value,10 or fewer
+,,Total,149
+,"BLEDSOE, TN",Less than 65 Years,50
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,138
+,"MARSHALL, KY",Less than 65 Years,50
+,,65 Years or more,89
+,,No value,10 or fewer
+,,Total,139
+,"SCHENECTADY, NY",Less than 65 Years,64
+,,65 Years or more,83
+,,No value,10 or fewer
+,,Total,147
+,"MORRIS, NJ",Less than 65 Years,75
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,186
+,"GRUNDY, MO",Less than 65 Years,62
+,,65 Years or more,68
+,,No value,10 or fewer
+,,Total,130
+,"PENNINGTON, MN",Less than 65 Years,46
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,138
+,"SCOTT, KY",Less than 65 Years,65
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,153
+,"ATLANTIC, NJ",Less than 65 Years,56
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,138
+,"BOURBON, KY",Less than 65 Years,61
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,122
+,"GRAVES, KY",Less than 65 Years,53
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,134
+,"CAMPBELL, KY",Less than 65 Years,66
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,140
+,"SHELBY, KY",Less than 65 Years,69
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,112
+,"HILLSDALE, MI",Less than 65 Years,42
+,,65 Years or more,85
+,,No value,10 or fewer
+,,Total,127
+,"WINDSOR, VT",Less than 65 Years,41
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,123
+,"WARREN, NY",Less than 65 Years,94
+,,65 Years or more,274
+,,No value,10 or fewer
+,,Total,368
+,"SAGADAHOC, ME",Less than 65 Years,49
+,,65 Years or more,107
+,,No value,10 or fewer
+,,Total,156
+,"CLAY, MS",Less than 65 Years,92
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,193
+,"WALTHALL, MS",Less than 65 Years,55
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,125
+,"GREENE, NY",Less than 65 Years,99
+,,65 Years or more,174
+,,No value,10 or fewer
+,,Total,273
+,"PLAQUEMINES, LA",Less than 65 Years,42
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,112
+,"LEE, NC",Less than 65 Years,56
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,140
+,"AVERY, NC",Less than 65 Years,67
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,169
+,"REDWOOD, MN",Less than 65 Years,34
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,110
+,"ASSUMPTION, LA",Less than 65 Years,56
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,111
+,"DYER, TN",Less than 65 Years,138
+,,65 Years or more,209
+,,No value,10 or fewer
+,,Total,347
+,"BOONE, KY",Less than 65 Years,74
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,120
+,"SCHOHARIE, NY",Less than 65 Years,41
+,,65 Years or more,87
+,,No value,10 or fewer
+,,Total,128
+,"MENOMINEE, MI",Less than 65 Years,35
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,112
+,"SAINT CLAIR, MI",Less than 65 Years,51
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,127
+,"WEAKLEY, TN",Less than 65 Years,107
+,,65 Years or more,169
+,,No value,10 or fewer
+,,Total,276
+,"LAWRENCE, MS",Less than 65 Years,28
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,85
+,"RICHMOND, NY",Less than 65 Years,77
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,124
+,"PASSAIC, NJ",Less than 65 Years,60
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,161
+,"FLOYD, KY",Less than 65 Years,50
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,124
+,"HOPKINS, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,25
+,"CASWELL, NC",Less than 65 Years,34
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,103
+,"ROCK, MN",Less than 65 Years,34
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,109
+,"GASTON, NC",Less than 65 Years,50
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,89
+,"JOHNSON, TN",Less than 65 Years,47
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,116
+,"HOUSTON, MN",Less than 65 Years,27
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,104
+,"PINE, MN",Less than 65 Years,26
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,85
+,"GATES, NC",Less than 65 Years,28
+,,65 Years or more,68
+,,No value,10 or fewer
+,,Total,96
+,"PULASKI, MO",Less than 65 Years,46
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,100
+,"ANDREW, MO",Less than 65 Years,29
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,109
+,"HENRY, KY",Less than 65 Years,67
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,128
+,"ITAWAMBA, MS",Less than 65 Years,79
+,,65 Years or more,129
+,,No value,10 or fewer
+,,Total,208
+,"CARROLL, MD",Less than 65 Years,46
+,,65 Years or more,67
+,,No value,10 or fewer
+,,Total,113
+,"POLK, NC",Less than 65 Years,46
+,,65 Years or more,181
+,,No value,10 or fewer
+,,Total,227
+,"ALLEGANY, MD",Less than 65 Years,34
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,84
+,"BUFFALO, NE",Less than 65 Years,45
+,,65 Years or more,133
+,,No value,10 or fewer
+,,Total,178
+,"CRAVEN, NC",Less than 65 Years,46
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,108
+,"JACKSON, MN",Less than 65 Years,21
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,87
+,"LAUREL, KY",Less than 65 Years,51
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,94
+,"SULLIVAN, NH",Less than 65 Years,32
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,101
+,"ROSEAU, MN",Less than 65 Years,52
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,126
+,"LIVINGSTON, MO",Less than 65 Years,31
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,104
+,"WASHINGTON, NC",Less than 65 Years,38
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,94
+,"JONES, MS",Less than 65 Years,34
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,94
+,"CLEARWATER, MN",Less than 65 Years,37
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,88
+,"CATAWBA, NC",Less than 65 Years,42
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,86
+,"NESHOBA, MS",Less than 65 Years,44
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,94
+,"ROCKINGHAM, NH",Less than 65 Years,51
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,106
+,"PERRY, MS",Less than 65 Years,47
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,94
+,"FRANKLIN, KY",Less than 65 Years,43
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,89
+,"OSCEOLA, MI",Less than 65 Years,35
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,94
+,"CECIL, MD",Less than 65 Years,63
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,121
+,"TISHOMINGO, MS",Less than 65 Years,60
+,,65 Years or more,104
+,,No value,10 or fewer
+,,Total,164
+,"TODD, MN",Less than 65 Years,25
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,87
+,"CARLTON, MN",Less than 65 Years,38
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,86
+,"CALHOUN, MS",Less than 65 Years,37
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,100
+,"SAINT BERNARD, LA",Less than 65 Years,45
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,78
+,"YELLOWSTONE, MT",Less than 65 Years,63
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,88
+,"TERREBONNE, LA",Less than 65 Years,57
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,84
+,"FARIBAULT, MN",Less than 65 Years,35
+,,65 Years or more,68
+,,No value,10 or fewer
+,,Total,103
+,"TOMPKINS, NY",Less than 65 Years,34
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,74
+,"VALENCIA, NM",Less than 65 Years,39
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,92
+,"LARUE, KY",Less than 65 Years,30
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,85
+,"MEADE, KY",Less than 65 Years,43
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,97
+,"PANOLA, MS",Less than 65 Years,46
+,,65 Years or more,67
+,,No value,10 or fewer
+,,Total,113
+,"LYON, NV",Less than 65 Years,31
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,86
+,"MCDOWELL, NC",Less than 65 Years,27
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,104
+,"SALINE, NE",Less than 65 Years,49
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,100
+,"WASHINGTON, NY",Less than 65 Years,78
+,,65 Years or more,144
+,,No value,10 or fewer
+,,Total,222
+,"NELSON, KY",Less than 65 Years,29
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,63
+,"SPENCER, KY",Less than 65 Years,44
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,82
+,"KNOX, KY",Less than 65 Years,32
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,93
+,"WEBSTER, MS",Less than 65 Years,76
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,150
+,"HARDEMAN, TN",Less than 65 Years,107
+,,65 Years or more,126
+,,No value,10 or fewer
+,,Total,233
+,"SAINT LOUIS, MO",Less than 65 Years,29
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,81
+,"OSWEGO, NY",Less than 65 Years,25
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,73
+,"MURRAY, MN",Less than 65 Years,18
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,76
+,"MARION, TN",Less than 65 Years,44
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,98
+,"STANLY, NC",Less than 65 Years,41
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,93
+,"COPIAH, MS",Less than 65 Years,34
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,67
+,"TATE, MS",Less than 65 Years,39
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,99
+,"WOODFORD, KY",Less than 65 Years,30
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,70
+,"MERRIMACK, NH",Less than 65 Years,17
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,72
+,"ROCKLAND, NY",Less than 65 Years,32
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,81
+,"POINTE COUPEE, LA",Less than 65 Years,28
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,65
+,"RUTHERFORD, NC",Less than 65 Years,26
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,95
+,"MERRICK, NE",Less than 65 Years,29
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,69
+,"KEMPER, MS",Less than 65 Years,41
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,87
+,"WEBSTER, KY",Less than 65 Years,27
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,50
+,"SURRY, NC",Less than 65 Years,15
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,63
+,"ULSTER, NY",Less than 65 Years,34
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,82
+,"MOREHOUSE, LA",Less than 65 Years,16
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,58
+,"DAKOTA, NE",Less than 65 Years,34
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,76
+,"YALOBUSHA, MS",Less than 65 Years,31
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,71
+,"CAMDEN, NC",Less than 65 Years,24
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,64
+,"COVINGTON, MS",Less than 65 Years,28
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,84
+,"SCOTT, MO",Less than 65 Years,31
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,68
+,"AITKIN, MN",Less than 65 Years,24
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,78
+,"CARVER, MN",Less than 65 Years,22
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,64
+,"SCOTTS BLUFF, NE",Less than 65 Years,58
+,,65 Years or more,134
+,,No value,10 or fewer
+,,Total,192
+,"CHICKASAW, MS",Less than 65 Years,59
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,115
+,"BENTON, TN",Less than 65 Years,91
+,,65 Years or more,113
+,,No value,10 or fewer
+,,Total,204
+,"LAKE, MI",Less than 65 Years,30
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,66
+,"CARTERET, NC",Less than 65 Years,20
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,71
+,"RICHLAND, MT",Less than 65 Years,29
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,69
+,"BALLARD, KY",Less than 65 Years,31
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,66
+,"SAINT JAMES, LA",Less than 65 Years,35
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,80
+,"DAVIDSON, TN",Less than 65 Years,31
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,59
+,"SIMPSON, MS",Less than 65 Years,34
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,68
+,"ANDERSON, KY",Less than 65 Years,33
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,65
+,"GARRARD, KY",Less than 65 Years,40
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,69
+,"ISANTI, MN",Less than 65 Years,37
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,60
+,"KENNEBEC, ME",Less than 65 Years,16
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,52
+,"ASHE, NC",Less than 65 Years,33
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,79
+,"TIPPAH, MS",Less than 65 Years,32
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,63
+,"LIVINGSTON, KY",Less than 65 Years,17
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,52
+,"MADISON, NY",Less than 65 Years,19
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,53
+,"EATON, MI",Less than 65 Years,30
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,58
+,"MARSHALL, MN",Less than 65 Years,24
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,57
+,"AMITE, MS",Less than 65 Years,23
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,73
+,"ORANGE, VT",Less than 65 Years,26
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,62
+,"CAYUGA, NY",Less than 65 Years,21
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,50
+,"LINCOLN, MS",Less than 65 Years,13
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,46
+,"LAPEER, MI",Less than 65 Years,36
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,72
+,"BENTON, MS",Less than 65 Years,41
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,68
+,"OKTIBBEHA, MS",Less than 65 Years,26
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,63
+,"KNOX, TN",Less than 65 Years,30
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,64
+,"MORRISON, MN",Less than 65 Years,18
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,64
+,"GRANVILLE, NC",Less than 65 Years,29
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,55
+,"LAUDERDALE, TN",Less than 65 Years,39
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,83
+,"NORMAN, MN",Less than 65 Years,26
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,48
+,"GEORGE, MS",Less than 65 Years,32
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,70
+,"HANCOCK, TN",Less than 65 Years,27
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,44
+,"STONE, MS",Less than 65 Years,24
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,50
+,"RICHLAND, LA",Less than 65 Years,24
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,53
+,"WARREN, MS",Less than 65 Years,32
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,61
+,"FRANKLIN, VT",Less than 65 Years,25
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,51
+,"MOORE, NC",Less than 65 Years,28
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,60
+,"GRANT, MN",Less than 65 Years,16
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,45
+,"CLINTON, MO",Less than 65 Years,17
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,49
+,"MAHNOMEN, MN",Less than 65 Years,33
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,57
+,"CHESTER, TN",Less than 65 Years,51
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,142
+,"LYON, KY",Less than 65 Years,13
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,44
+,"PULASKI, KY",Less than 65 Years,15
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,29
+,"ALCORN, MS",Less than 65 Years,32
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,66
+,"JEFFERSON DAVIS, MS",Less than 65 Years,20
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,45
+,"CUMBERLAND, NJ",Less than 65 Years,31
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,54
+,"TRANSYLVANIA, NC",Less than 65 Years,15
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,49
+,"HUBBARD, MN",Less than 65 Years,11
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,46
+,"UNION, LA",Less than 65 Years,19
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,47
+,"FULTON, NY",Less than 65 Years,24
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,59
+,"TUNICA, MS",Less than 65 Years,26
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,51
+,"LYON, MN",Less than 65 Years,18
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,49
+,"TYRRELL, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,37
+,"SAINT MARYS, MD",Less than 65 Years,18
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,48
+,"MONTGOMERY, NY",Less than 65 Years,23
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,46
+,"NOXUBEE, MS",Less than 65 Years,29
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,54
+,"CARROLL, MS",Less than 65 Years,21
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,52
+,"CHEYENNE, NE",Less than 65 Years,23
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,68
+,"CROCKETT, TN",Less than 65 Years,41
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,120
+,"DUTCHESS, NY",Less than 65 Years,26
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,41
+,"SALEM, NJ",Less than 65 Years,22
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,40
+,"SILVER BOW, MT",Less than 65 Years,24
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,45
+,"JACKSON, KY",Less than 65 Years,20
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,37
+,"SUSSEX, NJ",Less than 65 Years,19
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,43
+,"CLEVELAND, NC",Less than 65 Years,25
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,39
+,"WABASHA, MN",Less than 65 Years,11
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,43
+,"WEST FELICIANA, LA",Less than 65 Years,15
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,39
+,"BRECKINRIDGE, KY",Less than 65 Years,17
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,37
+,"KITTSON, MN",Less than 65 Years,15
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,47
+,"PERSON, NC",Less than 65 Years,23
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,41
+,"YELLOW MEDICINE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,28
+,"RHEA, TN",Less than 65 Years,16
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,37
+,"SAINT HELENA, LA",Less than 65 Years,12
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,34
+,"GENTRY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,48
+,"CARSON CITY, NV",Less than 65 Years,18
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,34
+,"LETCHER, KY",Less than 65 Years,15
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,43
+,"MEEKER, MN",Less than 65 Years,11
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,34
+,"CRAWFORD, MO",Less than 65 Years,12
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,34
+,"BOYLE, KY",Less than 65 Years,15
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,33
+,"VANCE, NC",Less than 65 Years,18
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,32
+,"HANCOCK, ME",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,30
+,"WILKES, NC",Less than 65 Years,16
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,38
+,"WINONA, MN",Less than 65 Years,20
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,37
+,"STODDARD, MO",Less than 65 Years,13
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,33
+,"SENECA, NY",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,30
+,"CALVERT, MD",Less than 65 Years,17
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,44
+,"CARLISLE, KY",Less than 65 Years,11
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,37
+,"EVANGELINE, LA",Less than 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"DOUGLAS, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,31
+,"LINCOLN, LA",Less than 65 Years,14
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,40
+,"SANTA FE, NM",Less than 65 Years,14
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,39
+,"WARREN, NC",Less than 65 Years,16
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,35
+,"DAVIESS, KY",Less than 65 Years,11
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,23
+,"WYOMING, NY",Less than 65 Years,11
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,35
+,"TRIMBLE, KY",Less than 65 Years,26
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,49
+,"CATTARAUGUS, NY",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,25
+,"DEKALB, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,40
+,"BERKSHIRE, MA",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,27
+,"LAKE, TN",Less than 65 Years,22
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,66
+,"MERCER, KY",Less than 65 Years,15
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,31
+,"CADDO, LA",Less than 65 Years,17
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,28
+,"WADENA, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,27
+,"CHURCHILL, NV",Less than 65 Years,12
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,32
+,"FULTON, KY",Less than 65 Years,18
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,46
+,"LEE, KY",Less than 65 Years,13
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,26
+,"GRAYSON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,21
+,"HAMPSHIRE, MA",Less than 65 Years,22
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,41
+,"MCCREARY, KY",Less than 65 Years,12
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,31
+,"DOUGLAS, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,34
+,"MARIES, MO",Less than 65 Years,11
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,35
+,"RAPIDES, LA",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"SWIFT, MN",Less than 65 Years,12
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,30
+,"BOLLINGER, MO",Less than 65 Years,19
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,33
+,"HUMPHREYS, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,24
+,"CALDWELL, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,23
+,"DENT, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,28
+,"HYDE, NC",Less than 65 Years,12
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,32
+,"POWELL, KY",Less than 65 Years,12
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,25
+,"GRUNDY, TN",Less than 65 Years,19
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,31
+,"BATH, KY",Less than 65 Years,13
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,27
+,"RENVILLE, MN",Less than 65 Years,13
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,30
+,"POLK, TN",Less than 65 Years,21
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,57
+,"RUTLAND, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,34
+,"CHEROKEE, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,42
+,"FILLMORE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,21
+,"JASPER, MS",Less than 65 Years,13
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,35
+,"SAINT CHARLES, MO",Less than 65 Years,12
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,29
+,"JOHNSON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,27
+,"SCHUYLER, NY",Less than 65 Years,13
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,28
+,"DUNKLIN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,38
+,"WINDHAM, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,27
+,"SMITH, MS",Less than 65 Years,14
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,33
+,"GRAND ISLE, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,26
+,"HOLT, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,23
+,"MONTGOMERY, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,24
+,"RICE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,28
+,"HENDERSON, TN",Less than 65 Years,37
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,73
+,"MONTGOMERY, MS",Less than 65 Years,16
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,29
+,"ELKO, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,24
+,"WEST CARROLL, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,23
+,"GREENE, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"YATES, NY",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,21
+,"SAGINAW, MI",Less than 65 Years,13
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,24
+,"WILKIN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,25
+,"DODGE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,27
+,"NYE, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,34
+,"OLMSTED, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,26
+,"WILLIAMSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,23
+,"CALLOWAY, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,24
+,"RED LAKE, MN",Less than 65 Years,13
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,27
+,"BEAUREGARD, LA",Less than 65 Years,16
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,54
+,"STRAFFORD, NH",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,21
+,"ADAMS, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,17
+,"FRANKLIN, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,25
+,"GREENE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,23
+,"RUTHERFORD, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"SHIAWASSEE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,21
+,"HAMILTON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,26
+,"HAYWOOD, TN",Less than 65 Years,19
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,52
+,"LAFAYETTE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,27
+,"LAMOILLE, VT",Less than 65 Years,13
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,26
+,"SAUNDERS, NE",Less than 65 Years,16
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,27
+,"TETON, MT",Less than 65 Years,12
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,38
+,"JEFFERSON, NY",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,22
+,"LINCOLN, KY",Less than 65 Years,12
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,26
+,"MADISON, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,20
+,"HARLAN, KY",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"HENRY, TN",Less than 65 Years,24
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,41
+,"CARROLL, KY",Less than 65 Years,15
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,26
+,"CLAY, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"GRAND TRAVERSE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,24
+,"SEWARD, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,23
+,"TRAVERSE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,15
+,"JOHNSON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"MONTGOMERY, TN",Less than 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"MERCER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,24
+,"ROCKCASTLE, KY",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"LEFLORE, MS",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"SOMERSET, ME",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"CUMBERLAND, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,24
+,"MCNAIRY, TN",Less than 65 Years,19
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,58
+,"BOYD, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,22
+,"SCOTLAND, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,19
+,"WASHINGTON, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"WINSTON, MS",Less than 65 Years,11
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,26
+,"HARRISON, KY",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"CASEY, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,19
+,"CRITTENDEN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"FLEMING, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,20
+,"HAYWOOD, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,18
+,"MCMINN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"PARK, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"SUMNER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"WASHINGTON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,20
+,"BREATHITT, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,20
+,"AVOYELLES, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,17
+,"MARTIN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"KANABEC, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,12
+,"TEXAS, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"DAVIESS, MO",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"HAMBLEN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"JONES, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"MAGOFFIN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"PIERCE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"HART, KY",Less than 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"CHOCTAW, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,19
+,"CLINTON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PIPESTONE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"ALLEN, LA",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"CHOUTEAU, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,30
+,"ISABELLA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CUSTER, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEMISCOT, MO",Less than 65 Years,20
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,35
+,"WILKINSON, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"CONCORDIA, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"TALLAHATCHIE, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CALDWELL, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"GRANT, KY",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"TUSCOLA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,15
+,"BOONE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DIXON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"DONA ANA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"MACON, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,21
+,"BELL, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,20
+,"MANISTEE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MASON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"VERNON, LA",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"CAMPBELL, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"FRANKLIN, MA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"JACKSON, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,14
+,"BAY, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"BOLIVAR, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BOSSIER, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCLEOD, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WARREN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CHRISTIAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREENUP, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MISSOULA, MT",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"WEBSTER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,16
+,"CALDWELL, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,17
+,"KNOTT, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,15
+,"TAYLOR, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLOUNT, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"BLUE EARTH, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEVIER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"BIG STONE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEIGS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,21
+,"SAINT LOUIS CITY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"ADAIR, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"BELKNAP, NH",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"DAWSON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"PERRY, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COAHOMA, MS",Less than 65 Years,11
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,24
+,"DECATUR, TN",Less than 65 Years,14
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,38
+,"JEFFERSON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"SANILAC, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALEDONIA, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"COOS, NH",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"RICHMOND, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"TORRANCE, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CARTER, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LESLIE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MUHLENBERG, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUNFLOWER, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COCKE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MITCHELL, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"SAINT FRANCOIS, MO",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CLINTON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,18
+,"WILSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ANSON, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"BENNINGTON, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,15
+,"BROWN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"GREEN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,13
+,"OTOE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PENDLETON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"PUTNAM, NY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CLAIBORNE, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLATHEAD, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MAURY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"PLATTE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"VAN BUREN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"HICKMAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"KEITH, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MARQUETTE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,19
+,"NEW MADRID, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"RAY, MO",Less than 65 Years,17
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,31
+,"CEDAR, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"JASPER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"JEFFERSON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MARION, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"FRANKLIN, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"LINN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIDLAND, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"NANCE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALEXANDER, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BATES, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"GOODHUE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"QUITMAN, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, NY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"PAMLICO, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDERSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AROOSTOOK, ME",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHIPPEWA, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STANTON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"RUSSELL, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MISSISSIPPI, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LE SUEUR, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROWAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WASHINGTON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MARTIN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HURON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORLEANS, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"ROSCOMMON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"FRANKLIN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IOSCO, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWEN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OWSLEY, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WORTH, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRACKEN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAINGER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOUDON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCKINLEY, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YANCEY, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMMET, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMDEN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CIBOLA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEXFORD, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANTELOPE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEBOYGAN, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRONTIER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GASCONADE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"GLACIER, MT",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"LAKE OF THE WOODS, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"LEWIS, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"ROBERTSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, ME",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,12
+,"BARREN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CURRY, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"HARDIN, TN",Less than 65 Years,11
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,22
+,"JEFFERSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NICHOLAS, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHIPPEWA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKINSON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARRISON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"LAKE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NATCHITOCHES, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PISCATAQUIS, ME",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIBLEY, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDDY, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"JEFFERSON, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TRIGG, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YORK, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHRISTIAN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TANEY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLEVOIX, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HUMBOLDT, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCLEAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENIFEE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHARKEY, MS",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENTON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUMING, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"QUAY, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEGHANY, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOK, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRATIOT, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTMORENCY, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NICOLLET, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THURSTON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUKES, MA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREEBORN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HILL, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"LOGAN, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTERO, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POPE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ALPENA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANTRIM, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLIOTT, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAC QUI PARLE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OHIO, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALLATIN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA SALLE, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGEMAW, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POLK, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STONE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOLFE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIG HORN, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CATAHOULA, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOOKER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOX BUTTE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROADWATER, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLFAX, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLFAX, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEUEL, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EAST CARROLL, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRESQUE ISLE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIO ARRIBA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TENSAS, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLADWIN, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LACLEDE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHELPS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RAVALLI, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RED WILLOW, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLIVAN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARENAC, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENZIE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOLT, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMPHREYS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KALKASKA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NANTUCKET, MA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NUCKOLLS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PETTIS, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PONDERA, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROOSEVELT, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STOREY, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALGER, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAIBORNE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDMONSON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEELANAU, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MISSAUKEE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORRILL, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"THOMAS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VERNON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANCOCK, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOS ALAMOS, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOWER, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OTSEGO, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEELE, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWAIN, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAOS, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALCONA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAWFORD, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FERGUS, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCDONALD, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RIPLEY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SABINE, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINT CLAIR, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SOCORRO, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WATONWAN, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATCHISON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARRY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMERON, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARBON, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEER LODGE, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUGHTON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINERAL, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN MIGUEL, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COOPER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWSON, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FILLMORE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FURNAS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAKE, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANDER, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTSON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAINTE GENEVIEVE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERMAN, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STILLWATER, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAIR, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVERHEAD, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIENVILLE, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHASE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEMAHA, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSCODA, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERSHING, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE PINE, NV",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURT, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHERRY, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DOUGLAS, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMILTON, NY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KEARNEY, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PAWNEE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROSEBUD, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOONE, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEATHAM, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALLAS, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWES, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FENTRESS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HICKORY, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERKINS, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHOOLCRAFT, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SIMPSON, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOOLE, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINN, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUTLER, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAHAM, NC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREELEY, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWELL, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUDITH BASIN, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUCE, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OSAGE, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OVERTON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROOSEVELT, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASECA, MN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WEBSTER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOYD, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARTER, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LUNA, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACKINAC, MI",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"METCALFE, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OREGON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RICHARDSON, NE",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHINGTON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AUDRAIN, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARTON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAIBORNE, LA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, NM",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, KY",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, MO",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MEAGHER, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PHILLIPS, MT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 65 Years,4435
+,,65 Years or more,6701
+,,No value,10 or fewer
+,,Total,11136
+,Total,Less than 65 Years,123848
+,,65 Years or more,192555
+,,No value,10 or fewer
+,,Total,316403

--- a/data/epic/raw/staging/D02c_Falls_EDvisits_CountiesND_VA_Year_Age.csv
+++ b/data/epic/raw/staging/D02c_Falls_EDvisits_CountiesND_VA_Year_Age.csv
@@ -1,0 +1,11462 @@
+﻿Session Title,Falls in ND-VA,,
+Session Description,county level by year,,
+Session ID,2748483,,
+Data Model,ED Encounters,,
+Population Base,All ED Encounters,,
+Population Criteria Filters: These criteria are a summary and do not fully reflect the content of the exported session.,State of Residence (U.S.): ND-VA,ED Diagnoses: Fall,
+Session Date Range,1/1/2023 - 7/17/2025 (Based On Arrival Date),,
+Measure,Number of ED Encounters,,
+Export User,Stephanie Perniciaro,,
+Date of Export,8/8/2025,,
+,,,
+,,,
+,,,Number of ED Encounters
+Year,County of Residence,Age at Time of Visit,
+Jan 1 – Dec 31 2023,"CUYAHOGA, OH",Less than 65 Years,9181
+,,65 Years or more,9408
+,,No value,10 or fewer
+,,Total,18589
+,"TARRANT, TX",Less than 65 Years,9996
+,,65 Years or more,10822
+,,No value,10 or fewer
+,,Total,20818
+,"FRANKLIN, OH",Less than 65 Years,7235
+,,65 Years or more,9486
+,,No value,10 or fewer
+,,Total,16721
+,"DALLAS, TX",Less than 65 Years,7208
+,,65 Years or more,8669
+,,No value,10 or fewer
+,,Total,15877
+,"HARRIS, TX",Less than 65 Years,4074
+,,65 Years or more,4555
+,,No value,10 or fewer
+,,Total,8629
+,"PHILADELPHIA, PA",Less than 65 Years,5613
+,,65 Years or more,5438
+,,No value,10 or fewer
+,,Total,11052
+,"HAMILTON, OH",Less than 65 Years,3922
+,,65 Years or more,7265
+,,No value,10 or fewer
+,,Total,11187
+,"MONTGOMERY, OH",Less than 65 Years,4260
+,,65 Years or more,6316
+,,No value,10 or fewer
+,,Total,10576
+,"LEHIGH, PA",Less than 65 Years,2919
+,,65 Years or more,4595
+,,No value,10 or fewer
+,,Total,7514
+,"NORTHAMPTON, PA",Less than 65 Years,2346
+,,65 Years or more,4347
+,,No value,10 or fewer
+,,Total,6693
+,"TULSA, OK",Less than 65 Years,2382
+,,65 Years or more,4296
+,,No value,10 or fewer
+,,Total,6678
+,"GREENVILLE, SC",Less than 65 Years,2117
+,,65 Years or more,3496
+,,No value,10 or fewer
+,,Total,5613
+,"YORK, PA",Less than 65 Years,1869
+,,65 Years or more,3823
+,,No value,10 or fewer
+,,Total,5692
+,"SPARTANBURG, SC",Less than 65 Years,2172
+,,65 Years or more,3373
+,,No value,10 or fewer
+,,Total,5545
+,"ALLEGHENY, PA",Less than 65 Years,1564
+,,65 Years or more,3438
+,,No value,10 or fewer
+,,Total,5002
+,"SUMMIT, OH",Less than 65 Years,1499
+,,65 Years or more,3214
+,,No value,10 or fewer
+,,Total,4713
+,"VIRGINIA BEACH CITY, VA",Less than 65 Years,1770
+,,65 Years or more,3840
+,,No value,10 or fewer
+,,Total,5610
+,"BUTLER, OH",Less than 65 Years,1935
+,,65 Years or more,3374
+,,No value,10 or fewer
+,,Total,5309
+,"FAIRFAX, VA",Less than 65 Years,1768
+,,65 Years or more,3109
+,,No value,10 or fewer
+,,Total,4877
+,"MONTGOMERY, PA",Less than 65 Years,1226
+,,65 Years or more,3551
+,,No value,10 or fewer
+,,Total,4777
+,"LORAIN, OH",Less than 65 Years,1794
+,,65 Years or more,2454
+,,No value,10 or fewer
+,,Total,4248
+,"SHELBY, TN",Less than 65 Years,1252
+,,65 Years or more,1744
+,,No value,10 or fewer
+,,Total,2996
+,"COLLIN, TX",Less than 65 Years,1566
+,,65 Years or more,2946
+,,No value,10 or fewer
+,,Total,4512
+,"CHESTER, PA",Less than 65 Years,1191
+,,65 Years or more,3189
+,,No value,10 or fewer
+,,Total,4380
+,"DELAWARE, PA",Less than 65 Years,1324
+,,65 Years or more,2927
+,,No value,10 or fewer
+,,Total,4251
+,"BUCKS, PA",Less than 65 Years,1139
+,,65 Years or more,3000
+,,No value,10 or fewer
+,,Total,4139
+,"CHARLESTON, SC",Less than 65 Years,1378
+,,65 Years or more,2627
+,,No value,10 or fewer
+,,Total,4005
+,"LUCAS, OH",Less than 65 Years,1867
+,,65 Years or more,2017
+,,No value,10 or fewer
+,,Total,3884
+,"LANCASTER, PA",Less than 65 Years,1081
+,,65 Years or more,2562
+,,No value,10 or fewer
+,,Total,3643
+,"DENTON, TX",Less than 65 Years,1362
+,,65 Years or more,2228
+,,No value,10 or fewer
+,,Total,3590
+,"JOHNSON, TX",Less than 65 Years,1604
+,,65 Years or more,1886
+,,No value,10 or fewer
+,,Total,3490
+,"BELL, TX",Less than 65 Years,1628
+,,65 Years or more,1455
+,,No value,10 or fewer
+,,Total,3083
+,"LAKE, OH",Less than 65 Years,675
+,,65 Years or more,1143
+,,No value,10 or fewer
+,,Total,1818
+,"MULTNOMAH, OR",Less than 65 Years,1384
+,,65 Years or more,1747
+,,No value,10 or fewer
+,,Total,3131
+,"MAHONING, OH",Less than 65 Years,1103
+,,65 Years or more,2217
+,,No value,10 or fewer
+,,Total,3320
+,"WARREN, OH",Less than 65 Years,875
+,,65 Years or more,2258
+,,No value,10 or fewer
+,,Total,3133
+,"RICHLAND, SC",Less than 65 Years,1201
+,,65 Years or more,1466
+,,No value,10 or fewer
+,,Total,2667
+,"LOUDOUN, VA",Less than 65 Years,1215
+,,65 Years or more,1774
+,,No value,10 or fewer
+,,Total,2989
+,"BEXAR, TX",Less than 65 Years,1340
+,,65 Years or more,1571
+,,No value,10 or fewer
+,,Total,2911
+,"CLERMONT, OH",Less than 65 Years,948
+,,65 Years or more,1893
+,,No value,10 or fewer
+,,Total,2841
+,"CLARK, OH",Less than 65 Years,1124
+,,65 Years or more,1649
+,,No value,10 or fewer
+,,Total,2773
+,"ANDERSON, SC",Less than 65 Years,895
+,,65 Years or more,1698
+,,No value,10 or fewer
+,,Total,2593
+,"MONTGOMERY, TX",Less than 65 Years,708
+,,65 Years or more,1249
+,,No value,10 or fewer
+,,Total,1957
+,"NEWPORT NEWS CITY, VA",Less than 65 Years,1118
+,,65 Years or more,1492
+,,No value,10 or fewer
+,,Total,2610
+,"CHESAPEAKE CITY, VA",Less than 65 Years,826
+,,65 Years or more,1736
+,,No value,10 or fewer
+,,Total,2562
+,"SULLIVAN, TN",Less than 65 Years,1025
+,,65 Years or more,1780
+,,No value,10 or fewer
+,,Total,2805
+,"MEDINA, OH",Less than 65 Years,965
+,,65 Years or more,1524
+,,No value,10 or fewer
+,,Total,2489
+,"GREENE, OH",Less than 65 Years,917
+,,65 Years or more,1737
+,,No value,10 or fewer
+,,Total,2654
+,"NORFOLK CITY, VA",Less than 65 Years,1197
+,,65 Years or more,1447
+,,No value,10 or fewer
+,,Total,2644
+,"FORT BEND, TX",Less than 65 Years,575
+,,65 Years or more,1028
+,,No value,10 or fewer
+,,Total,1603
+,"PRINCE WILLIAM, VA",Less than 65 Years,1066
+,,65 Years or more,1296
+,,No value,10 or fewer
+,,Total,2362
+,"DELAWARE, OH",Less than 65 Years,707
+,,65 Years or more,1731
+,,No value,10 or fewer
+,,Total,2438
+,"ELLIS, TX",Less than 65 Years,861
+,,65 Years or more,1629
+,,No value,10 or fewer
+,,Total,2490
+,"DESCHUTES, OR",Less than 65 Years,814
+,,65 Years or more,1660
+,,No value,10 or fewer
+,,Total,2474
+,"MCLENNAN, TX",Less than 65 Years,1098
+,,65 Years or more,1289
+,,No value,10 or fewer
+,,Total,2387
+,"HAMILTON, TN",Less than 65 Years,950
+,,65 Years or more,1229
+,,No value,10 or fewer
+,,Total,2179
+,"FRANKLIN, PA",Less than 65 Years,781
+,,65 Years or more,1507
+,,No value,10 or fewer
+,,Total,2288
+,"ERIE, PA",Less than 65 Years,883
+,,65 Years or more,1345
+,,No value,10 or fewer
+,,Total,2228
+,"HENRICO, VA",Less than 65 Years,815
+,,65 Years or more,1252
+,,No value,10 or fewer
+,,Total,2067
+,"BERKS, PA",Less than 65 Years,1002
+,,65 Years or more,1244
+,,No value,10 or fewer
+,,Total,2246
+,"SCHUYLKILL, PA",Less than 65 Years,692
+,,65 Years or more,1249
+,,No value,10 or fewer
+,,Total,1941
+,"MONROE, PA",Less than 65 Years,788
+,,65 Years or more,1003
+,,No value,10 or fewer
+,,Total,1791
+,"LICKING, OH",Less than 65 Years,701
+,,65 Years or more,1383
+,,No value,10 or fewer
+,,Total,2084
+,"MIAMI, OH",Less than 65 Years,777
+,,65 Years or more,1253
+,,No value,10 or fewer
+,,Total,2030
+,"DAUPHIN, PA",Less than 65 Years,795
+,,65 Years or more,1023
+,,No value,10 or fewer
+,,Total,1818
+,"FLORENCE, SC",Less than 65 Years,785
+,,65 Years or more,1094
+,,No value,10 or fewer
+,,Total,1879
+,"FAYETTE, PA",Less than 65 Years,785
+,,65 Years or more,1066
+,,No value,10 or fewer
+,,Total,1851
+,"CHESTERFIELD, VA",Less than 65 Years,696
+,,65 Years or more,1147
+,,No value,10 or fewer
+,,Total,1843
+,"TRUMBULL, OH",Less than 65 Years,652
+,,65 Years or more,1044
+,,No value,10 or fewer
+,,Total,1696
+,"CUMBERLAND, PA",Less than 65 Years,499
+,,65 Years or more,1318
+,,No value,10 or fewer
+,,Total,1817
+,"RICHLAND, OH",Less than 65 Years,535
+,,65 Years or more,1123
+,,No value,10 or fewer
+,,Total,1658
+,"LINN, OR",Less than 65 Years,547
+,,65 Years or more,1121
+,,No value,10 or fewer
+,,Total,1668
+,"HAMPTON CITY, VA",Less than 65 Years,702
+,,65 Years or more,952
+,,No value,10 or fewer
+,,Total,1654
+,"CHITTENDEN, VT",Less than 65 Years,515
+,,65 Years or more,1100
+,,No value,10 or fewer
+,,Total,1615
+,"WESTMORELAND, PA",Less than 65 Years,491
+,,65 Years or more,1093
+,,No value,10 or fewer
+,,Total,1584
+,"CARBON, PA",Less than 65 Years,592
+,,65 Years or more,966
+,,No value,10 or fewer
+,,Total,1558
+,"HORRY, SC",Less than 65 Years,413
+,,65 Years or more,1043
+,,No value,10 or fewer
+,,Total,1456
+,"KAUFMAN, TX",Less than 65 Years,727
+,,65 Years or more,824
+,,No value,10 or fewer
+,,Total,1551
+,"TRAVIS, TX",Less than 65 Years,596
+,,65 Years or more,958
+,,No value,10 or fewer
+,,Total,1554
+,"ARLINGTON, VA",Less than 65 Years,546
+,,65 Years or more,978
+,,No value,10 or fewer
+,,Total,1524
+,"STARK, OH",Less than 65 Years,437
+,,65 Years or more,874
+,,No value,10 or fewer
+,,Total,1311
+,"PORTAGE, OH",Less than 65 Years,364
+,,65 Years or more,681
+,,No value,10 or fewer
+,,Total,1045
+,"BERKELEY, SC",Less than 65 Years,599
+,,65 Years or more,800
+,,No value,10 or fewer
+,,Total,1399
+,"JAMES CITY, VA",Less than 65 Years,384
+,,65 Years or more,1098
+,,No value,10 or fewer
+,,Total,1482
+,"PARKER, TX",Less than 65 Years,668
+,,65 Years or more,847
+,,No value,10 or fewer
+,,Total,1515
+,"PICKENS, SC",Less than 65 Years,523
+,,65 Years or more,820
+,,No value,10 or fewer
+,,Total,1343
+,"CASS, ND",Less than 65 Years,650
+,,65 Years or more,775
+,,No value,10 or fewer
+,,Total,1425
+,"CLACKAMAS, OR",Less than 65 Years,446
+,,65 Years or more,1022
+,,No value,10 or fewer
+,,Total,1468
+,"SMITH, TX",Less than 65 Years,554
+,,65 Years or more,879
+,,No value,10 or fewer
+,,Total,1433
+,"WILLIAMSON, TX",Less than 65 Years,448
+,,65 Years or more,890
+,,No value,10 or fewer
+,,Total,1338
+,"HENDERSON, TX",Less than 65 Years,584
+,,65 Years or more,847
+,,No value,10 or fewer
+,,Total,1431
+,"WASHINGTON, TN",Less than 65 Years,485
+,,65 Years or more,951
+,,No value,10 or fewer
+,,Total,1436
+,"RICHMOND CITY, VA",Less than 65 Years,692
+,,65 Years or more,503
+,,No value,10 or fewer
+,,Total,1195
+,"OKLAHOMA, OK",Less than 65 Years,425
+,,65 Years or more,440
+,,No value,10 or fewer
+,,Total,865
+,"SUFFOLK CITY, VA",Less than 65 Years,512
+,,65 Years or more,772
+,,No value,10 or fewer
+,,Total,1284
+,"MARION, OH",Less than 65 Years,488
+,,65 Years or more,771
+,,No value,10 or fewer
+,,Total,1259
+,"LUZERNE, PA",Less than 65 Years,434
+,,65 Years or more,634
+,,No value,10 or fewer
+,,Total,1068
+,"FAIRFIELD, OH",Less than 65 Years,411
+,,65 Years or more,663
+,,No value,10 or fewer
+,,Total,1074
+,"MINNEHAHA, SD",Less than 65 Years,487
+,,65 Years or more,618
+,,No value,10 or fewer
+,,Total,1105
+,"LEBANON, PA",Less than 65 Years,374
+,,65 Years or more,772
+,,No value,10 or fewer
+,,Total,1146
+,"MUSKOGEE, OK",Less than 65 Years,451
+,,65 Years or more,707
+,,No value,10 or fewer
+,,Total,1158
+,"ALBEMARLE, VA",Less than 65 Years,276
+,,65 Years or more,832
+,,No value,10 or fewer
+,,Total,1108
+,"ADAMS, PA",Less than 65 Years,336
+,,65 Years or more,717
+,,No value,10 or fewer
+,,Total,1053
+,"WASHINGTON, PA",Less than 65 Years,335
+,,65 Years or more,710
+,,No value,10 or fewer
+,,Total,1045
+,"ALLEN, OH",Less than 65 Years,446
+,,65 Years or more,715
+,,No value,10 or fewer
+,,Total,1161
+,"FREDERICK, VA",Less than 65 Years,119
+,,65 Years or more,289
+,,No value,10 or fewer
+,,Total,408
+,"GEAUGA, OH",Less than 65 Years,211
+,,65 Years or more,487
+,,No value,10 or fewer
+,,Total,698
+,"WASHINGTON, OR",Less than 65 Years,372
+,,65 Years or more,648
+,,No value,10 or fewer
+,,Total,1020
+,"CHEROKEE, SC",Less than 65 Years,456
+,,65 Years or more,608
+,,No value,10 or fewer
+,,Total,1064
+,"PORTSMOUTH CITY, VA",Less than 65 Years,457
+,,65 Years or more,504
+,,No value,10 or fewer
+,,Total,961
+,"LINCOLN, OR",Less than 65 Years,301
+,,65 Years or more,711
+,,No value,10 or fewer
+,,Total,1012
+,"MARION, OR",Less than 65 Years,355
+,,65 Years or more,449
+,,No value,10 or fewer
+,,Total,804
+,"GREENWOOD, SC",Less than 65 Years,404
+,,65 Years or more,637
+,,No value,10 or fewer
+,,Total,1041
+,"ROCKWALL, TX",Less than 65 Years,324
+,,65 Years or more,628
+,,No value,10 or fewer
+,,Total,952
+,"SALT LAKE, UT",Less than 65 Years,449
+,,65 Years or more,526
+,,No value,10 or fewer
+,,Total,975
+,"ROGERS, OK",Less than 65 Years,283
+,,65 Years or more,636
+,,No value,10 or fewer
+,,Total,919
+,"COOS, OR",Less than 65 Years,262
+,,65 Years or more,574
+,,No value,10 or fewer
+,,Total,836
+,"WASHINGTON, VA",Less than 65 Years,305
+,,65 Years or more,677
+,,No value,10 or fewer
+,,Total,982
+,"GRAND FORKS, ND",Less than 65 Years,447
+,,65 Years or more,474
+,,No value,10 or fewer
+,,Total,921
+,"HAWKINS, TN",Less than 65 Years,381
+,,65 Years or more,563
+,,No value,10 or fewer
+,,Total,944
+,"TOM GREEN, TX",Less than 65 Years,406
+,,65 Years or more,528
+,,No value,10 or fewer
+,,Total,934
+,"YORK, VA",Less than 65 Years,255
+,,65 Years or more,620
+,,No value,10 or fewer
+,,Total,875
+,"OCONEE, SC",Less than 65 Years,274
+,,65 Years or more,539
+,,No value,10 or fewer
+,,Total,813
+,"GREENE, TN",Less than 65 Years,294
+,,65 Years or more,578
+,,No value,10 or fewer
+,,Total,872
+,"HANOVER, VA",Less than 65 Years,187
+,,65 Years or more,581
+,,No value,10 or fewer
+,,Total,768
+,"ALEXANDRIA CITY, VA",Less than 65 Years,329
+,,65 Years or more,460
+,,No value,10 or fewer
+,,Total,789
+,"PICKAWAY, OH",Less than 65 Years,290
+,,65 Years or more,496
+,,No value,10 or fewer
+,,Total,786
+,"LEXINGTON, SC",Less than 65 Years,409
+,,65 Years or more,394
+,,No value,10 or fewer
+,,Total,803
+,"ATHENS, OH",Less than 65 Years,342
+,,65 Years or more,558
+,,No value,10 or fewer
+,,Total,900
+,"NUECES, TX",Less than 65 Years,702
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,727
+,"BURNET, TX",Less than 65 Years,270
+,,65 Years or more,514
+,,No value,10 or fewer
+,,Total,784
+,"PREBLE, OH",Less than 65 Years,303
+,,65 Years or more,525
+,,No value,10 or fewer
+,,Total,828
+,"BENTON, OR",Less than 65 Years,254
+,,65 Years or more,506
+,,No value,10 or fewer
+,,Total,760
+,"LANCASTER, SC",Less than 65 Years,301
+,,65 Years or more,427
+,,No value,10 or fewer
+,,Total,728
+,"POTTER, TX",Less than 65 Years,252
+,,65 Years or more,423
+,,No value,10 or fewer
+,,Total,675
+,"ASHTABULA, OH",Less than 65 Years,115
+,,65 Years or more,182
+,,No value,10 or fewer
+,,Total,297
+,"RANDALL, TX",Less than 65 Years,218
+,,65 Years or more,432
+,,No value,10 or fewer
+,,Total,650
+,"LAURENS, SC",Less than 65 Years,339
+,,65 Years or more,466
+,,No value,10 or fewer
+,,Total,805
+,"BURLEIGH, ND",Less than 65 Years,345
+,,65 Years or more,478
+,,No value,10 or fewer
+,,Total,823
+,"BUTLER, PA",Less than 65 Years,254
+,,65 Years or more,497
+,,No value,10 or fewer
+,,Total,751
+,"WOOD, OH",Less than 65 Years,225
+,,65 Years or more,433
+,,No value,10 or fewer
+,,Total,658
+,"KERSHAW, SC",Less than 65 Years,275
+,,65 Years or more,428
+,,No value,10 or fewer
+,,Total,703
+,"ROCKINGHAM, VA",Less than 65 Years,174
+,,65 Years or more,480
+,,No value,10 or fewer
+,,Total,654
+,"SUMTER, SC",Less than 65 Years,259
+,,65 Years or more,327
+,,No value,10 or fewer
+,,Total,586
+,"BELMONT, OH",Less than 65 Years,181
+,,65 Years or more,391
+,,No value,10 or fewer
+,,Total,572
+,"UNION, SC",Less than 65 Years,275
+,,65 Years or more,424
+,,No value,10 or fewer
+,,Total,699
+,"BRAZOS, TX",Less than 65 Years,260
+,,65 Years or more,377
+,,No value,10 or fewer
+,,Total,637
+,"ACCOMACK, VA",Less than 65 Years,256
+,,65 Years or more,422
+,,No value,10 or fewer
+,,Total,678
+,"BRADFORD, PA",Less than 65 Years,208
+,,65 Years or more,403
+,,No value,10 or fewer
+,,Total,611
+,"TIPTON, TN",Less than 65 Years,241
+,,65 Years or more,276
+,,No value,10 or fewer
+,,Total,517
+,"WASHINGTON, TX",Less than 65 Years,196
+,,65 Years or more,448
+,,No value,10 or fewer
+,,Total,644
+,"LACKAWANNA, PA",Less than 65 Years,172
+,,65 Years or more,241
+,,No value,10 or fewer
+,,Total,413
+,"GLOUCESTER, VA",Less than 65 Years,246
+,,65 Years or more,420
+,,No value,10 or fewer
+,,Total,666
+,"TUSCARAWAS, OH",Less than 65 Years,90
+,,65 Years or more,174
+,,No value,10 or fewer
+,,Total,264
+,"WILLIAMS, OH",Less than 65 Years,248
+,,65 Years or more,394
+,,No value,10 or fewer
+,,Total,642
+,"BRAZORIA, TX",Less than 65 Years,197
+,,65 Years or more,210
+,,No value,10 or fewer
+,,Total,407
+,"SHENANDOAH, VA",Less than 65 Years,78
+,,65 Years or more,162
+,,No value,10 or fewer
+,,Total,240
+,"CARTER, TN",Less than 65 Years,241
+,,65 Years or more,376
+,,No value,10 or fewer
+,,Total,617
+,"CREEK, OK",Less than 65 Years,200
+,,65 Years or more,372
+,,No value,10 or fewer
+,,Total,572
+,"WAGONER, OK",Less than 65 Years,187
+,,65 Years or more,404
+,,No value,10 or fewer
+,,Total,591
+,"GALVESTON, TX",Less than 65 Years,138
+,,65 Years or more,333
+,,No value,10 or fewer
+,,Total,471
+,"BROWN, OH",Less than 65 Years,229
+,,65 Years or more,347
+,,No value,10 or fewer
+,,Total,576
+,"ISLE OF WIGHT, VA",Less than 65 Years,193
+,,65 Years or more,370
+,,No value,10 or fewer
+,,Total,563
+,"ERATH, TX",Less than 65 Years,268
+,,65 Years or more,351
+,,No value,10 or fewer
+,,Total,619
+,"MADISON, TN",Less than 65 Years,13
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,28
+,"DARLINGTON, SC",Less than 65 Years,183
+,,65 Years or more,333
+,,No value,10 or fewer
+,,Total,516
+,"CROOK, OR",Less than 65 Years,146
+,,65 Years or more,376
+,,No value,10 or fewer
+,,Total,522
+,"CRAWFORD, OH",Less than 65 Years,201
+,,65 Years or more,389
+,,No value,10 or fewer
+,,Total,590
+,"WISE, VA",Less than 65 Years,226
+,,65 Years or more,314
+,,No value,10 or fewer
+,,Total,540
+,"JEFFERSON, OR",Less than 65 Years,222
+,,65 Years or more,302
+,,No value,10 or fewer
+,,Total,524
+,"ASHLAND, OH",Less than 65 Years,83
+,,65 Years or more,229
+,,No value,10 or fewer
+,,Total,312
+,"ORANGEBURG, SC",Less than 65 Years,95
+,,65 Years or more,98
+,,No value,10 or fewer
+,,Total,193
+,"DILLON, SC",Less than 65 Years,230
+,,65 Years or more,262
+,,No value,10 or fewer
+,,Total,492
+,"WOOD, TX",Less than 65 Years,200
+,,65 Years or more,321
+,,No value,10 or fewer
+,,Total,521
+,"WARREN, VA",Less than 65 Years,79
+,,65 Years or more,122
+,,No value,10 or fewer
+,,Total,201
+,"MECKLENBURG, VA",Less than 65 Years,184
+,,65 Years or more,314
+,,No value,10 or fewer
+,,Total,498
+,"LLANO, TX",Less than 65 Years,151
+,,65 Years or more,339
+,,No value,10 or fewer
+,,Total,490
+,"DARKE, OH",Less than 65 Years,147
+,,65 Years or more,195
+,,No value,10 or fewer
+,,Total,342
+,"MADISON, OH",Less than 65 Years,166
+,,65 Years or more,322
+,,No value,10 or fewer
+,,Total,488
+,"SENECA, OH",Less than 65 Years,199
+,,65 Years or more,259
+,,No value,10 or fewer
+,,Total,458
+,"CORYELL, TX",Less than 65 Years,200
+,,65 Years or more,224
+,,No value,10 or fewer
+,,Total,424
+,"SMYTH, VA",Less than 65 Years,177
+,,65 Years or more,256
+,,No value,10 or fewer
+,,Total,433
+,"DORCHESTER, SC",Less than 65 Years,218
+,,65 Years or more,221
+,,No value,10 or fewer
+,,Total,439
+,"PETERSBURG CITY, VA",Less than 65 Years,209
+,,65 Years or more,281
+,,No value,10 or fewer
+,,Total,490
+,"MALHEUR, OR",Less than 65 Years,178
+,,65 Years or more,241
+,,No value,10 or fewer
+,,Total,419
+,"CHAMPAIGN, OH",Less than 65 Years,164
+,,65 Years or more,253
+,,No value,10 or fewer
+,,Total,417
+,"MAYES, OK",Less than 65 Years,153
+,,65 Years or more,263
+,,No value,10 or fewer
+,,Total,416
+,"RUSK, TX",Less than 65 Years,154
+,,65 Years or more,237
+,,No value,10 or fewer
+,,Total,391
+,"CULPEPER, VA",Less than 65 Years,79
+,,65 Years or more,146
+,,No value,10 or fewer
+,,Total,225
+,"CHARLOTTESVILLE CITY, VA",Less than 65 Years,162
+,,65 Years or more,210
+,,No value,10 or fewer
+,,Total,372
+,"COLUMBIANA, OH",Less than 65 Years,129
+,,65 Years or more,299
+,,No value,10 or fewer
+,,Total,428
+,"CLARENDON, SC",Less than 65 Years,141
+,,65 Years or more,241
+,,No value,10 or fewer
+,,Total,382
+,"OBION, TN",Less than 65 Years,151
+,,65 Years or more,207
+,,No value,10 or fewer
+,,Total,358
+,"HALIFAX, VA",Less than 65 Years,135
+,,65 Years or more,268
+,,No value,10 or fewer
+,,Total,403
+,"CHEROKEE, TX",Less than 65 Years,189
+,,65 Years or more,172
+,,No value,10 or fewer
+,,Total,361
+,"CARROLL, TN",Less than 65 Years,89
+,,65 Years or more,193
+,,No value,10 or fewer
+,,Total,282
+,"HARRISONBURG CITY, VA",Less than 65 Years,138
+,,65 Years or more,224
+,,No value,10 or fewer
+,,Total,362
+,"UMATILLA, OR",Less than 65 Years,116
+,,65 Years or more,206
+,,No value,10 or fewer
+,,Total,322
+,"SANDUSKY, OH",Less than 65 Years,136
+,,65 Years or more,200
+,,No value,10 or fewer
+,,Total,336
+,"WASHINGTON, RI",Less than 65 Years,98
+,,65 Years or more,308
+,,No value,10 or fewer
+,,Total,406
+,"HIGHLAND, OH",Less than 65 Years,68
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,141
+,"OKMULGEE, OK",Less than 65 Years,147
+,,65 Years or more,199
+,,No value,10 or fewer
+,,Total,346
+,"RUSSELL, VA",Less than 65 Years,158
+,,65 Years or more,222
+,,No value,10 or fewer
+,,Total,380
+,"CHESTERFIELD, SC",Less than 65 Years,131
+,,65 Years or more,233
+,,No value,10 or fewer
+,,Total,364
+,"HIDALGO, TX",Less than 65 Years,65
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,91
+,"PUTNAM, OH",Less than 65 Years,102
+,,65 Years or more,227
+,,No value,10 or fewer
+,,Total,329
+,"MERCER, PA",Less than 65 Years,85
+,,65 Years or more,214
+,,No value,10 or fewer
+,,Total,299
+,"HOOD, TX",Less than 65 Years,135
+,,65 Years or more,195
+,,No value,10 or fewer
+,,Total,330
+,"NEW KENT, VA",Less than 65 Years,99
+,,65 Years or more,217
+,,No value,10 or fewer
+,,Total,316
+,"WASHINGTON, VT",Less than 65 Years,95
+,,65 Years or more,216
+,,No value,10 or fewer
+,,Total,311
+,"STUTSMAN, ND",Less than 65 Years,150
+,,65 Years or more,197
+,,No value,10 or fewer
+,,Total,347
+,"SCOTT, VA",Less than 65 Years,142
+,,65 Years or more,196
+,,No value,10 or fewer
+,,Total,338
+,"CLEVELAND, OK",Less than 65 Years,88
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,185
+,"DEFIANCE, OH",Less than 65 Years,112
+,,65 Years or more,193
+,,No value,10 or fewer
+,,Total,305
+,"MARION, SC",Less than 65 Years,122
+,,65 Years or more,208
+,,No value,10 or fewer
+,,Total,330
+,"LINCOLN, SD",Less than 65 Years,118
+,,65 Years or more,192
+,,No value,10 or fewer
+,,Total,310
+,"HURON, OH",Less than 65 Years,122
+,,65 Years or more,158
+,,No value,10 or fewer
+,,Total,280
+,"PENNINGTON, SD",Less than 65 Years,200
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,297
+,"HILL, TX",Less than 65 Years,140
+,,65 Years or more,162
+,,No value,10 or fewer
+,,Total,302
+,"LEE, VA",Less than 65 Years,139
+,,65 Years or more,182
+,,No value,10 or fewer
+,,Total,321
+,"WAYNE, OH",Less than 65 Years,114
+,,65 Years or more,164
+,,No value,10 or fewer
+,,Total,278
+,"SEQUOYAH, OK",Less than 65 Years,127
+,,65 Years or more,160
+,,No value,10 or fewer
+,,Total,287
+,"GIBSON, TN",Less than 65 Years,17
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,44
+,"BEAVER, PA",Less than 65 Years,102
+,,65 Years or more,187
+,,No value,10 or fewer
+,,Total,289
+,"ORANGE, VA",Less than 65 Years,73
+,,65 Years or more,157
+,,No value,10 or fewer
+,,Total,230
+,"HAYS, TX",Less than 65 Years,112
+,,65 Years or more,135
+,,No value,10 or fewer
+,,Total,247
+,"CRAIG, OK",Less than 65 Years,140
+,,65 Years or more,176
+,,No value,10 or fewer
+,,Total,316
+,"FAIRFIELD, SC",Less than 65 Years,99
+,,65 Years or more,138
+,,No value,10 or fewer
+,,Total,237
+,"CANADIAN, OK",Less than 65 Years,87
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,179
+,"WILLIAMSBURG, SC",Less than 65 Years,90
+,,65 Years or more,157
+,,No value,10 or fewer
+,,Total,247
+,"LAMPASAS, TX",Less than 65 Years,81
+,,65 Years or more,172
+,,No value,10 or fewer
+,,Total,253
+,"MORTON, ND",Less than 65 Years,119
+,,65 Years or more,169
+,,No value,10 or fewer
+,,Total,288
+,"CHESTER, SC",Less than 65 Years,158
+,,65 Years or more,142
+,,No value,10 or fewer
+,,Total,300
+,"LOUISA, VA",Less than 65 Years,105
+,,65 Years or more,158
+,,No value,10 or fewer
+,,Total,263
+,"MANASSAS CITY, VA",Less than 65 Years,109
+,,65 Years or more,136
+,,No value,10 or fewer
+,,Total,245
+,"FLUVANNA, VA",Less than 65 Years,109
+,,65 Years or more,159
+,,No value,10 or fewer
+,,Total,268
+,"FAYETTE, TN",Less than 65 Years,81
+,,65 Years or more,146
+,,No value,10 or fewer
+,,Total,227
+,"AUGLAIZE, OH",Less than 65 Years,89
+,,65 Years or more,166
+,,No value,10 or fewer
+,,Total,255
+,"LIBERTY, TX",Less than 65 Years,115
+,,65 Years or more,127
+,,No value,10 or fewer
+,,Total,242
+,"BRADLEY, TN",Less than 65 Years,128
+,,65 Years or more,89
+,,No value,10 or fewer
+,,Total,217
+,"NORTHAMPTON, VA",Less than 65 Years,83
+,,65 Years or more,175
+,,No value,10 or fewer
+,,Total,258
+,"ERIE, OH",Less than 65 Years,86
+,,65 Years or more,156
+,,No value,10 or fewer
+,,Total,242
+,"VAN ZANDT, TX",Less than 65 Years,99
+,,65 Years or more,148
+,,No value,10 or fewer
+,,Total,247
+,"COLUMBIA, OR",Less than 65 Years,78
+,,65 Years or more,159
+,,No value,10 or fewer
+,,Total,237
+,"COLONIAL HEIGHTS CITY, VA",Less than 65 Years,92
+,,65 Years or more,143
+,,No value,10 or fewer
+,,Total,235
+,"WINCHESTER CITY, VA",Less than 65 Years,46
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,99
+,"BRISTOL CITY, VA",Less than 65 Years,124
+,,65 Years or more,142
+,,No value,10 or fewer
+,,Total,266
+,"MCINTOSH, OK",Less than 65 Years,73
+,,65 Years or more,156
+,,No value,10 or fewer
+,,Total,229
+,"CLINTON, OH",Less than 65 Years,80
+,,65 Years or more,140
+,,No value,10 or fewer
+,,Total,220
+,"ADDISON, VT",Less than 65 Years,52
+,,65 Years or more,177
+,,No value,10 or fewer
+,,Total,229
+,"SEQUATCHIE, TN",Less than 65 Years,103
+,,65 Years or more,139
+,,No value,10 or fewer
+,,Total,242
+,"BROWN, SD",Less than 65 Years,101
+,,65 Years or more,128
+,,No value,10 or fewer
+,,Total,229
+,"FAUQUIER, VA",Less than 65 Years,83
+,,65 Years or more,138
+,,No value,10 or fewer
+,,Total,221
+,"BRUNSWICK, VA",Less than 65 Years,90
+,,65 Years or more,123
+,,No value,10 or fewer
+,,Total,213
+,"PIKE, PA",Less than 65 Years,80
+,,65 Years or more,109
+,,No value,10 or fewer
+,,Total,189
+,"MILAM, TX",Less than 65 Years,66
+,,65 Years or more,150
+,,No value,10 or fewer
+,,Total,216
+,"PAGE, VA",Less than 65 Years,36
+,,65 Years or more,72
+,,No value,10 or fewer
+,,Total,108
+,"MORROW, OH",Less than 65 Years,81
+,,65 Years or more,138
+,,No value,10 or fewer
+,,Total,219
+,"UNICOI, TN",Less than 65 Years,80
+,,65 Years or more,147
+,,No value,10 or fewer
+,,Total,227
+,"ROSS, OH",Less than 65 Years,88
+,,65 Years or more,120
+,,No value,10 or fewer
+,,Total,208
+,"CLARKE, VA",Less than 65 Years,21
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,109
+,"YORK, SC",Less than 65 Years,95
+,,65 Years or more,117
+,,No value,10 or fewer
+,,Total,212
+,"WISE, TX",Less than 65 Years,131
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,237
+,"UNION, OH",Less than 65 Years,90
+,,65 Years or more,137
+,,No value,10 or fewer
+,,Total,227
+,"CHAMBERS, TX",Less than 65 Years,98
+,,65 Years or more,123
+,,No value,10 or fewer
+,,Total,221
+,"ARMSTRONG, PA",Less than 65 Years,81
+,,65 Years or more,144
+,,No value,10 or fewer
+,,Total,225
+,"BLEDSOE, TN",Less than 65 Years,103
+,,65 Years or more,116
+,,No value,10 or fewer
+,,Total,219
+,"HARDIN, OH",Less than 65 Years,73
+,,65 Years or more,134
+,,No value,10 or fewer
+,,Total,207
+,"POWHATAN, VA",Less than 65 Years,66
+,,65 Years or more,124
+,,No value,10 or fewer
+,,Total,190
+,"AIKEN, SC",Less than 65 Years,29
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,69
+,"DINWIDDIE, VA",Less than 65 Years,92
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,186
+,"OTTAWA, OH",Less than 65 Years,61
+,,65 Years or more,136
+,,No value,10 or fewer
+,,Total,197
+,"DICKENSON, VA",Less than 65 Years,85
+,,65 Years or more,122
+,,No value,10 or fewer
+,,Total,207
+,"TAZEWELL, VA",Less than 65 Years,89
+,,65 Years or more,113
+,,No value,10 or fewer
+,,Total,202
+,"SHELBY, OH",Less than 65 Years,95
+,,65 Years or more,114
+,,No value,10 or fewer
+,,Total,209
+,"WINDSOR, VT",Less than 65 Years,86
+,,65 Years or more,118
+,,No value,10 or fewer
+,,Total,204
+,"HUNT, TX",Less than 65 Years,79
+,,65 Years or more,138
+,,No value,10 or fewer
+,,Total,217
+,"GREENE, VA",Less than 65 Years,80
+,,65 Years or more,143
+,,No value,10 or fewer
+,,Total,223
+,"GREENE, PA",Less than 65 Years,88
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,185
+,"BAKER, OR",Less than 65 Years,61
+,,65 Years or more,126
+,,No value,10 or fewer
+,,Total,187
+,"POQUOSON CITY, VA",Less than 65 Years,50
+,,65 Years or more,147
+,,No value,10 or fewer
+,,Total,197
+,"FAIRFAX CITY, VA",Less than 65 Years,57
+,,65 Years or more,114
+,,No value,10 or fewer
+,,Total,171
+,"LE FLORE, OK",Less than 65 Years,84
+,,65 Years or more,107
+,,No value,10 or fewer
+,,Total,191
+,"SOUTHAMPTON, VA",Less than 65 Years,72
+,,65 Years or more,122
+,,No value,10 or fewer
+,,Total,194
+,"WYANDOT, OH",Less than 65 Years,52
+,,65 Years or more,120
+,,No value,10 or fewer
+,,Total,172
+,"PERRY, PA",Less than 65 Years,73
+,,65 Years or more,147
+,,No value,10 or fewer
+,,Total,220
+,"DYER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"WEAKLEY, TN",Less than 65 Years,17
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,62
+,"KING WILLIAM, VA",Less than 65 Years,55
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,147
+,"KNOX, OH",Less than 65 Years,62
+,,65 Years or more,117
+,,No value,10 or fewer
+,,Total,179
+,"JOHNSON, TN",Less than 65 Years,51
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,153
+,"MONROE, OH",Less than 65 Years,47
+,,65 Years or more,119
+,,No value,10 or fewer
+,,Total,166
+,"ESSEX, VA",Less than 65 Years,68
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,139
+,"MIDDLESEX, VA",Less than 65 Years,58
+,,65 Years or more,117
+,,No value,10 or fewer
+,,Total,175
+,"VAN WERT, OH",Less than 65 Years,24
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,53
+,"MARLBORO, SC",Less than 65 Years,74
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,184
+,"NEWPORT, RI",Less than 65 Years,36
+,,65 Years or more,140
+,,No value,10 or fewer
+,,Total,176
+,"GOOCHLAND, VA",Less than 65 Years,56
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,151
+,"FRANKLIN CITY, VA",Less than 65 Years,60
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,152
+,"PAYNE, OK",Less than 65 Years,48
+,,65 Years or more,86
+,,No value,10 or fewer
+,,Total,134
+,"WALSH, ND",Less than 65 Years,47
+,,65 Years or more,98
+,,No value,10 or fewer
+,,Total,145
+,"NAVARRO, TX",Less than 65 Years,56
+,,65 Years or more,105
+,,No value,10 or fewer
+,,Total,161
+,"LANCASTER, VA",Less than 65 Years,26
+,,65 Years or more,144
+,,No value,10 or fewer
+,,Total,170
+,"PRINCE GEORGE, VA",Less than 65 Years,66
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,161
+,"AUGUSTA, VA",Less than 65 Years,49
+,,65 Years or more,98
+,,No value,10 or fewer
+,,Total,147
+,"GRAYSON, TX",Less than 65 Years,63
+,,65 Years or more,107
+,,No value,10 or fewer
+,,Total,170
+,"WILLIAMSBURG CITY, VA",Less than 65 Years,43
+,,65 Years or more,114
+,,No value,10 or fewer
+,,Total,157
+,"ABBEVILLE, SC",Less than 65 Years,64
+,,65 Years or more,98
+,,No value,10 or fewer
+,,Total,162
+,"CLAY, SD",Less than 65 Years,60
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,152
+,"PANOLA, TX",Less than 65 Years,52
+,,65 Years or more,87
+,,No value,10 or fewer
+,,Total,139
+,"NORTHUMBERLAND, VA",Less than 65 Years,31
+,,65 Years or more,112
+,,No value,10 or fewer
+,,Total,143
+,"FULTON, OH",Less than 65 Years,55
+,,65 Years or more,93
+,,No value,10 or fewer
+,,Total,148
+,"MATHEWS, VA",Less than 65 Years,46
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,143
+,"WALLER, TX",Less than 65 Years,52
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,97
+,"WESTMORELAND, VA",Less than 65 Years,41
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,116
+,"LAWRENCE, PA",Less than 65 Years,41
+,,65 Years or more,98
+,,No value,10 or fewer
+,,Total,139
+,"GRIMES, TX",Less than 65 Years,41
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,119
+,"BLANCO, TX",Less than 65 Years,44
+,,65 Years or more,103
+,,No value,10 or fewer
+,,Total,147
+,"GREENSVILLE, VA",Less than 65 Years,42
+,,65 Years or more,72
+,,No value,10 or fewer
+,,Total,114
+,"CAMP, TX",Less than 65 Years,34
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,107
+,"HARDEMAN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,19
+,"LOGAN, OH",Less than 65 Years,55
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,133
+,"LUNENBURG, VA",Less than 65 Years,55
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,125
+,"WASHINGTON, OH",Less than 65 Years,59
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,125
+,"MARION, TN",Less than 65 Years,43
+,,65 Years or more,72
+,,No value,10 or fewer
+,,Total,115
+,"RICHMOND, VA",Less than 65 Years,40
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,121
+,"LANE, OR",Less than 65 Years,72
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,138
+,"BOSQUE, TX",Less than 65 Years,58
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,140
+,"FAYETTE, OH",Less than 65 Years,54
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,125
+,"SCIOTO, OH",Less than 65 Years,52
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,125
+,"AUSTIN, TX",Less than 65 Years,26
+,,65 Years or more,65
+,,No value,10 or fewer
+,,Total,91
+,"UNION, SD",Less than 65 Years,36
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,112
+,"BURLESON, TX",Less than 65 Years,28
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,102
+,"ADAMS, OH",Less than 65 Years,41
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,102
+,"BEAUFORT, SC",Less than 65 Years,40
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,116
+,"MADISON, VA",Less than 65 Years,35
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,96
+,"NELSON, VA",Less than 65 Years,33
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,109
+,"PROVIDENCE, RI",Less than 65 Years,72
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,124
+,"KING AND QUEEN, VA",Less than 65 Years,37
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,98
+,"CALHOUN, SC",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"TRAILL, ND",Less than 65 Years,33
+,,65 Years or more,67
+,,No value,10 or fewer
+,,Total,100
+,"BENTON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"ANDERSON, TX",Less than 65 Years,40
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,99
+,"FALLS, TX",Less than 65 Years,52
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,113
+,"HANCOCK, OH",Less than 65 Years,37
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,108
+,"JEFFERSON, OH",Less than 65 Years,32
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,82
+,"SUSQUEHANNA, PA",Less than 65 Years,37
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,99
+,"SAN PATRICIO, TX",Less than 65 Years,101
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,106
+,"SUSSEX, VA",Less than 65 Years,43
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,104
+,"HENRY, VA",Less than 65 Years,46
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,117
+,"MCCORMICK, SC",Less than 65 Years,37
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,114
+,"LEE, SC",Less than 65 Years,41
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,101
+,"DAVIDSON, TN",Less than 65 Years,69
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,106
+,"COOKE, TX",Less than 65 Years,51
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,102
+,"TIOGA, PA",Less than 65 Years,35
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,94
+,"GUERNSEY, OH",Less than 65 Years,22
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,77
+,"MEIGS, OH",Less than 65 Years,45
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,98
+,"UPSHUR, TX",Less than 65 Years,28
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,74
+,"PALO PINTO, TX",Less than 65 Years,49
+,,65 Years or more,64
+,,No value,10 or fewer
+,,Total,113
+,"CHARLES CITY, VA",Less than 65 Years,34
+,,65 Years or more,72
+,,No value,10 or fewer
+,,Total,106
+,"PEMBINA, ND",Less than 65 Years,32
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,111
+,"NEWBERRY, SC",Less than 65 Years,37
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,107
+,"EDGEFIELD, SC",Less than 65 Years,19
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,42
+,"MUSKINGUM, OH",Less than 65 Years,60
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,114
+,"TURNER, SD",Less than 65 Years,34
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,111
+,"WAYNE, PA",Less than 65 Years,31
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,91
+,"PERRY, OH",Less than 65 Years,34
+,,65 Years or more,67
+,,No value,10 or fewer
+,,Total,101
+,"GEORGETOWN, SC",Less than 65 Years,30
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,77
+,"GREGG, TX",Less than 65 Years,41
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,92
+,"ORANGE, VT",Less than 65 Years,46
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,97
+,"YAMHILL, OR",Less than 65 Years,47
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,98
+,"STAFFORD, VA",Less than 65 Years,55
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,100
+,"HOCKING, OH",Less than 65 Years,33
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,90
+,"COLLETON, SC",Less than 65 Years,29
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,80
+,"KNOX, TN",Less than 65 Years,44
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,77
+,"DAY, SD",Less than 65 Years,26
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,83
+,"POLK, OR",Less than 65 Years,37
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,84
+,"LAUDERDALE, TN",Less than 65 Years,41
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,63
+,"SALUDA, SC",Less than 65 Years,24
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,68
+,"ROBERTSON, TX",Less than 65 Years,24
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,78
+,"HANCOCK, TN",Less than 65 Years,51
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,98
+,"WHARTON, TX",Less than 65 Years,21
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,56
+,"DAVIS, UT",Less than 65 Years,41
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,86
+,"FALLS CHURCH CITY, VA",Less than 65 Years,24
+,,65 Years or more,64
+,,No value,10 or fewer
+,,Total,88
+,"BUCKINGHAM, VA",Less than 65 Years,40
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,82
+,"COMAL, TX",Less than 65 Years,37
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,89
+,"CHEROKEE, OK",Less than 65 Years,31
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,71
+,"ROBERTS, SD",Less than 65 Years,37
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,82
+,"FRANKLIN, VT",Less than 65 Years,29
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,74
+,"BAMBERG, SC",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,21
+,"CHESTER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SURRY, VA",Less than 65 Years,23
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,71
+,"SPOTSYLVANIA, VA",Less than 65 Years,34
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,78
+,"WASHINGTON, OK",Less than 65 Years,27
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,66
+,"HOPEWELL CITY, VA",Less than 65 Years,46
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,87
+,"TRIPP, SD",Less than 65 Years,34
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,78
+,"CAROLINE, VA",Less than 65 Years,27
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,71
+,"CARROLL, OH",Less than 65 Years,14
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,40
+,"WALKER, TX",Less than 65 Years,23
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,80
+,"BRULE, SD",Less than 65 Years,49
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,90
+,"PAWNEE, OK",Less than 65 Years,27
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,57
+,"HARNEY, OR",Less than 65 Years,22
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,82
+,"CRAWFORD, PA",Less than 65 Years,32
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,68
+,"TITUS, TX",Less than 65 Years,36
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,60
+,"DANVILLE CITY, VA",Less than 65 Years,31
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,75
+,"NORTON CITY, VA",Less than 65 Years,24
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,54
+,"CROCKETT, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HENRY, OH",Less than 65 Years,35
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,75
+,"PAULDING, OH",Less than 65 Years,16
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,47
+,"BASTROP, TX",Less than 65 Years,25
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,60
+,"UTAH, UT",Less than 65 Years,47
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,77
+,"JACKSON, OH",Less than 65 Years,23
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,71
+,"NOTTOWAY, VA",Less than 65 Years,27
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,71
+,"EL PASO, TX",Less than 65 Years,36
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,57
+,"JEFFERSON, TX",Less than 65 Years,25
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,47
+,"MERCER, ND",Less than 65 Years,16
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,56
+,"MORROW, OR",Less than 65 Years,23
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,60
+,"WICHITA, TX",Less than 65 Years,38
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,67
+,"LINCOLN, OK",Less than 65 Years,18
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,40
+,"MCKENZIE, ND",Less than 65 Years,30
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,63
+,"MORRIS, TX",Less than 65 Years,22
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,59
+,"PITTSBURG, OK",Less than 65 Years,18
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,42
+,"RHEA, TN",Less than 65 Years,27
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,53
+,"OTTAWA, OK",Less than 65 Years,25
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,69
+,"BUCHANAN, VA",Less than 65 Years,21
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,53
+,"PITTSYLVANIA, VA",Less than 65 Years,29
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,62
+,"RICHLAND, ND",Less than 65 Years,20
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,53
+,"WYOMING, PA",Less than 65 Years,18
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,47
+,"LIMESTONE, TX",Less than 65 Years,22
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,50
+,"CAMERON, TX",Less than 65 Years,32
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,44
+,"MEADE, SD",Less than 65 Years,35
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,53
+,"MEDINA, TX",Less than 65 Years,23
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,63
+,"NELSON, ND",Less than 65 Years,12
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,48
+,"LAWRENCE, SD",Less than 65 Years,21
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,53
+,"AMELIA, VA",Less than 65 Years,19
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,49
+,"MERCER, OH",Less than 65 Years,18
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,45
+,"BARNWELL, SC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"VINTON, OH",Less than 65 Years,20
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,56
+,"DELAWARE, OK",Less than 65 Years,24
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,49
+,"POLK, TX",Less than 65 Years,21
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,50
+,"KLAMATH, OR",Less than 65 Years,20
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,51
+,"LOGAN, OK",Less than 65 Years,23
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,45
+,"RAPPAHANNOCK, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,31
+,"GUADALUPE, TX",Less than 65 Years,28
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,56
+,"STAUNTON CITY, VA",Less than 65 Years,17
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,48
+,"WAYNESBORO CITY, VA",Less than 65 Years,26
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,50
+,"FAYETTE, TX",Less than 65 Years,16
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,51
+,"DOUGLAS, OR",Less than 65 Years,23
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,64
+,"SAN SABA, TX",Less than 65 Years,14
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,50
+,"LAKE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,25
+,"JACKSON, OR",Less than 65 Years,28
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,53
+,"CHARLOTTE, VA",Less than 65 Years,21
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,56
+,"COMANCHE, TX",Less than 65 Years,25
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,49
+,"KENDALL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,51
+,"MANASSAS PARK CITY, VA",Less than 65 Years,16
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,37
+,"HUTCHINSON, TX",Less than 65 Years,12
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,39
+,"INDIANA, PA",Less than 65 Years,22
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,47
+,"POTTAWATOMIE, OK",Less than 65 Years,14
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,31
+,"HARRISON, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,40
+,"HASKELL, OK",Less than 65 Years,16
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,44
+,"GRUNDY, TN",Less than 65 Years,23
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,42
+,"LEON, TX",Less than 65 Years,13
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,42
+,"LEE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,38
+,"LUBBOCK, TX",Less than 65 Years,21
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,48
+,"COSHOCTON, OH",Less than 65 Years,15
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,49
+,"PIKE, OH",Less than 65 Years,17
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,40
+,"POLK, TN",Less than 65 Years,15
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,31
+,"RUTLAND, VT",Less than 65 Years,18
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,41
+,"BARNES, ND",Less than 65 Years,23
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,51
+,"BRISTOL, RI",Less than 65 Years,10 or fewer
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,39
+,"OSAGE, OK",Less than 65 Years,13
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,39
+,"FULTON, PA",Less than 65 Years,19
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,43
+,"WINDHAM, VT",Less than 65 Years,16
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,44
+,"COMANCHE, OK",Less than 65 Years,13
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,30
+,"FANNIN, TX",Less than 65 Years,22
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,49
+,"JIM WELLS, TX",Less than 65 Years,35
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"WYTHE, VA",Less than 65 Years,21
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,41
+,"GRAND ISLE, VT",Less than 65 Years,11
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,40
+,"CUMBERLAND, VA",Less than 65 Years,12
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,33
+,"HENDERSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENT, RI",Less than 65 Years,20
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,46
+,"OKFUSKEE, OK",Less than 65 Years,19
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,44
+,"EASTLAND, TX",Less than 65 Years,11
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,47
+,"WILLIAMS, ND",Less than 65 Years,13
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,31
+,"FREESTONE, TX",Less than 65 Years,14
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,36
+,"MONTAGUE, TX",Less than 65 Years,14
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,41
+,"TILLAMOOK, OR",Less than 65 Years,14
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,45
+,"WILLIAMSON, TN",Less than 65 Years,24
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,46
+,"CAVALIER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,33
+,"WEBB, TX",Less than 65 Years,29
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,46
+,"LAMOURE, ND",Less than 65 Years,20
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,49
+,"RUTHERFORD, TN",Less than 65 Years,17
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,36
+,"HAYWOOD, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"SUMMIT, UT",Less than 65 Years,16
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,41
+,"FALL RIVER, SD",Less than 65 Years,15
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,36
+,"LAMOILLE, VT",Less than 65 Years,14
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,37
+,"HOPKINS, TX",Less than 65 Years,18
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,36
+,"SOMERVELL, TX",Less than 65 Years,21
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,36
+,"TAYLOR, TX",Less than 65 Years,25
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,41
+,"GRADY, OK",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"HENRY, TN",Less than 65 Years,11
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,25
+,"VENANGO, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,32
+,"HAMILTON, TX",Less than 65 Years,14
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,31
+,"LYMAN, SD",Less than 65 Years,21
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,36
+,"MCLEAN, ND",Less than 65 Years,18
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,35
+,"SOMERSET, PA",Less than 65 Years,20
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,32
+,"MONTGOMERY, TN",Less than 65 Years,15
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,34
+,"RAMSEY, ND",Less than 65 Years,13
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,29
+,"PIERCE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,37
+,"CUMBERLAND, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,32
+,"GRIGGS, ND",Less than 65 Years,11
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,41
+,"LYNCHBURG CITY, VA",Less than 65 Years,12
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,30
+,"MCNAIRY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANGELINA, TX",Less than 65 Years,15
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,26
+,"SAN JACINTO, TX",Less than 65 Years,14
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,27
+,"BOWIE, TX",Less than 65 Years,15
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,38
+,"CARTER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,22
+,"CUSTER, SD",Less than 65 Years,18
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,44
+,"GREGORY, SD",Less than 65 Years,12
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,36
+,"MCMINN, TN",Less than 65 Years,12
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,29
+,"NORTHUMBERLAND, PA",Less than 65 Years,17
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,29
+,"SUMNER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,28
+,"GALLIA, OH",Less than 65 Years,11
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,33
+,"MCCLAIN, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,18
+,"NACOGDOCHES, TX",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"CAMBRIA, PA",Less than 65 Years,14
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,34
+,"MCCULLOCH, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MIDLAND, TX",Less than 65 Years,18
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,35
+,"TOWNER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,28
+,"DICKEY, ND",Less than 65 Years,11
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,29
+,"HAMBLEN, TN",Less than 65 Years,16
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,36
+,"STARK, ND",Less than 65 Years,16
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,30
+,"MARTINSVILLE CITY, VA",Less than 65 Years,16
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,31
+,"ATASCOSA, TX",Less than 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"BEDFORD, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,20
+,"KERR, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,33
+,"MATAGORDA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"SULLIVAN, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,27
+,"WILSON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,25
+,"LAKE, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"PRINCE EDWARD, VA",Less than 65 Years,16
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,29
+,"STEPHENS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,20
+,"CASS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,21
+,"RAINS, TX",Less than 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"SIOUX, ND",Less than 65 Years,22
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"BUFFALO, SD",Less than 65 Years,22
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,30
+,"CALDWELL, TX",Less than 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"CARSON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,18
+,"CENTRE, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,25
+,"COLORADO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"RUNNELS, TX",Less than 65 Years,13
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,33
+,"TOOELE, UT",Less than 65 Years,16
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,32
+,"ARANSAS, TX",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"GRAY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,20
+,"LYCOMING, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"GRANT, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,24
+,"KAY, OK",Less than 65 Years,13
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,28
+,"MCCOOK, SD",Less than 65 Years,13
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,28
+,"YOUNG, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,19
+,"CAMPBELL, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,20
+,"WEBER, UT",Less than 65 Years,19
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,31
+,"ORANGE, TX",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"ROANOKE, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,24
+,"DEUEL, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"WARD, ND",Less than 65 Years,17
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,31
+,"BLOUNT, TN",Less than 65 Years,12
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,28
+,"DOUGLAS, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,22
+,"HOUSTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,26
+,"SEVIER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,21
+,"BANDERA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,31
+,"MEIGS, TN",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"WHEELER, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,27
+,"AMHERST, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"BLAND, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,19
+,"CLATSOP, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,17
+,"DECATUR, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RANSOM, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,22
+,"WASHINGTON, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,23
+,"BLAIR, PA",Less than 65 Years,12
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,24
+,"CALEDONIA, VT",Less than 65 Years,11
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,23
+,"ECTOR, TX",Less than 65 Years,13
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,24
+,"LAWRENCE, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,22
+,"VICTORIA, TX",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"BROWN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"COLUMBIA, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,24
+,"KLEBERG, TX",Less than 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"ADAIR, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,22
+,"WASCO, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,26
+,"COCKE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"HUGHES, OK",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"WARREN, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,24
+,"JACK, TX",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"WILSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"BENNINGTON, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CURRY, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,21
+,"HARDIN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"HARRISON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"MOORE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,18
+,"YANKTON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BUTTE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"DEAF SMITH, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,20
+,"GILLESPIE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"MAURY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MORGAN, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"VAN BUREN, TN",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"BENSON, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"HOLMES, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"SEMINOLE, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"DONLEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,22
+,"KING GEORGE, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MOUNTRAIL, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CADDO, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CODINGTON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,22
+,"LAKE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LATIMER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,17
+,"FRANKLIN, TX",Less than 65 Years,13
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,25
+,"GARFIELD, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"TODD, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREDERICKSBURG CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,19
+,"MONTGOMERY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"ROANOKE CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"GARVIN, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"ANDERSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"CAMPBELL, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"CUSTER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"PUTNAM, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"COKE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,19
+,"EDMUNDS, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,19
+,"STARR, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIVE OAK, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHELBY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BEE, TX",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"MAVERICK, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"NOBLE, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"TRINITY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCCURTAIN, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"ALLENDALE, SC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARION, PA",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"HAMPTON, SC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"JASPER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROLETTE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"ORLEANS, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"NOWATA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PATRICK, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"PONTOTOC, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"BRYAN, OK",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"GRAINGER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LOGAN, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOUDON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"POTTER, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CLEARFIELD, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,19
+,"GRAYSON, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"FRIO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HUNTINGDON, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROCKETT, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"FOSTER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CONCHO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,16
+,"DAVISON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MONROE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"ROBERTSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"ARMSTRONG, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BROOKINGS, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEELE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"SWISHER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAL VERDE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"KIDDER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"LAMAR, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"MARSHALL, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEPHENS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"DUVAL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"JOSEPHINE, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CACHE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"FRANKLIN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"JUNIATA, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MOODY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BECKHAM, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCKEAN, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MIFFLIN, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CARROLL, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASTRO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCHENRY, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALLOWA, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"HOWARD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"JASPER, SC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINGFISHER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEXINGTON CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOBLE, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APPOMATTOX, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MURRAY, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARMER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKBRIDGE, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOTETOURT, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMMONS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEADLE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMPORIA CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILLIAM, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOOD RIVER, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"LOVE, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"UVALDE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLES MIX, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAVACA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPINK, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARCHER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"DALLAM, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUNN, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSTON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHITA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELK, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMPHREYS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MELLETTE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SARGENT, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TYLER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASATCH, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AURORA, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALLAHAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAIBORNE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CORSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILES, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUGHES, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRION, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OLIVER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"REFUGIO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STERLING, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHOCTAW, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEWEY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HETTINGER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIOWA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINER, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PULASKI, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WELLS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATOKA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOX ELDER, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDDY, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KARNES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SNYDER, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODWARD, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COTTON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DIMMIT, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMLIN, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANSFORD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OCHILTREE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UINTAH, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OLDHAM, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUSHMATAHA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALEM, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARBON, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLEMAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALAX CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCPHERSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENARD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGLALA LAKOTA, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RED RIVER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TEXAS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HALE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HIGHLAND, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JIM HOGG, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOLAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REAGAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SABINE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUTTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILBARGER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLACY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEGHANY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEATHAM, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FENTRESS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GONZALES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHLEICHER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALWORTH, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COAL, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDWARDS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARTLEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUTCHINSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAJOR, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCINTOSH, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTOUR, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OVERTON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RADFORD, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERIDAN, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALFALFA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOTTINEAU, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHILDRESS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COVINGTON CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEWEY, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DIVIDE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERKINS, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCURRY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHEELER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ZAVALA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAYLOR, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BON HOMME, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOKS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURKE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLLINGSWORTH, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAND, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARPER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HASKELL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HEMPHILL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINGSBURY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN AUGUSTINE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEWART, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BATH, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BREWSTER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CANNON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUCHESNE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMERY, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOREST, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILES, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HICKMAN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMB, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIPSCOMB, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PECOS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REAL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANPETE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEVIER, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHACKELFORD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERMAN, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERMAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STANLEY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDREWS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELTA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLIS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GAINES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAAKON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HALL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAND, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIMBLE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA SALLE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROGER MILLS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TERRY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TILLMAN, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENNETT, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BILLINGS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOWMAN, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUENA VISTA CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CIMARRON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWSON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAULK, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOLDEN VALLEY, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDEMAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUAB, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINNEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLARD, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVER, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRISCOE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESSEX, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOARD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARMON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PICKETT, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UPTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMERON, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COTTLE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAIG, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROSBY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JERAULD, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KANE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REEVES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ZAPATA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAILEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BORDEN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARFIELD, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLASSCOCK, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOLIAD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOCKLEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HYDE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TROUSDALE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YOAKUM, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ZIEBACH, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COCHRAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRANE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CULBERSON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FISHER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARZA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDING, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFF DAVIS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENEDY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENT, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYNN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCMULLEN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOORE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTER, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRESIDIO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RENVILLE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STONEWALL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TERRELL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THROCKMORTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINKLER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 65 Years,5552
+,,65 Years or more,10275
+,,No value,10 or fewer
+,,Total,15827
+,Total,Less than 65 Years,188137
+,,65 Years or more,290154
+,,No value,10 or fewer
+,,Total,478292
+Jan 1 – Dec 31 2024,"CUYAHOGA, OH",Less than 65 Years,11702
+,,65 Years or more,13650
+,,No value,10 or fewer
+,,Total,25352
+,"TARRANT, TX",Less than 65 Years,10646
+,,65 Years or more,12709
+,,No value,10 or fewer
+,,Total,23355
+,"FRANKLIN, OH",Less than 65 Years,8059
+,,65 Years or more,11273
+,,No value,10 or fewer
+,,Total,19332
+,"DALLAS, TX",Less than 65 Years,7672
+,,65 Years or more,9810
+,,No value,10 or fewer
+,,Total,17482
+,"HARRIS, TX",Less than 65 Years,5824
+,,65 Years or more,7007
+,,No value,10 or fewer
+,,Total,12831
+,"PHILADELPHIA, PA",Less than 65 Years,6681
+,,65 Years or more,6414
+,,No value,10 or fewer
+,,Total,13095
+,"HAMILTON, OH",Less than 65 Years,4225
+,,65 Years or more,7808
+,,No value,10 or fewer
+,,Total,12033
+,"MONTGOMERY, OH",Less than 65 Years,4472
+,,65 Years or more,7112
+,,No value,10 or fewer
+,,Total,11584
+,"LEHIGH, PA",Less than 65 Years,3195
+,,65 Years or more,4659
+,,No value,10 or fewer
+,,Total,7854
+,"NORTHAMPTON, PA",Less than 65 Years,2811
+,,65 Years or more,5042
+,,No value,10 or fewer
+,,Total,7853
+,"TULSA, OK",Less than 65 Years,2732
+,,65 Years or more,4836
+,,No value,10 or fewer
+,,Total,7568
+,"GREENVILLE, SC",Less than 65 Years,2513
+,,65 Years or more,4021
+,,No value,10 or fewer
+,,Total,6534
+,"YORK, PA",Less than 65 Years,2190
+,,65 Years or more,4322
+,,No value,10 or fewer
+,,Total,6512
+,"SPARTANBURG, SC",Less than 65 Years,2384
+,,65 Years or more,3956
+,,No value,10 or fewer
+,,Total,6340
+,"ALLEGHENY, PA",Less than 65 Years,1958
+,,65 Years or more,4154
+,,No value,10 or fewer
+,,Total,6112
+,"SUMMIT, OH",Less than 65 Years,1853
+,,65 Years or more,3956
+,,No value,10 or fewer
+,,Total,5809
+,"VIRGINIA BEACH CITY, VA",Less than 65 Years,1833
+,,65 Years or more,3824
+,,No value,10 or fewer
+,,Total,5657
+,"BUTLER, OH",Less than 65 Years,1987
+,,65 Years or more,3706
+,,No value,10 or fewer
+,,Total,5693
+,"FAIRFAX, VA",Less than 65 Years,2122
+,,65 Years or more,3693
+,,No value,10 or fewer
+,,Total,5815
+,"MONTGOMERY, PA",Less than 65 Years,1498
+,,65 Years or more,4124
+,,No value,10 or fewer
+,,Total,5622
+,"LORAIN, OH",Less than 65 Years,2123
+,,65 Years or more,3694
+,,No value,10 or fewer
+,,Total,5817
+,"SHELBY, TN",Less than 65 Years,1910
+,,65 Years or more,2498
+,,No value,10 or fewer
+,,Total,4408
+,"COLLIN, TX",Less than 65 Years,1617
+,,65 Years or more,3266
+,,No value,10 or fewer
+,,Total,4883
+,"CHESTER, PA",Less than 65 Years,1223
+,,65 Years or more,3610
+,,No value,10 or fewer
+,,Total,4833
+,"DELAWARE, PA",Less than 65 Years,1517
+,,65 Years or more,3275
+,,No value,10 or fewer
+,,Total,4792
+,"BUCKS, PA",Less than 65 Years,1341
+,,65 Years or more,3456
+,,No value,10 or fewer
+,,Total,4797
+,"CHARLESTON, SC",Less than 65 Years,1406
+,,65 Years or more,2989
+,,No value,10 or fewer
+,,Total,4395
+,"LUCAS, OH",Less than 65 Years,2057
+,,65 Years or more,2349
+,,No value,10 or fewer
+,,Total,4406
+,"LANCASTER, PA",Less than 65 Years,1311
+,,65 Years or more,3309
+,,No value,10 or fewer
+,,Total,4620
+,"DENTON, TX",Less than 65 Years,1535
+,,65 Years or more,2558
+,,No value,10 or fewer
+,,Total,4093
+,"JOHNSON, TX",Less than 65 Years,1641
+,,65 Years or more,2265
+,,No value,10 or fewer
+,,Total,3906
+,"BELL, TX",Less than 65 Years,2032
+,,65 Years or more,1870
+,,No value,10 or fewer
+,,Total,3902
+,"LAKE, OH",Less than 65 Years,1478
+,,65 Years or more,2945
+,,No value,10 or fewer
+,,Total,4423
+,"MULTNOMAH, OR",Less than 65 Years,1765
+,,65 Years or more,1997
+,,No value,10 or fewer
+,,Total,3762
+,"MAHONING, OH",Less than 65 Years,1278
+,,65 Years or more,2325
+,,No value,10 or fewer
+,,Total,3603
+,"WARREN, OH",Less than 65 Years,937
+,,65 Years or more,2347
+,,No value,10 or fewer
+,,Total,3284
+,"RICHLAND, SC",Less than 65 Years,1511
+,,65 Years or more,1933
+,,No value,10 or fewer
+,,Total,3444
+,"LOUDOUN, VA",Less than 65 Years,1234
+,,65 Years or more,2014
+,,No value,10 or fewer
+,,Total,3248
+,"BEXAR, TX",Less than 65 Years,1498
+,,65 Years or more,1482
+,,No value,10 or fewer
+,,Total,2980
+,"CLERMONT, OH",Less than 65 Years,1049
+,,65 Years or more,2008
+,,No value,10 or fewer
+,,Total,3057
+,"CLARK, OH",Less than 65 Years,1281
+,,65 Years or more,1737
+,,No value,10 or fewer
+,,Total,3018
+,"ANDERSON, SC",Less than 65 Years,1063
+,,65 Years or more,1924
+,,No value,10 or fewer
+,,Total,2987
+,"MONTGOMERY, TX",Less than 65 Years,1017
+,,65 Years or more,1877
+,,No value,10 or fewer
+,,Total,2894
+,"NEWPORT NEWS CITY, VA",Less than 65 Years,1227
+,,65 Years or more,1690
+,,No value,10 or fewer
+,,Total,2918
+,"CHESAPEAKE CITY, VA",Less than 65 Years,881
+,,65 Years or more,1938
+,,No value,10 or fewer
+,,Total,2819
+,"SULLIVAN, TN",Less than 65 Years,1033
+,,65 Years or more,1795
+,,No value,10 or fewer
+,,Total,2828
+,"MEDINA, OH",Less than 65 Years,1017
+,,65 Years or more,1825
+,,No value,10 or fewer
+,,Total,2842
+,"GREENE, OH",Less than 65 Years,931
+,,65 Years or more,1862
+,,No value,10 or fewer
+,,Total,2793
+,"NORFOLK CITY, VA",Less than 65 Years,1212
+,,65 Years or more,1525
+,,No value,10 or fewer
+,,Total,2737
+,"FORT BEND, TX",Less than 65 Years,972
+,,65 Years or more,1629
+,,No value,10 or fewer
+,,Total,2601
+,"PRINCE WILLIAM, VA",Less than 65 Years,1201
+,,65 Years or more,1674
+,,No value,10 or fewer
+,,Total,2875
+,"DELAWARE, OH",Less than 65 Years,736
+,,65 Years or more,2025
+,,No value,10 or fewer
+,,Total,2761
+,"ELLIS, TX",Less than 65 Years,965
+,,65 Years or more,1737
+,,No value,10 or fewer
+,,Total,2702
+,"DESCHUTES, OR",Less than 65 Years,862
+,,65 Years or more,1817
+,,No value,10 or fewer
+,,Total,2679
+,"MCLENNAN, TX",Less than 65 Years,1139
+,,65 Years or more,1497
+,,No value,10 or fewer
+,,Total,2636
+,"HAMILTON, TN",Less than 65 Years,1086
+,,65 Years or more,1419
+,,No value,10 or fewer
+,,Total,2505
+,"FRANKLIN, PA",Less than 65 Years,826
+,,65 Years or more,1615
+,,No value,10 or fewer
+,,Total,2441
+,"ERIE, PA",Less than 65 Years,977
+,,65 Years or more,1528
+,,No value,10 or fewer
+,,Total,2505
+,"HENRICO, VA",Less than 65 Years,924
+,,65 Years or more,1547
+,,No value,10 or fewer
+,,Total,2471
+,"BERKS, PA",Less than 65 Years,1082
+,,65 Years or more,1244
+,,No value,10 or fewer
+,,Total,2326
+,"SCHUYLKILL, PA",Less than 65 Years,887
+,,65 Years or more,1502
+,,No value,10 or fewer
+,,Total,2389
+,"MONROE, PA",Less than 65 Years,1030
+,,65 Years or more,1415
+,,No value,10 or fewer
+,,Total,2445
+,"LICKING, OH",Less than 65 Years,713
+,,65 Years or more,1602
+,,No value,10 or fewer
+,,Total,2315
+,"MIAMI, OH",Less than 65 Years,789
+,,65 Years or more,1337
+,,No value,10 or fewer
+,,Total,2126
+,"DAUPHIN, PA",Less than 65 Years,912
+,,65 Years or more,1235
+,,No value,10 or fewer
+,,Total,2147
+,"FLORENCE, SC",Less than 65 Years,841
+,,65 Years or more,1265
+,,No value,10 or fewer
+,,Total,2106
+,"FAYETTE, PA",Less than 65 Years,895
+,,65 Years or more,1177
+,,No value,10 or fewer
+,,Total,2072
+,"CHESTERFIELD, VA",Less than 65 Years,725
+,,65 Years or more,1249
+,,No value,10 or fewer
+,,Total,1974
+,"TRUMBULL, OH",Less than 65 Years,689
+,,65 Years or more,1243
+,,No value,10 or fewer
+,,Total,1932
+,"CUMBERLAND, PA",Less than 65 Years,619
+,,65 Years or more,1398
+,,No value,10 or fewer
+,,Total,2017
+,"RICHLAND, OH",Less than 65 Years,638
+,,65 Years or more,1352
+,,No value,10 or fewer
+,,Total,1990
+,"LINN, OR",Less than 65 Years,646
+,,65 Years or more,1281
+,,No value,10 or fewer
+,,Total,1927
+,"HAMPTON CITY, VA",Less than 65 Years,690
+,,65 Years or more,1140
+,,No value,10 or fewer
+,,Total,1830
+,"CHITTENDEN, VT",Less than 65 Years,567
+,,65 Years or more,1303
+,,No value,10 or fewer
+,,Total,1870
+,"WESTMORELAND, PA",Less than 65 Years,538
+,,65 Years or more,1281
+,,No value,10 or fewer
+,,Total,1819
+,"CARBON, PA",Less than 65 Years,675
+,,65 Years or more,1118
+,,No value,10 or fewer
+,,Total,1793
+,"HORRY, SC",Less than 65 Years,569
+,,65 Years or more,1279
+,,No value,10 or fewer
+,,Total,1848
+,"KAUFMAN, TX",Less than 65 Years,774
+,,65 Years or more,939
+,,No value,10 or fewer
+,,Total,1713
+,"TRAVIS, TX",Less than 65 Years,670
+,,65 Years or more,1050
+,,No value,10 or fewer
+,,Total,1720
+,"ARLINGTON, VA",Less than 65 Years,633
+,,65 Years or more,1062
+,,No value,10 or fewer
+,,Total,1695
+,"STARK, OH",Less than 65 Years,571
+,,65 Years or more,1140
+,,No value,10 or fewer
+,,Total,1711
+,"PORTAGE, OH",Less than 65 Years,624
+,,65 Years or more,1275
+,,No value,10 or fewer
+,,Total,1899
+,"BERKELEY, SC",Less than 65 Years,704
+,,65 Years or more,984
+,,No value,10 or fewer
+,,Total,1688
+,"JAMES CITY, VA",Less than 65 Years,353
+,,65 Years or more,1222
+,,No value,10 or fewer
+,,Total,1575
+,"PARKER, TX",Less than 65 Years,667
+,,65 Years or more,897
+,,No value,10 or fewer
+,,Total,1564
+,"PICKENS, SC",Less than 65 Years,655
+,,65 Years or more,950
+,,No value,10 or fewer
+,,Total,1605
+,"CASS, ND",Less than 65 Years,645
+,,65 Years or more,959
+,,No value,10 or fewer
+,,Total,1604
+,"CLACKAMAS, OR",Less than 65 Years,515
+,,65 Years or more,1105
+,,No value,10 or fewer
+,,Total,1620
+,"SMITH, TX",Less than 65 Years,563
+,,65 Years or more,936
+,,No value,10 or fewer
+,,Total,1499
+,"WILLIAMSON, TX",Less than 65 Years,582
+,,65 Years or more,998
+,,No value,10 or fewer
+,,Total,1580
+,"HENDERSON, TX",Less than 65 Years,536
+,,65 Years or more,895
+,,No value,10 or fewer
+,,Total,1431
+,"WASHINGTON, TN",Less than 65 Years,511
+,,65 Years or more,958
+,,No value,10 or fewer
+,,Total,1469
+,"RICHMOND CITY, VA",Less than 65 Years,861
+,,65 Years or more,683
+,,No value,10 or fewer
+,,Total,1544
+,"OKLAHOMA, OK",Less than 65 Years,909
+,,65 Years or more,770
+,,No value,10 or fewer
+,,Total,1679
+,"SUFFOLK CITY, VA",Less than 65 Years,578
+,,65 Years or more,852
+,,No value,10 or fewer
+,,Total,1430
+,"MARION, OH",Less than 65 Years,536
+,,65 Years or more,862
+,,No value,10 or fewer
+,,Total,1398
+,"LUZERNE, PA",Less than 65 Years,604
+,,65 Years or more,779
+,,No value,10 or fewer
+,,Total,1383
+,"FAIRFIELD, OH",Less than 65 Years,515
+,,65 Years or more,881
+,,No value,10 or fewer
+,,Total,1396
+,"MINNEHAHA, SD",Less than 65 Years,542
+,,65 Years or more,840
+,,No value,10 or fewer
+,,Total,1382
+,"LEBANON, PA",Less than 65 Years,394
+,,65 Years or more,900
+,,No value,10 or fewer
+,,Total,1294
+,"MUSKOGEE, OK",Less than 65 Years,491
+,,65 Years or more,736
+,,No value,10 or fewer
+,,Total,1227
+,"ALBEMARLE, VA",Less than 65 Years,337
+,,65 Years or more,896
+,,No value,10 or fewer
+,,Total,1233
+,"ADAMS, PA",Less than 65 Years,363
+,,65 Years or more,917
+,,No value,10 or fewer
+,,Total,1280
+,"WASHINGTON, PA",Less than 65 Years,425
+,,65 Years or more,809
+,,No value,10 or fewer
+,,Total,1234
+,"ALLEN, OH",Less than 65 Years,427
+,,65 Years or more,730
+,,No value,10 or fewer
+,,Total,1157
+,"FREDERICK, VA",Less than 65 Years,465
+,,65 Years or more,1188
+,,No value,10 or fewer
+,,Total,1653
+,"GEAUGA, OH",Less than 65 Years,369
+,,65 Years or more,979
+,,No value,10 or fewer
+,,Total,1348
+,"WASHINGTON, OR",Less than 65 Years,477
+,,65 Years or more,755
+,,No value,10 or fewer
+,,Total,1232
+,"CHEROKEE, SC",Less than 65 Years,443
+,,65 Years or more,686
+,,No value,10 or fewer
+,,Total,1129
+,"PORTSMOUTH CITY, VA",Less than 65 Years,542
+,,65 Years or more,664
+,,No value,10 or fewer
+,,Total,1206
+,"LINCOLN, OR",Less than 65 Years,353
+,,65 Years or more,774
+,,No value,10 or fewer
+,,Total,1127
+,"MARION, OR",Less than 65 Years,534
+,,65 Years or more,683
+,,No value,10 or fewer
+,,Total,1217
+,"GREENWOOD, SC",Less than 65 Years,411
+,,65 Years or more,670
+,,No value,10 or fewer
+,,Total,1081
+,"ROCKWALL, TX",Less than 65 Years,324
+,,65 Years or more,730
+,,No value,10 or fewer
+,,Total,1054
+,"SALT LAKE, UT",Less than 65 Years,496
+,,65 Years or more,609
+,,No value,10 or fewer
+,,Total,1105
+,"ROGERS, OK",Less than 65 Years,342
+,,65 Years or more,744
+,,No value,10 or fewer
+,,Total,1086
+,"COOS, OR",Less than 65 Years,317
+,,65 Years or more,817
+,,No value,10 or fewer
+,,Total,1134
+,"WASHINGTON, VA",Less than 65 Years,316
+,,65 Years or more,672
+,,No value,10 or fewer
+,,Total,988
+,"GRAND FORKS, ND",Less than 65 Years,498
+,,65 Years or more,506
+,,No value,10 or fewer
+,,Total,1004
+,"HAWKINS, TN",Less than 65 Years,369
+,,65 Years or more,623
+,,No value,10 or fewer
+,,Total,992
+,"TOM GREEN, TX",Less than 65 Years,383
+,,65 Years or more,530
+,,No value,10 or fewer
+,,Total,913
+,"YORK, VA",Less than 65 Years,301
+,,65 Years or more,718
+,,No value,10 or fewer
+,,Total,1019
+,"OCONEE, SC",Less than 65 Years,315
+,,65 Years or more,646
+,,No value,10 or fewer
+,,Total,961
+,"GREENE, TN",Less than 65 Years,370
+,,65 Years or more,575
+,,No value,10 or fewer
+,,Total,945
+,"HANOVER, VA",Less than 65 Years,263
+,,65 Years or more,697
+,,No value,10 or fewer
+,,Total,960
+,"ALEXANDRIA CITY, VA",Less than 65 Years,366
+,,65 Years or more,575
+,,No value,10 or fewer
+,,Total,941
+,"PICKAWAY, OH",Less than 65 Years,323
+,,65 Years or more,628
+,,No value,10 or fewer
+,,Total,951
+,"LEXINGTON, SC",Less than 65 Years,521
+,,65 Years or more,433
+,,No value,10 or fewer
+,,Total,954
+,"ATHENS, OH",Less than 65 Years,354
+,,65 Years or more,540
+,,No value,10 or fewer
+,,Total,894
+,"NUECES, TX",Less than 65 Years,915
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,939
+,"BURNET, TX",Less than 65 Years,314
+,,65 Years or more,606
+,,No value,10 or fewer
+,,Total,920
+,"PREBLE, OH",Less than 65 Years,336
+,,65 Years or more,531
+,,No value,10 or fewer
+,,Total,867
+,"BENTON, OR",Less than 65 Years,281
+,,65 Years or more,617
+,,No value,10 or fewer
+,,Total,898
+,"LANCASTER, SC",Less than 65 Years,340
+,,65 Years or more,555
+,,No value,10 or fewer
+,,Total,895
+,"POTTER, TX",Less than 65 Years,301
+,,65 Years or more,604
+,,No value,10 or fewer
+,,Total,905
+,"ASHTABULA, OH",Less than 65 Years,437
+,,65 Years or more,645
+,,No value,10 or fewer
+,,Total,1082
+,"RANDALL, TX",Less than 65 Years,262
+,,65 Years or more,626
+,,No value,10 or fewer
+,,Total,888
+,"LAURENS, SC",Less than 65 Years,325
+,,65 Years or more,446
+,,No value,10 or fewer
+,,Total,771
+,"BURLEIGH, ND",Less than 65 Years,320
+,,65 Years or more,491
+,,No value,10 or fewer
+,,Total,811
+,"BUTLER, PA",Less than 65 Years,251
+,,65 Years or more,544
+,,No value,10 or fewer
+,,Total,795
+,"WOOD, OH",Less than 65 Years,281
+,,65 Years or more,588
+,,No value,10 or fewer
+,,Total,869
+,"KERSHAW, SC",Less than 65 Years,283
+,,65 Years or more,541
+,,No value,10 or fewer
+,,Total,824
+,"ROCKINGHAM, VA",Less than 65 Years,204
+,,65 Years or more,607
+,,No value,10 or fewer
+,,Total,811
+,"SUMTER, SC",Less than 65 Years,367
+,,65 Years or more,451
+,,No value,10 or fewer
+,,Total,818
+,"BELMONT, OH",Less than 65 Years,269
+,,65 Years or more,501
+,,No value,10 or fewer
+,,Total,770
+,"UNION, SC",Less than 65 Years,309
+,,65 Years or more,448
+,,No value,10 or fewer
+,,Total,757
+,"BRAZOS, TX",Less than 65 Years,334
+,,65 Years or more,441
+,,No value,10 or fewer
+,,Total,775
+,"ACCOMACK, VA",Less than 65 Years,256
+,,65 Years or more,479
+,,No value,10 or fewer
+,,Total,735
+,"BRADFORD, PA",Less than 65 Years,229
+,,65 Years or more,485
+,,No value,10 or fewer
+,,Total,714
+,"TIPTON, TN",Less than 65 Years,344
+,,65 Years or more,387
+,,No value,10 or fewer
+,,Total,731
+,"WASHINGTON, TX",Less than 65 Years,195
+,,65 Years or more,454
+,,No value,10 or fewer
+,,Total,649
+,"LACKAWANNA, PA",Less than 65 Years,296
+,,65 Years or more,522
+,,No value,10 or fewer
+,,Total,818
+,"GLOUCESTER, VA",Less than 65 Years,235
+,,65 Years or more,437
+,,No value,10 or fewer
+,,Total,672
+,"TUSCARAWAS, OH",Less than 65 Years,307
+,,65 Years or more,550
+,,No value,10 or fewer
+,,Total,857
+,"WILLIAMS, OH",Less than 65 Years,269
+,,65 Years or more,455
+,,No value,10 or fewer
+,,Total,724
+,"BRAZORIA, TX",Less than 65 Years,286
+,,65 Years or more,329
+,,No value,10 or fewer
+,,Total,615
+,"SHENANDOAH, VA",Less than 65 Years,307
+,,65 Years or more,632
+,,No value,10 or fewer
+,,Total,939
+,"CARTER, TN",Less than 65 Years,268
+,,65 Years or more,423
+,,No value,10 or fewer
+,,Total,691
+,"CREEK, OK",Less than 65 Years,216
+,,65 Years or more,430
+,,No value,10 or fewer
+,,Total,646
+,"WAGONER, OK",Less than 65 Years,192
+,,65 Years or more,475
+,,No value,10 or fewer
+,,Total,667
+,"GALVESTON, TX",Less than 65 Years,206
+,,65 Years or more,394
+,,No value,10 or fewer
+,,Total,600
+,"BROWN, OH",Less than 65 Years,246
+,,65 Years or more,382
+,,No value,10 or fewer
+,,Total,628
+,"ISLE OF WIGHT, VA",Less than 65 Years,166
+,,65 Years or more,461
+,,No value,10 or fewer
+,,Total,627
+,"ERATH, TX",Less than 65 Years,208
+,,65 Years or more,367
+,,No value,10 or fewer
+,,Total,575
+,"MADISON, TN",Less than 65 Years,214
+,,65 Years or more,258
+,,No value,10 or fewer
+,,Total,472
+,"DARLINGTON, SC",Less than 65 Years,232
+,,65 Years or more,364
+,,No value,10 or fewer
+,,Total,596
+,"CROOK, OR",Less than 65 Years,207
+,,65 Years or more,394
+,,No value,10 or fewer
+,,Total,601
+,"CRAWFORD, OH",Less than 65 Years,190
+,,65 Years or more,368
+,,No value,10 or fewer
+,,Total,558
+,"WISE, VA",Less than 65 Years,237
+,,65 Years or more,316
+,,No value,10 or fewer
+,,Total,553
+,"JEFFERSON, OR",Less than 65 Years,251
+,,65 Years or more,345
+,,No value,10 or fewer
+,,Total,596
+,"ASHLAND, OH",Less than 65 Years,191
+,,65 Years or more,520
+,,No value,10 or fewer
+,,Total,711
+,"ORANGEBURG, SC",Less than 65 Years,300
+,,65 Years or more,471
+,,No value,10 or fewer
+,,Total,771
+,"DILLON, SC",Less than 65 Years,218
+,,65 Years or more,330
+,,No value,10 or fewer
+,,Total,548
+,"WOOD, TX",Less than 65 Years,157
+,,65 Years or more,364
+,,No value,10 or fewer
+,,Total,521
+,"WARREN, VA",Less than 65 Years,297
+,,65 Years or more,489
+,,No value,10 or fewer
+,,Total,786
+,"MECKLENBURG, VA",Less than 65 Years,170
+,,65 Years or more,353
+,,No value,10 or fewer
+,,Total,523
+,"LLANO, TX",Less than 65 Years,181
+,,65 Years or more,371
+,,No value,10 or fewer
+,,Total,552
+,"DARKE, OH",Less than 65 Years,227
+,,65 Years or more,422
+,,No value,10 or fewer
+,,Total,649
+,"MADISON, OH",Less than 65 Years,192
+,,65 Years or more,334
+,,No value,10 or fewer
+,,Total,526
+,"SENECA, OH",Less than 65 Years,207
+,,65 Years or more,341
+,,No value,10 or fewer
+,,Total,548
+,"CORYELL, TX",Less than 65 Years,252
+,,65 Years or more,277
+,,No value,10 or fewer
+,,Total,529
+,"SMYTH, VA",Less than 65 Years,224
+,,65 Years or more,274
+,,No value,10 or fewer
+,,Total,498
+,"DORCHESTER, SC",Less than 65 Years,202
+,,65 Years or more,318
+,,No value,10 or fewer
+,,Total,520
+,"PETERSBURG CITY, VA",Less than 65 Years,195
+,,65 Years or more,274
+,,No value,10 or fewer
+,,Total,469
+,"MALHEUR, OR",Less than 65 Years,211
+,,65 Years or more,268
+,,No value,10 or fewer
+,,Total,479
+,"CHAMPAIGN, OH",Less than 65 Years,179
+,,65 Years or more,292
+,,No value,10 or fewer
+,,Total,471
+,"MAYES, OK",Less than 65 Years,178
+,,65 Years or more,284
+,,No value,10 or fewer
+,,Total,462
+,"RUSK, TX",Less than 65 Years,185
+,,65 Years or more,302
+,,No value,10 or fewer
+,,Total,487
+,"CULPEPER, VA",Less than 65 Years,231
+,,65 Years or more,372
+,,No value,10 or fewer
+,,Total,603
+,"CHARLOTTESVILLE CITY, VA",Less than 65 Years,232
+,,65 Years or more,255
+,,No value,10 or fewer
+,,Total,487
+,"COLUMBIANA, OH",Less than 65 Years,127
+,,65 Years or more,291
+,,No value,10 or fewer
+,,Total,418
+,"CLARENDON, SC",Less than 65 Years,179
+,,65 Years or more,283
+,,No value,10 or fewer
+,,Total,462
+,"OBION, TN",Less than 65 Years,131
+,,65 Years or more,258
+,,No value,10 or fewer
+,,Total,389
+,"HALIFAX, VA",Less than 65 Years,149
+,,65 Years or more,263
+,,No value,10 or fewer
+,,Total,412
+,"CHEROKEE, TX",Less than 65 Years,241
+,,65 Years or more,214
+,,No value,10 or fewer
+,,Total,455
+,"CARROLL, TN",Less than 65 Years,133
+,,65 Years or more,231
+,,No value,10 or fewer
+,,Total,364
+,"HARRISONBURG CITY, VA",Less than 65 Years,146
+,,65 Years or more,264
+,,No value,10 or fewer
+,,Total,410
+,"UMATILLA, OR",Less than 65 Years,185
+,,65 Years or more,252
+,,No value,10 or fewer
+,,Total,437
+,"SANDUSKY, OH",Less than 65 Years,136
+,,65 Years or more,241
+,,No value,10 or fewer
+,,Total,377
+,"WASHINGTON, RI",Less than 65 Years,91
+,,65 Years or more,268
+,,No value,10 or fewer
+,,Total,359
+,"HIGHLAND, OH",Less than 65 Years,170
+,,65 Years or more,339
+,,No value,10 or fewer
+,,Total,509
+,"OKMULGEE, OK",Less than 65 Years,125
+,,65 Years or more,253
+,,No value,10 or fewer
+,,Total,378
+,"RUSSELL, VA",Less than 65 Years,137
+,,65 Years or more,225
+,,No value,10 or fewer
+,,Total,362
+,"CHESTERFIELD, SC",Less than 65 Years,156
+,,65 Years or more,227
+,,No value,10 or fewer
+,,Total,383
+,"HIDALGO, TX",Less than 65 Years,374
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,406
+,"PUTNAM, OH",Less than 65 Years,108
+,,65 Years or more,265
+,,No value,10 or fewer
+,,Total,373
+,"MERCER, PA",Less than 65 Years,82
+,,65 Years or more,264
+,,No value,10 or fewer
+,,Total,346
+,"HOOD, TX",Less than 65 Years,154
+,,65 Years or more,208
+,,No value,10 or fewer
+,,Total,362
+,"NEW KENT, VA",Less than 65 Years,135
+,,65 Years or more,203
+,,No value,10 or fewer
+,,Total,338
+,"WASHINGTON, VT",Less than 65 Years,91
+,,65 Years or more,255
+,,No value,10 or fewer
+,,Total,346
+,"STUTSMAN, ND",Less than 65 Years,163
+,,65 Years or more,180
+,,No value,10 or fewer
+,,Total,343
+,"SCOTT, VA",Less than 65 Years,114
+,,65 Years or more,210
+,,No value,10 or fewer
+,,Total,324
+,"CLEVELAND, OK",Less than 65 Years,184
+,,65 Years or more,240
+,,No value,10 or fewer
+,,Total,424
+,"DEFIANCE, OH",Less than 65 Years,118
+,,65 Years or more,198
+,,No value,10 or fewer
+,,Total,316
+,"MARION, SC",Less than 65 Years,137
+,,65 Years or more,187
+,,No value,10 or fewer
+,,Total,324
+,"LINCOLN, SD",Less than 65 Years,116
+,,65 Years or more,219
+,,No value,10 or fewer
+,,Total,335
+,"HURON, OH",Less than 65 Years,152
+,,65 Years or more,209
+,,No value,10 or fewer
+,,Total,361
+,"PENNINGTON, SD",Less than 65 Years,221
+,,65 Years or more,103
+,,No value,10 or fewer
+,,Total,324
+,"HILL, TX",Less than 65 Years,147
+,,65 Years or more,191
+,,No value,10 or fewer
+,,Total,338
+,"LEE, VA",Less than 65 Years,172
+,,65 Years or more,178
+,,No value,10 or fewer
+,,Total,350
+,"WAYNE, OH",Less than 65 Years,128
+,,65 Years or more,194
+,,No value,10 or fewer
+,,Total,322
+,"SEQUOYAH, OK",Less than 65 Years,129
+,,65 Years or more,202
+,,No value,10 or fewer
+,,Total,331
+,"GIBSON, TN",Less than 65 Years,85
+,,65 Years or more,141
+,,No value,10 or fewer
+,,Total,226
+,"BEAVER, PA",Less than 65 Years,95
+,,65 Years or more,205
+,,No value,10 or fewer
+,,Total,300
+,"ORANGE, VA",Less than 65 Years,135
+,,65 Years or more,225
+,,No value,10 or fewer
+,,Total,360
+,"HAYS, TX",Less than 65 Years,185
+,,65 Years or more,196
+,,No value,10 or fewer
+,,Total,381
+,"CRAIG, OK",Less than 65 Years,115
+,,65 Years or more,194
+,,No value,10 or fewer
+,,Total,309
+,"FAIRFIELD, SC",Less than 65 Years,136
+,,65 Years or more,224
+,,No value,10 or fewer
+,,Total,360
+,"CANADIAN, OK",Less than 65 Years,211
+,,65 Years or more,189
+,,No value,10 or fewer
+,,Total,400
+,"WILLIAMSBURG, SC",Less than 65 Years,151
+,,65 Years or more,210
+,,No value,10 or fewer
+,,Total,361
+,"LAMPASAS, TX",Less than 65 Years,87
+,,65 Years or more,229
+,,No value,10 or fewer
+,,Total,316
+,"MORTON, ND",Less than 65 Years,116
+,,65 Years or more,204
+,,No value,10 or fewer
+,,Total,320
+,"CHESTER, SC",Less than 65 Years,153
+,,65 Years or more,148
+,,No value,10 or fewer
+,,Total,301
+,"LOUISA, VA",Less than 65 Years,127
+,,65 Years or more,181
+,,No value,10 or fewer
+,,Total,308
+,"MANASSAS CITY, VA",Less than 65 Years,146
+,,65 Years or more,162
+,,No value,10 or fewer
+,,Total,308
+,"FLUVANNA, VA",Less than 65 Years,98
+,,65 Years or more,205
+,,No value,10 or fewer
+,,Total,303
+,"FAYETTE, TN",Less than 65 Years,90
+,,65 Years or more,197
+,,No value,10 or fewer
+,,Total,287
+,"AUGLAIZE, OH",Less than 65 Years,86
+,,65 Years or more,227
+,,No value,10 or fewer
+,,Total,313
+,"LIBERTY, TX",Less than 65 Years,129
+,,65 Years or more,161
+,,No value,10 or fewer
+,,Total,290
+,"BRADLEY, TN",Less than 65 Years,122
+,,65 Years or more,136
+,,No value,10 or fewer
+,,Total,258
+,"NORTHAMPTON, VA",Less than 65 Years,92
+,,65 Years or more,194
+,,No value,10 or fewer
+,,Total,286
+,"ERIE, OH",Less than 65 Years,97
+,,65 Years or more,213
+,,No value,10 or fewer
+,,Total,310
+,"VAN ZANDT, TX",Less than 65 Years,119
+,,65 Years or more,183
+,,No value,10 or fewer
+,,Total,302
+,"COLUMBIA, OR",Less than 65 Years,87
+,,65 Years or more,210
+,,No value,10 or fewer
+,,Total,297
+,"COLONIAL HEIGHTS CITY, VA",Less than 65 Years,88
+,,65 Years or more,176
+,,No value,10 or fewer
+,,Total,264
+,"WINCHESTER CITY, VA",Less than 65 Years,129
+,,65 Years or more,219
+,,No value,10 or fewer
+,,Total,348
+,"BRISTOL CITY, VA",Less than 65 Years,133
+,,65 Years or more,140
+,,No value,10 or fewer
+,,Total,273
+,"MCINTOSH, OK",Less than 65 Years,66
+,,65 Years or more,194
+,,No value,10 or fewer
+,,Total,260
+,"CLINTON, OH",Less than 65 Years,100
+,,65 Years or more,159
+,,No value,10 or fewer
+,,Total,259
+,"ADDISON, VT",Less than 65 Years,75
+,,65 Years or more,196
+,,No value,10 or fewer
+,,Total,271
+,"SEQUATCHIE, TN",Less than 65 Years,106
+,,65 Years or more,161
+,,No value,10 or fewer
+,,Total,267
+,"BROWN, SD",Less than 65 Years,119
+,,65 Years or more,165
+,,No value,10 or fewer
+,,Total,284
+,"FAUQUIER, VA",Less than 65 Years,116
+,,65 Years or more,161
+,,No value,10 or fewer
+,,Total,277
+,"BRUNSWICK, VA",Less than 65 Years,106
+,,65 Years or more,162
+,,No value,10 or fewer
+,,Total,268
+,"PIKE, PA",Less than 65 Years,121
+,,65 Years or more,152
+,,No value,10 or fewer
+,,Total,273
+,"MILAM, TX",Less than 65 Years,89
+,,65 Years or more,179
+,,No value,10 or fewer
+,,Total,268
+,"PAGE, VA",Less than 65 Years,109
+,,65 Years or more,197
+,,No value,10 or fewer
+,,Total,306
+,"MORROW, OH",Less than 65 Years,106
+,,65 Years or more,164
+,,No value,10 or fewer
+,,Total,270
+,"UNICOI, TN",Less than 65 Years,87
+,,65 Years or more,181
+,,No value,10 or fewer
+,,Total,268
+,"ROSS, OH",Less than 65 Years,112
+,,65 Years or more,134
+,,No value,10 or fewer
+,,Total,246
+,"CLARKE, VA",Less than 65 Years,75
+,,65 Years or more,255
+,,No value,10 or fewer
+,,Total,330
+,"YORK, SC",Less than 65 Years,114
+,,65 Years or more,158
+,,No value,10 or fewer
+,,Total,272
+,"WISE, TX",Less than 65 Years,112
+,,65 Years or more,114
+,,No value,10 or fewer
+,,Total,226
+,"UNION, OH",Less than 65 Years,89
+,,65 Years or more,160
+,,No value,10 or fewer
+,,Total,249
+,"CHAMBERS, TX",Less than 65 Years,78
+,,65 Years or more,153
+,,No value,10 or fewer
+,,Total,231
+,"ARMSTRONG, PA",Less than 65 Years,82
+,,65 Years or more,160
+,,No value,10 or fewer
+,,Total,242
+,"BLEDSOE, TN",Less than 65 Years,97
+,,65 Years or more,135
+,,No value,10 or fewer
+,,Total,232
+,"HARDIN, OH",Less than 65 Years,77
+,,65 Years or more,145
+,,No value,10 or fewer
+,,Total,222
+,"POWHATAN, VA",Less than 65 Years,78
+,,65 Years or more,130
+,,No value,10 or fewer
+,,Total,208
+,"AIKEN, SC",Less than 65 Years,86
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,183
+,"DINWIDDIE, VA",Less than 65 Years,111
+,,65 Years or more,129
+,,No value,10 or fewer
+,,Total,240
+,"OTTAWA, OH",Less than 65 Years,89
+,,65 Years or more,144
+,,No value,10 or fewer
+,,Total,233
+,"DICKENSON, VA",Less than 65 Years,93
+,,65 Years or more,131
+,,No value,10 or fewer
+,,Total,224
+,"TAZEWELL, VA",Less than 65 Years,102
+,,65 Years or more,118
+,,No value,10 or fewer
+,,Total,220
+,"SHELBY, OH",Less than 65 Years,91
+,,65 Years or more,130
+,,No value,10 or fewer
+,,Total,221
+,"WINDSOR, VT",Less than 65 Years,83
+,,65 Years or more,145
+,,No value,10 or fewer
+,,Total,228
+,"HUNT, TX",Less than 65 Years,78
+,,65 Years or more,132
+,,No value,10 or fewer
+,,Total,210
+,"GREENE, VA",Less than 65 Years,91
+,,65 Years or more,120
+,,No value,10 or fewer
+,,Total,211
+,"GREENE, PA",Less than 65 Years,103
+,,65 Years or more,108
+,,No value,10 or fewer
+,,Total,211
+,"BAKER, OR",Less than 65 Years,46
+,,65 Years or more,176
+,,No value,10 or fewer
+,,Total,222
+,"POQUOSON CITY, VA",Less than 65 Years,46
+,,65 Years or more,160
+,,No value,10 or fewer
+,,Total,206
+,"FAIRFAX CITY, VA",Less than 65 Years,81
+,,65 Years or more,165
+,,No value,10 or fewer
+,,Total,246
+,"LE FLORE, OK",Less than 65 Years,87
+,,65 Years or more,130
+,,No value,10 or fewer
+,,Total,217
+,"SOUTHAMPTON, VA",Less than 65 Years,78
+,,65 Years or more,130
+,,No value,10 or fewer
+,,Total,208
+,"WYANDOT, OH",Less than 65 Years,57
+,,65 Years or more,143
+,,No value,10 or fewer
+,,Total,200
+,"PERRY, PA",Less than 65 Years,61
+,,65 Years or more,129
+,,No value,10 or fewer
+,,Total,190
+,"DYER, TN",Less than 65 Years,53
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,148
+,"WEAKLEY, TN",Less than 65 Years,64
+,,65 Years or more,105
+,,No value,10 or fewer
+,,Total,169
+,"KING WILLIAM, VA",Less than 65 Years,85
+,,65 Years or more,131
+,,No value,10 or fewer
+,,Total,216
+,"KNOX, OH",Less than 65 Years,71
+,,65 Years or more,126
+,,No value,10 or fewer
+,,Total,197
+,"JOHNSON, TN",Less than 65 Years,86
+,,65 Years or more,129
+,,No value,10 or fewer
+,,Total,215
+,"MONROE, OH",Less than 65 Years,76
+,,65 Years or more,137
+,,No value,10 or fewer
+,,Total,213
+,"ESSEX, VA",Less than 65 Years,79
+,,65 Years or more,155
+,,No value,10 or fewer
+,,Total,234
+,"MIDDLESEX, VA",Less than 65 Years,65
+,,65 Years or more,133
+,,No value,10 or fewer
+,,Total,198
+,"VAN WERT, OH",Less than 65 Years,87
+,,65 Years or more,128
+,,No value,10 or fewer
+,,Total,215
+,"MARLBORO, SC",Less than 65 Years,81
+,,65 Years or more,105
+,,No value,10 or fewer
+,,Total,186
+,"NEWPORT, RI",Less than 65 Years,40
+,,65 Years or more,159
+,,No value,10 or fewer
+,,Total,199
+,"GOOCHLAND, VA",Less than 65 Years,67
+,,65 Years or more,137
+,,No value,10 or fewer
+,,Total,204
+,"FRANKLIN CITY, VA",Less than 65 Years,73
+,,65 Years or more,125
+,,No value,10 or fewer
+,,Total,198
+,"PAYNE, OK",Less than 65 Years,80
+,,65 Years or more,124
+,,No value,10 or fewer
+,,Total,204
+,"WALSH, ND",Less than 65 Years,72
+,,65 Years or more,104
+,,No value,10 or fewer
+,,Total,176
+,"NAVARRO, TX",Less than 65 Years,72
+,,65 Years or more,105
+,,No value,10 or fewer
+,,Total,177
+,"LANCASTER, VA",Less than 65 Years,53
+,,65 Years or more,142
+,,No value,10 or fewer
+,,Total,195
+,"PRINCE GEORGE, VA",Less than 65 Years,71
+,,65 Years or more,103
+,,No value,10 or fewer
+,,Total,174
+,"AUGUSTA, VA",Less than 65 Years,71
+,,65 Years or more,125
+,,No value,10 or fewer
+,,Total,196
+,"GRAYSON, TX",Less than 65 Years,66
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,172
+,"WILLIAMSBURG CITY, VA",Less than 65 Years,47
+,,65 Years or more,132
+,,No value,10 or fewer
+,,Total,179
+,"ABBEVILLE, SC",Less than 65 Years,51
+,,65 Years or more,117
+,,No value,10 or fewer
+,,Total,168
+,"CLAY, SD",Less than 65 Years,59
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,165
+,"PANOLA, TX",Less than 65 Years,51
+,,65 Years or more,112
+,,No value,10 or fewer
+,,Total,163
+,"NORTHUMBERLAND, VA",Less than 65 Years,40
+,,65 Years or more,128
+,,No value,10 or fewer
+,,Total,168
+,"FULTON, OH",Less than 65 Years,62
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,164
+,"MATHEWS, VA",Less than 65 Years,37
+,,65 Years or more,134
+,,No value,10 or fewer
+,,Total,171
+,"WALLER, TX",Less than 65 Years,62
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,143
+,"WESTMORELAND, VA",Less than 65 Years,54
+,,65 Years or more,121
+,,No value,10 or fewer
+,,Total,175
+,"LAWRENCE, PA",Less than 65 Years,51
+,,65 Years or more,104
+,,No value,10 or fewer
+,,Total,155
+,"GRIMES, TX",Less than 65 Years,56
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,148
+,"BLANCO, TX",Less than 65 Years,50
+,,65 Years or more,105
+,,No value,10 or fewer
+,,Total,155
+,"GREENSVILLE, VA",Less than 65 Years,72
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,178
+,"CAMP, TX",Less than 65 Years,70
+,,65 Years or more,87
+,,No value,10 or fewer
+,,Total,157
+,"HARDEMAN, TN",Less than 65 Years,42
+,,65 Years or more,72
+,,No value,10 or fewer
+,,Total,114
+,"LOGAN, OH",Less than 65 Years,54
+,,65 Years or more,96
+,,No value,10 or fewer
+,,Total,150
+,"LUNENBURG, VA",Less than 65 Years,56
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,150
+,"WASHINGTON, OH",Less than 65 Years,65
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,142
+,"MARION, TN",Less than 65 Years,61
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,141
+,"RICHMOND, VA",Less than 65 Years,40
+,,65 Years or more,94
+,,No value,10 or fewer
+,,Total,134
+,"LANE, OR",Less than 65 Years,55
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,146
+,"BOSQUE, TX",Less than 65 Years,54
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,125
+,"FAYETTE, OH",Less than 65 Years,56
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,131
+,"SCIOTO, OH",Less than 65 Years,55
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,137
+,"AUSTIN, TX",Less than 65 Years,42
+,,65 Years or more,98
+,,No value,10 or fewer
+,,Total,140
+,"UNION, SD",Less than 65 Years,50
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,147
+,"BURLESON, TX",Less than 65 Years,43
+,,65 Years or more,105
+,,No value,10 or fewer
+,,Total,148
+,"ADAMS, OH",Less than 65 Years,59
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,135
+,"BEAUFORT, SC",Less than 65 Years,33
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,125
+,"MADISON, VA",Less than 65 Years,46
+,,65 Years or more,105
+,,No value,10 or fewer
+,,Total,151
+,"NELSON, VA",Less than 65 Years,35
+,,65 Years or more,99
+,,No value,10 or fewer
+,,Total,134
+,"PROVIDENCE, RI",Less than 65 Years,76
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,120
+,"KING AND QUEEN, VA",Less than 65 Years,43
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,122
+,"CALHOUN, SC",Less than 65 Years,61
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,158
+,"TRAILL, ND",Less than 65 Years,36
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,133
+,"BENTON, TN",Less than 65 Years,39
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,83
+,"ANDERSON, TX",Less than 65 Years,56
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,127
+,"FALLS, TX",Less than 65 Years,49
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,123
+,"HANCOCK, OH",Less than 65 Years,45
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,116
+,"JEFFERSON, OH",Less than 65 Years,48
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,111
+,"SUSQUEHANNA, PA",Less than 65 Years,35
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,119
+,"SAN PATRICIO, TX",Less than 65 Years,114
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,117
+,"SUSSEX, VA",Less than 65 Years,44
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,113
+,"HENRY, VA",Less than 65 Years,39
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,105
+,"MCCORMICK, SC",Less than 65 Years,32
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,113
+,"LEE, SC",Less than 65 Years,41
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,111
+,"DAVIDSON, TN",Less than 65 Years,66
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,119
+,"COOKE, TX",Less than 65 Years,52
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,115
+,"TIOGA, PA",Less than 65 Years,36
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,110
+,"GUERNSEY, OH",Less than 65 Years,22
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,75
+,"MEIGS, OH",Less than 65 Years,37
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,107
+,"UPSHUR, TX",Less than 65 Years,40
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,115
+,"PALO PINTO, TX",Less than 65 Years,42
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,111
+,"CHARLES CITY, VA",Less than 65 Years,44
+,,65 Years or more,64
+,,No value,10 or fewer
+,,Total,108
+,"PEMBINA, ND",Less than 65 Years,32
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,91
+,"NEWBERRY, SC",Less than 65 Years,43
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,105
+,"EDGEFIELD, SC",Less than 65 Years,50
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,123
+,"MUSKINGUM, OH",Less than 65 Years,41
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,92
+,"TURNER, SD",Less than 65 Years,17
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,99
+,"WAYNE, PA",Less than 65 Years,38
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,95
+,"PERRY, OH",Less than 65 Years,33
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,93
+,"GEORGETOWN, SC",Less than 65 Years,44
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,123
+,"GREGG, TX",Less than 65 Years,38
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,113
+,"ORANGE, VT",Less than 65 Years,44
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,93
+,"YAMHILL, OR",Less than 65 Years,40
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,109
+,"STAFFORD, VA",Less than 65 Years,57
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,97
+,"HOCKING, OH",Less than 65 Years,36
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,96
+,"COLLETON, SC",Less than 65 Years,37
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,91
+,"KNOX, TN",Less than 65 Years,45
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,100
+,"DAY, SD",Less than 65 Years,38
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,116
+,"POLK, OR",Less than 65 Years,41
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,94
+,"LAUDERDALE, TN",Less than 65 Years,45
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,89
+,"SALUDA, SC",Less than 65 Years,39
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,101
+,"ROBERTSON, TX",Less than 65 Years,31
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,90
+,"HANCOCK, TN",Less than 65 Years,45
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,90
+,"WHARTON, TX",Less than 65 Years,32
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,85
+,"DAVIS, UT",Less than 65 Years,44
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,97
+,"FALLS CHURCH CITY, VA",Less than 65 Years,27
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,96
+,"BUCKINGHAM, VA",Less than 65 Years,43
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,89
+,"COMAL, TX",Less than 65 Years,28
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,82
+,"CHEROKEE, OK",Less than 65 Years,36
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,99
+,"ROBERTS, SD",Less than 65 Years,44
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,98
+,"FRANKLIN, VT",Less than 65 Years,32
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,93
+,"BAMBERG, SC",Less than 65 Years,55
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,125
+,"CHESTER, TN",Less than 65 Years,21
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,66
+,"SURRY, VA",Less than 65 Years,35
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,91
+,"SPOTSYLVANIA, VA",Less than 65 Years,44
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,84
+,"WASHINGTON, OK",Less than 65 Years,43
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,101
+,"HOPEWELL CITY, VA",Less than 65 Years,44
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,71
+,"TRIPP, SD",Less than 65 Years,33
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,82
+,"CAROLINE, VA",Less than 65 Years,34
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,77
+,"CARROLL, OH",Less than 65 Years,33
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,85
+,"WALKER, TX",Less than 65 Years,24
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,81
+,"BRULE, SD",Less than 65 Years,23
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,66
+,"PAWNEE, OK",Less than 65 Years,35
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,94
+,"HARNEY, OR",Less than 65 Years,23
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,61
+,"CRAWFORD, PA",Less than 65 Years,25
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,74
+,"TITUS, TX",Less than 65 Years,40
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,74
+,"DANVILLE CITY, VA",Less than 65 Years,28
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,83
+,"NORTON CITY, VA",Less than 65 Years,28
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,81
+,"CROCKETT, TN",Less than 65 Years,31
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,66
+,"HENRY, OH",Less than 65 Years,27
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,68
+,"PAULDING, OH",Less than 65 Years,42
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,87
+,"BASTROP, TX",Less than 65 Years,40
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,86
+,"UTAH, UT",Less than 65 Years,34
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,58
+,"JACKSON, OH",Less than 65 Years,20
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,61
+,"NOTTOWAY, VA",Less than 65 Years,31
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,69
+,"EL PASO, TX",Less than 65 Years,44
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,83
+,"JEFFERSON, TX",Less than 65 Years,37
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,65
+,"MERCER, ND",Less than 65 Years,38
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,86
+,"MORROW, OR",Less than 65 Years,37
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,83
+,"WICHITA, TX",Less than 65 Years,36
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,74
+,"LINCOLN, OK",Less than 65 Years,36
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,77
+,"MCKENZIE, ND",Less than 65 Years,40
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,70
+,"MORRIS, TX",Less than 65 Years,25
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,70
+,"PITTSBURG, OK",Less than 65 Years,36
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,80
+,"RHEA, TN",Less than 65 Years,41
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,78
+,"OTTAWA, OK",Less than 65 Years,19
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,63
+,"BUCHANAN, VA",Less than 65 Years,28
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,65
+,"PITTSYLVANIA, VA",Less than 65 Years,15
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,56
+,"RICHLAND, ND",Less than 65 Years,22
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,68
+,"WYOMING, PA",Less than 65 Years,21
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,61
+,"LIMESTONE, TX",Less than 65 Years,26
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,69
+,"CAMERON, TX",Less than 65 Years,34
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,62
+,"MEADE, SD",Less than 65 Years,49
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,70
+,"MEDINA, TX",Less than 65 Years,24
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,58
+,"NELSON, ND",Less than 65 Years,16
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,65
+,"LAWRENCE, SD",Less than 65 Years,27
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,75
+,"AMELIA, VA",Less than 65 Years,15
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,68
+,"MERCER, OH",Less than 65 Years,20
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,73
+,"BARNWELL, SC",Less than 65 Years,45
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,84
+,"VINTON, OH",Less than 65 Years,23
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,58
+,"DELAWARE, OK",Less than 65 Years,33
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,68
+,"POLK, TX",Less than 65 Years,12
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,53
+,"KLAMATH, OR",Less than 65 Years,20
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,56
+,"LOGAN, OK",Less than 65 Years,39
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,81
+,"RAPPAHANNOCK, VA",Less than 65 Years,22
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,82
+,"GUADALUPE, TX",Less than 65 Years,36
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,67
+,"STAUNTON CITY, VA",Less than 65 Years,21
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,64
+,"WAYNESBORO CITY, VA",Less than 65 Years,29
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,58
+,"FAYETTE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,60
+,"DOUGLAS, OR",Less than 65 Years,21
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,48
+,"SAN SABA, TX",Less than 65 Years,20
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,57
+,"LAKE, TN",Less than 65 Years,17
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,48
+,"JACKSON, OR",Less than 65 Years,24
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,56
+,"CHARLOTTE, VA",Less than 65 Years,25
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,47
+,"COMANCHE, TX",Less than 65 Years,24
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,50
+,"KENDALL, TX",Less than 65 Years,14
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,53
+,"MANASSAS PARK CITY, VA",Less than 65 Years,31
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,54
+,"HUTCHINSON, TX",Less than 65 Years,20
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,64
+,"INDIANA, PA",Less than 65 Years,26
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,54
+,"POTTAWATOMIE, OK",Less than 65 Years,31
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,64
+,"HARRISON, OH",Less than 65 Years,16
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,57
+,"HASKELL, OK",Less than 65 Years,16
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,48
+,"GRUNDY, TN",Less than 65 Years,16
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,51
+,"LEON, TX",Less than 65 Years,15
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,47
+,"LEE, TX",Less than 65 Years,12
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,48
+,"LUBBOCK, TX",Less than 65 Years,26
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,48
+,"COSHOCTON, OH",Less than 65 Years,13
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,53
+,"PIKE, OH",Less than 65 Years,18
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,48
+,"POLK, TN",Less than 65 Years,15
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,33
+,"RUTLAND, VT",Less than 65 Years,17
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,46
+,"BARNES, ND",Less than 65 Years,23
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,53
+,"BRISTOL, RI",Less than 65 Years,13
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,55
+,"OSAGE, OK",Less than 65 Years,18
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,54
+,"FULTON, PA",Less than 65 Years,22
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,47
+,"WINDHAM, VT",Less than 65 Years,17
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,45
+,"COMANCHE, OK",Less than 65 Years,23
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,45
+,"FANNIN, TX",Less than 65 Years,19
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,41
+,"JIM WELLS, TX",Less than 65 Years,43
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,46
+,"WYTHE, VA",Less than 65 Years,14
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,47
+,"GRAND ISLE, VT",Less than 65 Years,14
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,48
+,"CUMBERLAND, VA",Less than 65 Years,15
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,49
+,"HENDERSON, TN",Less than 65 Years,16
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,34
+,"KENT, RI",Less than 65 Years,28
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,42
+,"OKFUSKEE, OK",Less than 65 Years,18
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,44
+,"EASTLAND, TX",Less than 65 Years,16
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,45
+,"WILLIAMS, ND",Less than 65 Years,19
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,50
+,"FREESTONE, TX",Less than 65 Years,20
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,50
+,"MONTAGUE, TX",Less than 65 Years,21
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,45
+,"TILLAMOOK, OR",Less than 65 Years,12
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,42
+,"WILLIAMSON, TN",Less than 65 Years,14
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,38
+,"CAVALIER, ND",Less than 65 Years,21
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,53
+,"WEBB, TX",Less than 65 Years,25
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,39
+,"LAMOURE, ND",Less than 65 Years,14
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,36
+,"RUTHERFORD, TN",Less than 65 Years,25
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,46
+,"HAYWOOD, TN",Less than 65 Years,18
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,36
+,"SUMMIT, UT",Less than 65 Years,12
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,42
+,"FALL RIVER, SD",Less than 65 Years,18
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,48
+,"LAMOILLE, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,37
+,"HOPKINS, TX",Less than 65 Years,12
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,36
+,"SOMERVELL, TX",Less than 65 Years,21
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,40
+,"TAYLOR, TX",Less than 65 Years,26
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,47
+,"GRADY, OK",Less than 65 Years,25
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,58
+,"HENRY, TN",Less than 65 Years,15
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,32
+,"VENANGO, PA",Less than 65 Years,16
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,37
+,"HAMILTON, TX",Less than 65 Years,13
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,48
+,"LYMAN, SD",Less than 65 Years,27
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,38
+,"MCLEAN, ND",Less than 65 Years,16
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,37
+,"SOMERSET, PA",Less than 65 Years,23
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,49
+,"MONTGOMERY, TN",Less than 65 Years,21
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,34
+,"RAMSEY, ND",Less than 65 Years,15
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,44
+,"PIERCE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,35
+,"CUMBERLAND, TN",Less than 65 Years,15
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,35
+,"GRIGGS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,29
+,"LYNCHBURG CITY, VA",Less than 65 Years,13
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,36
+,"MCNAIRY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,25
+,"ANGELINA, TX",Less than 65 Years,21
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,39
+,"SAN JACINTO, TX",Less than 65 Years,12
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,30
+,"BOWIE, TX",Less than 65 Years,17
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,33
+,"CARTER, OK",Less than 65 Years,22
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,47
+,"CUSTER, SD",Less than 65 Years,11
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,23
+,"GREGORY, SD",Less than 65 Years,11
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,33
+,"MCMINN, TN",Less than 65 Years,17
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,38
+,"NORTHUMBERLAND, PA",Less than 65 Years,17
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,29
+,"SUMNER, TN",Less than 65 Years,19
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,39
+,"GALLIA, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,20
+,"MCCLAIN, OK",Less than 65 Years,20
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,38
+,"NACOGDOCHES, TX",Less than 65 Years,17
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,34
+,"CAMBRIA, PA",Less than 65 Years,17
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,33
+,"MCCULLOCH, TX",Less than 65 Years,13
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,44
+,"MIDLAND, TX",Less than 65 Years,15
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,26
+,"TOWNER, ND",Less than 65 Years,17
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,40
+,"DICKEY, ND",Less than 65 Years,12
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,37
+,"HAMBLEN, TN",Less than 65 Years,14
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,26
+,"STARK, ND",Less than 65 Years,20
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,37
+,"MARTINSVILLE CITY, VA",Less than 65 Years,11
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,33
+,"ATASCOSA, TX",Less than 65 Years,21
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,33
+,"BEDFORD, VA",Less than 65 Years,15
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,39
+,"KERR, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,33
+,"MATAGORDA, TX",Less than 65 Years,11
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,32
+,"SULLIVAN, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,34
+,"WILSON, TX",Less than 65 Years,13
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,36
+,"LAKE, OR",Less than 65 Years,14
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,29
+,"PRINCE EDWARD, VA",Less than 65 Years,16
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,31
+,"STEPHENS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,33
+,"CASS, TX",Less than 65 Years,15
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,34
+,"RAINS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,27
+,"SIOUX, ND",Less than 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"BUFFALO, SD",Less than 65 Years,23
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"CALDWELL, TX",Less than 65 Years,16
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,30
+,"CARSON, TX",Less than 65 Years,14
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,29
+,"CENTRE, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,28
+,"COLORADO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,21
+,"RUNNELS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,27
+,"TOOELE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"ARANSAS, TX",Less than 65 Years,26
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"GRAY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,29
+,"LYCOMING, PA",Less than 65 Years,16
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,34
+,"GRANT, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,31
+,"KAY, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,24
+,"MCCOOK, SD",Less than 65 Years,12
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,33
+,"YOUNG, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,32
+,"CAMPBELL, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,31
+,"WEBER, UT",Less than 65 Years,14
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,25
+,"ORANGE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"ROANOKE, VA",Less than 65 Years,15
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,30
+,"DEUEL, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,26
+,"WARD, ND",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"BLOUNT, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"DOUGLAS, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,26
+,"HOUSTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,27
+,"SEVIER, TN",Less than 65 Years,13
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,26
+,"BANDERA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"MEIGS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,21
+,"WHEELER, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,26
+,"AMHERST, VA",Less than 65 Years,11
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,25
+,"BLAND, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,28
+,"CLATSOP, OR",Less than 65 Years,12
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,27
+,"DECATUR, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,18
+,"RANSOM, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,23
+,"WASHINGTON, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,24
+,"BLAIR, PA",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"CALEDONIA, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,22
+,"ECTOR, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"LAWRENCE, OH",Less than 65 Years,12
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,24
+,"VICTORIA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"BROWN, TX",Less than 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,28
+,"COLUMBIA, PA",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"KLEBERG, TX",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"ADAIR, OK",Less than 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"UNION, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,22
+,"WASCO, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"COCKE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,24
+,"HUGHES, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,20
+,"WARREN, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,17
+,"JACK, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,20
+,"WILSON, TN",Less than 65 Years,11
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,24
+,"BENNINGTON, VT",Less than 65 Years,11
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,27
+,"CURRY, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,17
+,"HARDIN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"HARRISON, TX",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"MOORE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,22
+,"YANKTON, SD",Less than 65 Years,12
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,26
+,"BUTTE, SD",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"DEAF SMITH, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,21
+,"GILLESPIE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,21
+,"MAURY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,23
+,"MORGAN, OH",Less than 65 Years,11
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,25
+,"VAN BUREN, TN",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,24
+,"BENSON, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,20
+,"HOLMES, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,24
+,"SEMINOLE, OK",Less than 65 Years,13
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,25
+,"DONLEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,16
+,"KING GEORGE, VA",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"MOUNTRAIL, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"CADDO, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,20
+,"CODINGTON, SD",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"LAKE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"LATIMER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,21
+,"FRANKLIN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"GARFIELD, OK",Less than 65 Years,11
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,31
+,"MADISON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,19
+,"TODD, SD",Less than 65 Years,24
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"FREDERICKSBURG CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"MONTGOMERY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"ROANOKE CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"GARVIN, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"ANDERSON, TN",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"CAMPBELL, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"CUSTER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,22
+,"PUTNAM, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,17
+,"COKE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"EDMUNDS, SD",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"STARR, TX",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"LIVE OAK, TX",Less than 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"SHELBY, TX",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"BEE, TX",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MAVERICK, TX",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"NOBLE, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"TRINITY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,17
+,"MCCURTAIN, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,22
+,"ALLENDALE, SC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CLARION, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"HAMPTON, SC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"JASPER, TX",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"ROLETTE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,17
+,"ORLEANS, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"NOWATA, OK",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"PATRICK, VA",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"PONTOTOC, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,13
+,"BRYAN, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"GRAINGER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"LOGAN, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"LOUDON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"POTTER, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CLEARFIELD, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"GRAYSON, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,18
+,"FRIO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,17
+,"HUNTINGDON, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"CROCKETT, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,17
+,"FOSTER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"CONCHO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAVISON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"MONROE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ARMSTRONG, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"BROOKINGS, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"HARDIN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"JEFFERSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"STEELE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,17
+,"SWISHER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"VAL VERDE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"KIDDER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"LAMAR, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"MARSHALL, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"STEPHENS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"DUVAL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"JOSEPHINE, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CACHE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"FRANKLIN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNIATA, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOODY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"BECKHAM, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,14
+,"BEDFORD, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCKEAN, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIFFLIN, PA",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"JACKSON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"JEFFERSON, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"CASTRO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,13
+,"MCHENRY, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WALLOWA, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, SC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINGFISHER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"LEXINGTON CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,17
+,"MASON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOBLE, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"APPOMATTOX, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MURRAY, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARMER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROCKBRIDGE, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOTETOURT, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"EMMONS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEADLE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMPORIA CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"GILLIAM, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOOD RIVER, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOVE, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UVALDE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CALHOUN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLES MIX, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAVACA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPINK, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ARCHER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALLAM, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUNN, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSTON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,15
+,"WASHITA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELK, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMPHREYS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MELLETTE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SARGENT, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TYLER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASATCH, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"AURORA, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALLAHAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAIBORNE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CORSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILES, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUGHES, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRION, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OLIVER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REFUGIO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STERLING, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHOCTAW, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEWEY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HETTINGER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIOWA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINER, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PULASKI, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WELLS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATOKA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOX ELDER, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDDY, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KARNES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"NEWTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SNYDER, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODWARD, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COTTON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DIMMIT, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMLIN, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANSFORD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OCHILTREE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UINTAH, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OLDHAM, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUSHMATAHA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALEM, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARBON, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLEMAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALAX CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCPHERSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENARD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGLALA LAKOTA, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RED RIVER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TEXAS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HALE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HIGHLAND, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JIM HOGG, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOLAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REAGAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SABINE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUTTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILBARGER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLACY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEGHANY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEATHAM, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FENTRESS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GONZALES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHLEICHER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALWORTH, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COAL, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDWARDS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARTLEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUTCHINSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAJOR, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCINTOSH, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTOUR, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OVERTON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RADFORD, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERIDAN, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALFALFA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOTTINEAU, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHILDRESS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COVINGTON CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEWEY, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DIVIDE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERKINS, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCURRY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHEELER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ZAVALA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAYLOR, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BON HOMME, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOKS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURKE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLLINGSWORTH, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAND, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARPER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HASKELL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HEMPHILL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINGSBURY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN AUGUSTINE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEWART, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BATH, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BREWSTER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CANNON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUCHESNE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMERY, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOREST, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILES, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HICKMAN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMB, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIPSCOMB, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PECOS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REAL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANPETE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEVIER, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHACKELFORD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERMAN, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERMAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STANLEY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDREWS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELTA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLIS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GAINES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAAKON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HALL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAND, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIMBLE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA SALLE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROGER MILLS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TERRY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TILLMAN, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENNETT, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BILLINGS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOWMAN, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUENA VISTA CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CIMARRON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWSON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAULK, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOLDEN VALLEY, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDEMAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUAB, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINNEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLARD, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVER, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRISCOE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESSEX, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOARD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARMON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PICKETT, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UPTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMERON, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COTTLE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAIG, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROSBY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JERAULD, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KANE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REEVES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ZAPATA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAILEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BORDEN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARFIELD, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLASSCOCK, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOLIAD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOCKLEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HYDE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TROUSDALE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YOAKUM, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ZIEBACH, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COCHRAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRANE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CULBERSON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FISHER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARZA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDING, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFF DAVIS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENEDY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENT, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYNN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCMULLEN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOORE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTER, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRESIDIO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RENVILLE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STONEWALL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TERRELL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THROCKMORTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINKLER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 65 Years,7481
+,,65 Years or more,14080
+,,No value,10 or fewer
+,,Total,21561
+,Total,Less than 65 Years,220217
+,,65 Years or more,350442
+,,No value,10 or fewer
+,,Total,570660
+Jan 1 – Jul 17 2025,"CUYAHOGA, OH",Less than 65 Years,7521
+,,65 Years or more,8466
+,,No value,10 or fewer
+,,Total,15987
+,"TARRANT, TX",Less than 65 Years,6019
+,,65 Years or more,7391
+,,No value,10 or fewer
+,,Total,13410
+,"FRANKLIN, OH",Less than 65 Years,4753
+,,65 Years or more,6310
+,,No value,10 or fewer
+,,Total,11063
+,"DALLAS, TX",Less than 65 Years,4556
+,,65 Years or more,5638
+,,No value,10 or fewer
+,,Total,10194
+,"HARRIS, TX",Less than 65 Years,5979
+,,65 Years or more,7218
+,,No value,10 or fewer
+,,Total,13197
+,"PHILADELPHIA, PA",Less than 65 Years,4183
+,,65 Years or more,3934
+,,No value,10 or fewer
+,,Total,8117
+,"HAMILTON, OH",Less than 65 Years,2446
+,,65 Years or more,4528
+,,No value,10 or fewer
+,,Total,6974
+,"MONTGOMERY, OH",Less than 65 Years,2573
+,,65 Years or more,3861
+,,No value,10 or fewer
+,,Total,6434
+,"LEHIGH, PA",Less than 65 Years,1933
+,,65 Years or more,2763
+,,No value,10 or fewer
+,,Total,4696
+,"NORTHAMPTON, PA",Less than 65 Years,1675
+,,65 Years or more,3084
+,,No value,10 or fewer
+,,Total,4759
+,"TULSA, OK",Less than 65 Years,1804
+,,65 Years or more,3004
+,,No value,10 or fewer
+,,Total,4808
+,"GREENVILLE, SC",Less than 65 Years,1455
+,,65 Years or more,2762
+,,No value,10 or fewer
+,,Total,4217
+,"YORK, PA",Less than 65 Years,1234
+,,65 Years or more,2346
+,,No value,10 or fewer
+,,Total,3580
+,"SPARTANBURG, SC",Less than 65 Years,1362
+,,65 Years or more,2126
+,,No value,10 or fewer
+,,Total,3488
+,"ALLEGHENY, PA",Less than 65 Years,1127
+,,65 Years or more,2397
+,,No value,10 or fewer
+,,Total,3524
+,"SUMMIT, OH",Less than 65 Years,1489
+,,65 Years or more,2461
+,,No value,10 or fewer
+,,Total,3950
+,"VIRGINIA BEACH CITY, VA",Less than 65 Years,991
+,,65 Years or more,2211
+,,No value,10 or fewer
+,,Total,3202
+,"BUTLER, OH",Less than 65 Years,1119
+,,65 Years or more,2045
+,,No value,10 or fewer
+,,Total,3164
+,"FAIRFAX, VA",Less than 65 Years,1183
+,,65 Years or more,2184
+,,No value,10 or fewer
+,,Total,3367
+,"MONTGOMERY, PA",Less than 65 Years,896
+,,65 Years or more,2466
+,,No value,10 or fewer
+,,Total,3362
+,"LORAIN, OH",Less than 65 Years,1476
+,,65 Years or more,2059
+,,No value,10 or fewer
+,,Total,3535
+,"SHELBY, TN",Less than 65 Years,2253
+,,65 Years or more,2751
+,,No value,10 or fewer
+,,Total,5004
+,"COLLIN, TX",Less than 65 Years,922
+,,65 Years or more,1908
+,,No value,10 or fewer
+,,Total,2830
+,"CHESTER, PA",Less than 65 Years,722
+,,65 Years or more,2162
+,,No value,10 or fewer
+,,Total,2884
+,"DELAWARE, PA",Less than 65 Years,909
+,,65 Years or more,2073
+,,No value,10 or fewer
+,,Total,2982
+,"BUCKS, PA",Less than 65 Years,717
+,,65 Years or more,1875
+,,No value,10 or fewer
+,,Total,2592
+,"CHARLESTON, SC",Less than 65 Years,870
+,,65 Years or more,1907
+,,No value,10 or fewer
+,,Total,2777
+,"LUCAS, OH",Less than 65 Years,1319
+,,65 Years or more,1375
+,,No value,10 or fewer
+,,Total,2694
+,"LANCASTER, PA",Less than 65 Years,705
+,,65 Years or more,1854
+,,No value,10 or fewer
+,,Total,2559
+,"DENTON, TX",Less than 65 Years,945
+,,65 Years or more,1589
+,,No value,10 or fewer
+,,Total,2534
+,"JOHNSON, TX",Less than 65 Years,1036
+,,65 Years or more,1421
+,,No value,10 or fewer
+,,Total,2457
+,"BELL, TX",Less than 65 Years,1162
+,,65 Years or more,1020
+,,No value,10 or fewer
+,,Total,2182
+,"LAKE, OH",Less than 65 Years,996
+,,65 Years or more,1876
+,,No value,10 or fewer
+,,Total,2872
+,"MULTNOMAH, OR",Less than 65 Years,1020
+,,65 Years or more,1139
+,,No value,10 or fewer
+,,Total,2159
+,"MAHONING, OH",Less than 65 Years,767
+,,65 Years or more,1357
+,,No value,10 or fewer
+,,Total,2124
+,"WARREN, OH",Less than 65 Years,543
+,,65 Years or more,1321
+,,No value,10 or fewer
+,,Total,1864
+,"RICHLAND, SC",Less than 65 Years,868
+,,65 Years or more,1173
+,,No value,10 or fewer
+,,Total,2041
+,"LOUDOUN, VA",Less than 65 Years,703
+,,65 Years or more,1077
+,,No value,10 or fewer
+,,Total,1780
+,"BEXAR, TX",Less than 65 Years,919
+,,65 Years or more,906
+,,No value,10 or fewer
+,,Total,1825
+,"CLERMONT, OH",Less than 65 Years,589
+,,65 Years or more,1161
+,,No value,10 or fewer
+,,Total,1750
+,"CLARK, OH",Less than 65 Years,680
+,,65 Years or more,993
+,,No value,10 or fewer
+,,Total,1673
+,"ANDERSON, SC",Less than 65 Years,689
+,,65 Years or more,1159
+,,No value,10 or fewer
+,,Total,1848
+,"MONTGOMERY, TX",Less than 65 Years,840
+,,65 Years or more,1564
+,,No value,10 or fewer
+,,Total,2404
+,"NEWPORT NEWS CITY, VA",Less than 65 Years,677
+,,65 Years or more,967
+,,No value,10 or fewer
+,,Total,1644
+,"CHESAPEAKE CITY, VA",Less than 65 Years,611
+,,65 Years or more,1168
+,,No value,10 or fewer
+,,Total,1779
+,"SULLIVAN, TN",Less than 65 Years,505
+,,65 Years or more,961
+,,No value,10 or fewer
+,,Total,1466
+,"MEDINA, OH",Less than 65 Years,643
+,,65 Years or more,1120
+,,No value,10 or fewer
+,,Total,1763
+,"GREENE, OH",Less than 65 Years,539
+,,65 Years or more,1098
+,,No value,10 or fewer
+,,Total,1637
+,"NORFOLK CITY, VA",Less than 65 Years,703
+,,65 Years or more,831
+,,No value,10 or fewer
+,,Total,1534
+,"FORT BEND, TX",Less than 65 Years,1084
+,,65 Years or more,1560
+,,No value,10 or fewer
+,,Total,2644
+,"PRINCE WILLIAM, VA",Less than 65 Years,667
+,,65 Years or more,932
+,,No value,10 or fewer
+,,Total,1599
+,"DELAWARE, OH",Less than 65 Years,445
+,,65 Years or more,1149
+,,No value,10 or fewer
+,,Total,1594
+,"ELLIS, TX",Less than 65 Years,568
+,,65 Years or more,1001
+,,No value,10 or fewer
+,,Total,1569
+,"DESCHUTES, OR",Less than 65 Years,505
+,,65 Years or more,1006
+,,No value,10 or fewer
+,,Total,1511
+,"MCLENNAN, TX",Less than 65 Years,577
+,,65 Years or more,753
+,,No value,10 or fewer
+,,Total,1330
+,"HAMILTON, TN",Less than 65 Years,630
+,,65 Years or more,878
+,,No value,10 or fewer
+,,Total,1508
+,"FRANKLIN, PA",Less than 65 Years,516
+,,65 Years or more,886
+,,No value,10 or fewer
+,,Total,1402
+,"ERIE, PA",Less than 65 Years,571
+,,65 Years or more,726
+,,No value,10 or fewer
+,,Total,1297
+,"HENRICO, VA",Less than 65 Years,521
+,,65 Years or more,921
+,,No value,10 or fewer
+,,Total,1442
+,"BERKS, PA",Less than 65 Years,640
+,,65 Years or more,672
+,,No value,10 or fewer
+,,Total,1312
+,"SCHUYLKILL, PA",Less than 65 Years,617
+,,65 Years or more,930
+,,No value,10 or fewer
+,,Total,1547
+,"MONROE, PA",Less than 65 Years,652
+,,65 Years or more,864
+,,No value,10 or fewer
+,,Total,1516
+,"LICKING, OH",Less than 65 Years,399
+,,65 Years or more,825
+,,No value,10 or fewer
+,,Total,1224
+,"MIAMI, OH",Less than 65 Years,461
+,,65 Years or more,779
+,,No value,10 or fewer
+,,Total,1240
+,"DAUPHIN, PA",Less than 65 Years,550
+,,65 Years or more,698
+,,No value,10 or fewer
+,,Total,1248
+,"FLORENCE, SC",Less than 65 Years,477
+,,65 Years or more,692
+,,No value,10 or fewer
+,,Total,1169
+,"FAYETTE, PA",Less than 65 Years,527
+,,65 Years or more,688
+,,No value,10 or fewer
+,,Total,1215
+,"CHESTERFIELD, VA",Less than 65 Years,457
+,,65 Years or more,801
+,,No value,10 or fewer
+,,Total,1258
+,"TRUMBULL, OH",Less than 65 Years,517
+,,65 Years or more,802
+,,No value,10 or fewer
+,,Total,1319
+,"CUMBERLAND, PA",Less than 65 Years,323
+,,65 Years or more,788
+,,No value,10 or fewer
+,,Total,1111
+,"RICHLAND, OH",Less than 65 Years,381
+,,65 Years or more,844
+,,No value,10 or fewer
+,,Total,1225
+,"LINN, OR",Less than 65 Years,376
+,,65 Years or more,716
+,,No value,10 or fewer
+,,Total,1092
+,"HAMPTON CITY, VA",Less than 65 Years,386
+,,65 Years or more,638
+,,No value,10 or fewer
+,,Total,1024
+,"CHITTENDEN, VT",Less than 65 Years,300
+,,65 Years or more,690
+,,No value,10 or fewer
+,,Total,990
+,"WESTMORELAND, PA",Less than 65 Years,319
+,,65 Years or more,714
+,,No value,10 or fewer
+,,Total,1033
+,"CARBON, PA",Less than 65 Years,415
+,,65 Years or more,631
+,,No value,10 or fewer
+,,Total,1046
+,"HORRY, SC",Less than 65 Years,331
+,,65 Years or more,737
+,,No value,10 or fewer
+,,Total,1068
+,"KAUFMAN, TX",Less than 65 Years,574
+,,65 Years or more,522
+,,No value,10 or fewer
+,,Total,1096
+,"TRAVIS, TX",Less than 65 Years,389
+,,65 Years or more,574
+,,No value,10 or fewer
+,,Total,963
+,"ARLINGTON, VA",Less than 65 Years,396
+,,65 Years or more,571
+,,No value,10 or fewer
+,,Total,967
+,"STARK, OH",Less than 65 Years,429
+,,65 Years or more,703
+,,No value,10 or fewer
+,,Total,1132
+,"PORTAGE, OH",Less than 65 Years,436
+,,65 Years or more,769
+,,No value,10 or fewer
+,,Total,1205
+,"BERKELEY, SC",Less than 65 Years,458
+,,65 Years or more,603
+,,No value,10 or fewer
+,,Total,1061
+,"JAMES CITY, VA",Less than 65 Years,225
+,,65 Years or more,758
+,,No value,10 or fewer
+,,Total,983
+,"PARKER, TX",Less than 65 Years,418
+,,65 Years or more,524
+,,No value,10 or fewer
+,,Total,942
+,"PICKENS, SC",Less than 65 Years,358
+,,65 Years or more,648
+,,No value,10 or fewer
+,,Total,1006
+,"CASS, ND",Less than 65 Years,380
+,,65 Years or more,538
+,,No value,10 or fewer
+,,Total,918
+,"CLACKAMAS, OR",Less than 65 Years,268
+,,65 Years or more,576
+,,No value,10 or fewer
+,,Total,844
+,"SMITH, TX",Less than 65 Years,372
+,,65 Years or more,562
+,,No value,10 or fewer
+,,Total,934
+,"WILLIAMSON, TX",Less than 65 Years,330
+,,65 Years or more,601
+,,No value,10 or fewer
+,,Total,931
+,"HENDERSON, TX",Less than 65 Years,314
+,,65 Years or more,526
+,,No value,10 or fewer
+,,Total,840
+,"WASHINGTON, TN",Less than 65 Years,257
+,,65 Years or more,478
+,,No value,10 or fewer
+,,Total,735
+,"RICHMOND CITY, VA",Less than 65 Years,500
+,,65 Years or more,353
+,,No value,10 or fewer
+,,Total,853
+,"OKLAHOMA, OK",Less than 65 Years,570
+,,65 Years or more,460
+,,No value,10 or fewer
+,,Total,1030
+,"SUFFOLK CITY, VA",Less than 65 Years,307
+,,65 Years or more,469
+,,No value,10 or fewer
+,,Total,776
+,"MARION, OH",Less than 65 Years,297
+,,65 Years or more,498
+,,No value,10 or fewer
+,,Total,795
+,"LUZERNE, PA",Less than 65 Years,387
+,,65 Years or more,459
+,,No value,10 or fewer
+,,Total,846
+,"FAIRFIELD, OH",Less than 65 Years,287
+,,65 Years or more,490
+,,No value,10 or fewer
+,,Total,777
+,"MINNEHAHA, SD",Less than 65 Years,280
+,,65 Years or more,441
+,,No value,10 or fewer
+,,Total,721
+,"LEBANON, PA",Less than 65 Years,289
+,,65 Years or more,473
+,,No value,10 or fewer
+,,Total,762
+,"MUSKOGEE, OK",Less than 65 Years,274
+,,65 Years or more,470
+,,No value,10 or fewer
+,,Total,744
+,"ALBEMARLE, VA",Less than 65 Years,202
+,,65 Years or more,534
+,,No value,10 or fewer
+,,Total,736
+,"ADAMS, PA",Less than 65 Years,214
+,,65 Years or more,515
+,,No value,10 or fewer
+,,Total,729
+,"WASHINGTON, PA",Less than 65 Years,260
+,,65 Years or more,511
+,,No value,10 or fewer
+,,Total,771
+,"ALLEN, OH",Less than 65 Years,299
+,,65 Years or more,417
+,,No value,10 or fewer
+,,Total,716
+,"FREDERICK, VA",Less than 65 Years,325
+,,65 Years or more,644
+,,No value,10 or fewer
+,,Total,969
+,"GEAUGA, OH",Less than 65 Years,274
+,,65 Years or more,601
+,,No value,10 or fewer
+,,Total,875
+,"WASHINGTON, OR",Less than 65 Years,241
+,,65 Years or more,384
+,,No value,10 or fewer
+,,Total,625
+,"CHEROKEE, SC",Less than 65 Years,273
+,,65 Years or more,410
+,,No value,10 or fewer
+,,Total,683
+,"PORTSMOUTH CITY, VA",Less than 65 Years,307
+,,65 Years or more,382
+,,No value,10 or fewer
+,,Total,689
+,"LINCOLN, OR",Less than 65 Years,199
+,,65 Years or more,459
+,,No value,10 or fewer
+,,Total,658
+,"MARION, OR",Less than 65 Years,363
+,,65 Years or more,405
+,,No value,10 or fewer
+,,Total,768
+,"GREENWOOD, SC",Less than 65 Years,209
+,,65 Years or more,378
+,,No value,10 or fewer
+,,Total,587
+,"ROCKWALL, TX",Less than 65 Years,201
+,,65 Years or more,464
+,,No value,10 or fewer
+,,Total,665
+,"SALT LAKE, UT",Less than 65 Years,262
+,,65 Years or more,314
+,,No value,10 or fewer
+,,Total,576
+,"ROGERS, OK",Less than 65 Years,216
+,,65 Years or more,423
+,,No value,10 or fewer
+,,Total,639
+,"COOS, OR",Less than 65 Years,184
+,,65 Years or more,396
+,,No value,10 or fewer
+,,Total,580
+,"WASHINGTON, VA",Less than 65 Years,198
+,,65 Years or more,352
+,,No value,10 or fewer
+,,Total,550
+,"GRAND FORKS, ND",Less than 65 Years,253
+,,65 Years or more,340
+,,No value,10 or fewer
+,,Total,593
+,"HAWKINS, TN",Less than 65 Years,232
+,,65 Years or more,306
+,,No value,10 or fewer
+,,Total,538
+,"TOM GREEN, TX",Less than 65 Years,241
+,,65 Years or more,355
+,,No value,10 or fewer
+,,Total,596
+,"YORK, VA",Less than 65 Years,133
+,,65 Years or more,376
+,,No value,10 or fewer
+,,Total,509
+,"OCONEE, SC",Less than 65 Years,220
+,,65 Years or more,387
+,,No value,10 or fewer
+,,Total,607
+,"GREENE, TN",Less than 65 Years,205
+,,65 Years or more,347
+,,No value,10 or fewer
+,,Total,552
+,"HANOVER, VA",Less than 65 Years,154
+,,65 Years or more,450
+,,No value,10 or fewer
+,,Total,604
+,"ALEXANDRIA CITY, VA",Less than 65 Years,212
+,,65 Years or more,359
+,,No value,10 or fewer
+,,Total,571
+,"PICKAWAY, OH",Less than 65 Years,218
+,,65 Years or more,342
+,,No value,10 or fewer
+,,Total,560
+,"LEXINGTON, SC",Less than 65 Years,274
+,,65 Years or more,236
+,,No value,10 or fewer
+,,Total,510
+,"ATHENS, OH",Less than 65 Years,170
+,,65 Years or more,249
+,,No value,10 or fewer
+,,Total,419
+,"NUECES, TX",Less than 65 Years,527
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,547
+,"BURNET, TX",Less than 65 Years,146
+,,65 Years or more,330
+,,No value,10 or fewer
+,,Total,476
+,"PREBLE, OH",Less than 65 Years,201
+,,65 Years or more,259
+,,No value,10 or fewer
+,,Total,460
+,"BENTON, OR",Less than 65 Years,136
+,,65 Years or more,351
+,,No value,10 or fewer
+,,Total,487
+,"LANCASTER, SC",Less than 65 Years,191
+,,65 Years or more,322
+,,No value,10 or fewer
+,,Total,513
+,"POTTER, TX",Less than 65 Years,178
+,,65 Years or more,367
+,,No value,10 or fewer
+,,Total,545
+,"ASHTABULA, OH",Less than 65 Years,269
+,,65 Years or more,448
+,,No value,10 or fewer
+,,Total,717
+,"RANDALL, TX",Less than 65 Years,165
+,,65 Years or more,387
+,,No value,10 or fewer
+,,Total,552
+,"LAURENS, SC",Less than 65 Years,216
+,,65 Years or more,254
+,,No value,10 or fewer
+,,Total,470
+,"BURLEIGH, ND",Less than 65 Years,141
+,,65 Years or more,267
+,,No value,10 or fewer
+,,Total,408
+,"BUTLER, PA",Less than 65 Years,152
+,,65 Years or more,343
+,,No value,10 or fewer
+,,Total,495
+,"WOOD, OH",Less than 65 Years,185
+,,65 Years or more,321
+,,No value,10 or fewer
+,,Total,506
+,"KERSHAW, SC",Less than 65 Years,179
+,,65 Years or more,286
+,,No value,10 or fewer
+,,Total,465
+,"ROCKINGHAM, VA",Less than 65 Years,150
+,,65 Years or more,349
+,,No value,10 or fewer
+,,Total,499
+,"SUMTER, SC",Less than 65 Years,215
+,,65 Years or more,309
+,,No value,10 or fewer
+,,Total,524
+,"BELMONT, OH",Less than 65 Years,208
+,,65 Years or more,358
+,,No value,10 or fewer
+,,Total,566
+,"UNION, SC",Less than 65 Years,177
+,,65 Years or more,243
+,,No value,10 or fewer
+,,Total,420
+,"BRAZOS, TX",Less than 65 Years,173
+,,65 Years or more,278
+,,No value,10 or fewer
+,,Total,451
+,"ACCOMACK, VA",Less than 65 Years,141
+,,65 Years or more,245
+,,No value,10 or fewer
+,,Total,386
+,"BRADFORD, PA",Less than 65 Years,151
+,,65 Years or more,248
+,,No value,10 or fewer
+,,Total,399
+,"TIPTON, TN",Less than 65 Years,234
+,,65 Years or more,239
+,,No value,10 or fewer
+,,Total,473
+,"WASHINGTON, TX",Less than 65 Years,127
+,,65 Years or more,289
+,,No value,10 or fewer
+,,Total,416
+,"LACKAWANNA, PA",Less than 65 Years,201
+,,65 Years or more,276
+,,No value,10 or fewer
+,,Total,477
+,"GLOUCESTER, VA",Less than 65 Years,119
+,,65 Years or more,233
+,,No value,10 or fewer
+,,Total,352
+,"TUSCARAWAS, OH",Less than 65 Years,212
+,,65 Years or more,356
+,,No value,10 or fewer
+,,Total,568
+,"WILLIAMS, OH",Less than 65 Years,122
+,,65 Years or more,201
+,,No value,10 or fewer
+,,Total,323
+,"BRAZORIA, TX",Less than 65 Years,281
+,,65 Years or more,369
+,,No value,10 or fewer
+,,Total,650
+,"SHENANDOAH, VA",Less than 65 Years,146
+,,65 Years or more,322
+,,No value,10 or fewer
+,,Total,468
+,"CARTER, TN",Less than 65 Years,147
+,,65 Years or more,191
+,,No value,10 or fewer
+,,Total,338
+,"CREEK, OK",Less than 65 Years,149
+,,65 Years or more,259
+,,No value,10 or fewer
+,,Total,408
+,"WAGONER, OK",Less than 65 Years,101
+,,65 Years or more,253
+,,No value,10 or fewer
+,,Total,354
+,"GALVESTON, TX",Less than 65 Years,165
+,,65 Years or more,351
+,,No value,10 or fewer
+,,Total,516
+,"BROWN, OH",Less than 65 Years,140
+,,65 Years or more,207
+,,No value,10 or fewer
+,,Total,347
+,"ISLE OF WIGHT, VA",Less than 65 Years,109
+,,65 Years or more,250
+,,No value,10 or fewer
+,,Total,359
+,"ERATH, TX",Less than 65 Years,132
+,,65 Years or more,195
+,,No value,10 or fewer
+,,Total,327
+,"MADISON, TN",Less than 65 Years,426
+,,65 Years or more,594
+,,No value,10 or fewer
+,,Total,1020
+,"DARLINGTON, SC",Less than 65 Years,154
+,,65 Years or more,204
+,,No value,10 or fewer
+,,Total,358
+,"CROOK, OR",Less than 65 Years,107
+,,65 Years or more,232
+,,No value,10 or fewer
+,,Total,339
+,"CRAWFORD, OH",Less than 65 Years,120
+,,65 Years or more,189
+,,No value,10 or fewer
+,,Total,309
+,"WISE, VA",Less than 65 Years,169
+,,65 Years or more,181
+,,No value,10 or fewer
+,,Total,350
+,"JEFFERSON, OR",Less than 65 Years,144
+,,65 Years or more,165
+,,No value,10 or fewer
+,,Total,309
+,"ASHLAND, OH",Less than 65 Years,124
+,,65 Years or more,266
+,,No value,10 or fewer
+,,Total,390
+,"ORANGEBURG, SC",Less than 65 Years,169
+,,65 Years or more,248
+,,No value,10 or fewer
+,,Total,417
+,"DILLON, SC",Less than 65 Years,127
+,,65 Years or more,205
+,,No value,10 or fewer
+,,Total,332
+,"WOOD, TX",Less than 65 Years,78
+,,65 Years or more,245
+,,No value,10 or fewer
+,,Total,323
+,"WARREN, VA",Less than 65 Years,158
+,,65 Years or more,212
+,,No value,10 or fewer
+,,Total,370
+,"MECKLENBURG, VA",Less than 65 Years,113
+,,65 Years or more,211
+,,No value,10 or fewer
+,,Total,324
+,"LLANO, TX",Less than 65 Years,97
+,,65 Years or more,200
+,,No value,10 or fewer
+,,Total,297
+,"DARKE, OH",Less than 65 Years,132
+,,65 Years or more,204
+,,No value,10 or fewer
+,,Total,336
+,"MADISON, OH",Less than 65 Years,106
+,,65 Years or more,205
+,,No value,10 or fewer
+,,Total,311
+,"SENECA, OH",Less than 65 Years,133
+,,65 Years or more,172
+,,No value,10 or fewer
+,,Total,305
+,"CORYELL, TX",Less than 65 Years,156
+,,65 Years or more,144
+,,No value,10 or fewer
+,,Total,300
+,"SMYTH, VA",Less than 65 Years,142
+,,65 Years or more,160
+,,No value,10 or fewer
+,,Total,302
+,"DORCHESTER, SC",Less than 65 Years,90
+,,65 Years or more,169
+,,No value,10 or fewer
+,,Total,259
+,"PETERSBURG CITY, VA",Less than 65 Years,120
+,,65 Years or more,139
+,,No value,10 or fewer
+,,Total,259
+,"MALHEUR, OR",Less than 65 Years,124
+,,65 Years or more,177
+,,No value,10 or fewer
+,,Total,301
+,"CHAMPAIGN, OH",Less than 65 Years,111
+,,65 Years or more,180
+,,No value,10 or fewer
+,,Total,291
+,"MAYES, OK",Less than 65 Years,107
+,,65 Years or more,189
+,,No value,10 or fewer
+,,Total,296
+,"RUSK, TX",Less than 65 Years,109
+,,65 Years or more,186
+,,No value,10 or fewer
+,,Total,295
+,"CULPEPER, VA",Less than 65 Years,138
+,,65 Years or more,193
+,,No value,10 or fewer
+,,Total,331
+,"CHARLOTTESVILLE CITY, VA",Less than 65 Years,109
+,,65 Years or more,162
+,,No value,10 or fewer
+,,Total,271
+,"COLUMBIANA, OH",Less than 65 Years,70
+,,65 Years or more,211
+,,No value,10 or fewer
+,,Total,281
+,"CLARENDON, SC",Less than 65 Years,101
+,,65 Years or more,139
+,,No value,10 or fewer
+,,Total,240
+,"OBION, TN",Less than 65 Years,117
+,,65 Years or more,209
+,,No value,10 or fewer
+,,Total,326
+,"HALIFAX, VA",Less than 65 Years,73
+,,65 Years or more,183
+,,No value,10 or fewer
+,,Total,256
+,"CHEROKEE, TX",Less than 65 Years,120
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,230
+,"CARROLL, TN",Less than 65 Years,134
+,,65 Years or more,230
+,,No value,10 or fewer
+,,Total,364
+,"HARRISONBURG CITY, VA",Less than 65 Years,85
+,,65 Years or more,142
+,,No value,10 or fewer
+,,Total,227
+,"UMATILLA, OR",Less than 65 Years,79
+,,65 Years or more,156
+,,No value,10 or fewer
+,,Total,235
+,"SANDUSKY, OH",Less than 65 Years,96
+,,65 Years or more,177
+,,No value,10 or fewer
+,,Total,273
+,"WASHINGTON, RI",Less than 65 Years,58
+,,65 Years or more,146
+,,No value,10 or fewer
+,,Total,204
+,"HIGHLAND, OH",Less than 65 Years,111
+,,65 Years or more,207
+,,No value,10 or fewer
+,,Total,318
+,"OKMULGEE, OK",Less than 65 Years,107
+,,65 Years or more,136
+,,No value,10 or fewer
+,,Total,243
+,"RUSSELL, VA",Less than 65 Years,71
+,,65 Years or more,149
+,,No value,10 or fewer
+,,Total,220
+,"CHESTERFIELD, SC",Less than 65 Years,68
+,,65 Years or more,146
+,,No value,10 or fewer
+,,Total,214
+,"HIDALGO, TX",Less than 65 Years,434
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,456
+,"PUTNAM, OH",Less than 65 Years,85
+,,65 Years or more,148
+,,No value,10 or fewer
+,,Total,233
+,"MERCER, PA",Less than 65 Years,89
+,,65 Years or more,193
+,,No value,10 or fewer
+,,Total,282
+,"HOOD, TX",Less than 65 Years,81
+,,65 Years or more,124
+,,No value,10 or fewer
+,,Total,205
+,"NEW KENT, VA",Less than 65 Years,87
+,,65 Years or more,139
+,,No value,10 or fewer
+,,Total,226
+,"WASHINGTON, VT",Less than 65 Years,73
+,,65 Years or more,150
+,,No value,10 or fewer
+,,Total,223
+,"STUTSMAN, ND",Less than 65 Years,69
+,,65 Years or more,108
+,,No value,10 or fewer
+,,Total,177
+,"SCOTT, VA",Less than 65 Years,79
+,,65 Years or more,115
+,,No value,10 or fewer
+,,Total,194
+,"CLEVELAND, OK",Less than 65 Years,119
+,,65 Years or more,126
+,,No value,10 or fewer
+,,Total,245
+,"DEFIANCE, OH",Less than 65 Years,76
+,,65 Years or more,157
+,,No value,10 or fewer
+,,Total,233
+,"MARION, SC",Less than 65 Years,65
+,,65 Years or more,133
+,,No value,10 or fewer
+,,Total,198
+,"LINCOLN, SD",Less than 65 Years,72
+,,65 Years or more,130
+,,No value,10 or fewer
+,,Total,202
+,"HURON, OH",Less than 65 Years,92
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,202
+,"PENNINGTON, SD",Less than 65 Years,127
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,218
+,"HILL, TX",Less than 65 Years,70
+,,65 Years or more,125
+,,No value,10 or fewer
+,,Total,195
+,"LEE, VA",Less than 65 Years,79
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,157
+,"WAYNE, OH",Less than 65 Years,84
+,,65 Years or more,131
+,,No value,10 or fewer
+,,Total,215
+,"SEQUOYAH, OK",Less than 65 Years,62
+,,65 Years or more,132
+,,No value,10 or fewer
+,,Total,194
+,"GIBSON, TN",Less than 65 Years,213
+,,65 Years or more,317
+,,No value,10 or fewer
+,,Total,530
+,"BEAVER, PA",Less than 65 Years,69
+,,65 Years or more,135
+,,No value,10 or fewer
+,,Total,204
+,"ORANGE, VA",Less than 65 Years,59
+,,65 Years or more,144
+,,No value,10 or fewer
+,,Total,203
+,"HAYS, TX",Less than 65 Years,86
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,163
+,"CRAIG, OK",Less than 65 Years,56
+,,65 Years or more,109
+,,No value,10 or fewer
+,,Total,165
+,"FAIRFIELD, SC",Less than 65 Years,77
+,,65 Years or more,113
+,,No value,10 or fewer
+,,Total,190
+,"CANADIAN, OK",Less than 65 Years,141
+,,65 Years or more,65
+,,No value,10 or fewer
+,,Total,206
+,"WILLIAMSBURG, SC",Less than 65 Years,65
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,175
+,"LAMPASAS, TX",Less than 65 Years,73
+,,65 Years or more,139
+,,No value,10 or fewer
+,,Total,212
+,"MORTON, ND",Less than 65 Years,63
+,,65 Years or more,110
+,,No value,10 or fewer
+,,Total,173
+,"CHESTER, SC",Less than 65 Years,83
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,167
+,"LOUISA, VA",Less than 65 Years,80
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,191
+,"MANASSAS CITY, VA",Less than 65 Years,109
+,,65 Years or more,99
+,,No value,10 or fewer
+,,Total,208
+,"FLUVANNA, VA",Less than 65 Years,65
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,176
+,"FAYETTE, TN",Less than 65 Years,76
+,,65 Years or more,142
+,,No value,10 or fewer
+,,Total,218
+,"AUGLAIZE, OH",Less than 65 Years,57
+,,65 Years or more,99
+,,No value,10 or fewer
+,,Total,156
+,"LIBERTY, TX",Less than 65 Years,84
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,186
+,"BRADLEY, TN",Less than 65 Years,105
+,,65 Years or more,135
+,,No value,10 or fewer
+,,Total,240
+,"NORTHAMPTON, VA",Less than 65 Years,55
+,,65 Years or more,112
+,,No value,10 or fewer
+,,Total,167
+,"ERIE, OH",Less than 65 Years,52
+,,65 Years or more,106
+,,No value,10 or fewer
+,,Total,158
+,"VAN ZANDT, TX",Less than 65 Years,64
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,161
+,"COLUMBIA, OR",Less than 65 Years,47
+,,65 Years or more,116
+,,No value,10 or fewer
+,,Total,163
+,"COLONIAL HEIGHTS CITY, VA",Less than 65 Years,70
+,,65 Years or more,125
+,,No value,10 or fewer
+,,Total,195
+,"WINCHESTER CITY, VA",Less than 65 Years,86
+,,65 Years or more,158
+,,No value,10 or fewer
+,,Total,244
+,"BRISTOL CITY, VA",Less than 65 Years,56
+,,65 Years or more,83
+,,No value,10 or fewer
+,,Total,139
+,"MCINTOSH, OK",Less than 65 Years,62
+,,65 Years or more,115
+,,No value,10 or fewer
+,,Total,177
+,"CLINTON, OH",Less than 65 Years,65
+,,65 Years or more,111
+,,No value,10 or fewer
+,,Total,176
+,"ADDISON, VT",Less than 65 Years,36
+,,65 Years or more,117
+,,No value,10 or fewer
+,,Total,153
+,"SEQUATCHIE, TN",Less than 65 Years,67
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,142
+,"BROWN, SD",Less than 65 Years,52
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,134
+,"FAUQUIER, VA",Less than 65 Years,57
+,,65 Years or more,87
+,,No value,10 or fewer
+,,Total,144
+,"BRUNSWICK, VA",Less than 65 Years,57
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,159
+,"PIKE, PA",Less than 65 Years,67
+,,65 Years or more,104
+,,No value,10 or fewer
+,,Total,171
+,"MILAM, TX",Less than 65 Years,57
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,145
+,"PAGE, VA",Less than 65 Years,71
+,,65 Years or more,140
+,,No value,10 or fewer
+,,Total,211
+,"MORROW, OH",Less than 65 Years,54
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,127
+,"UNICOI, TN",Less than 65 Years,37
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,121
+,"ROSS, OH",Less than 65 Years,56
+,,65 Years or more,104
+,,No value,10 or fewer
+,,Total,160
+,"CLARKE, VA",Less than 65 Years,50
+,,65 Years or more,121
+,,No value,10 or fewer
+,,Total,171
+,"YORK, SC",Less than 65 Years,53
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,126
+,"WISE, TX",Less than 65 Years,83
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,143
+,"UNION, OH",Less than 65 Years,52
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,128
+,"CHAMBERS, TX",Less than 65 Years,64
+,,65 Years or more,87
+,,No value,10 or fewer
+,,Total,151
+,"ARMSTRONG, PA",Less than 65 Years,54
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,131
+,"BLEDSOE, TN",Less than 65 Years,50
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,138
+,"HARDIN, OH",Less than 65 Years,68
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,156
+,"POWHATAN, VA",Less than 65 Years,52
+,,65 Years or more,135
+,,No value,10 or fewer
+,,Total,187
+,"AIKEN, SC",Less than 65 Years,137
+,,65 Years or more,183
+,,No value,10 or fewer
+,,Total,320
+,"DINWIDDIE, VA",Less than 65 Years,75
+,,65 Years or more,65
+,,No value,10 or fewer
+,,Total,140
+,"OTTAWA, OH",Less than 65 Years,42
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,133
+,"DICKENSON, VA",Less than 65 Years,47
+,,65 Years or more,83
+,,No value,10 or fewer
+,,Total,130
+,"TAZEWELL, VA",Less than 65 Years,74
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,137
+,"SHELBY, OH",Less than 65 Years,47
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,125
+,"WINDSOR, VT",Less than 65 Years,41
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,123
+,"HUNT, TX",Less than 65 Years,45
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,122
+,"GREENE, VA",Less than 65 Years,48
+,,65 Years or more,65
+,,No value,10 or fewer
+,,Total,113
+,"GREENE, PA",Less than 65 Years,65
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,146
+,"BAKER, OR",Less than 65 Years,32
+,,65 Years or more,95
+,,No value,10 or fewer
+,,Total,127
+,"POQUOSON CITY, VA",Less than 65 Years,39
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,130
+,"FAIRFAX CITY, VA",Less than 65 Years,46
+,,65 Years or more,64
+,,No value,10 or fewer
+,,Total,110
+,"LE FLORE, OK",Less than 65 Years,40
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,117
+,"SOUTHAMPTON, VA",Less than 65 Years,46
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,116
+,"WYANDOT, OH",Less than 65 Years,44
+,,65 Years or more,100
+,,No value,10 or fewer
+,,Total,144
+,"PERRY, PA",Less than 65 Years,26
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,105
+,"DYER, TN",Less than 65 Years,138
+,,65 Years or more,209
+,,No value,10 or fewer
+,,Total,347
+,"WEAKLEY, TN",Less than 65 Years,107
+,,65 Years or more,169
+,,No value,10 or fewer
+,,Total,276
+,"KING WILLIAM, VA",Less than 65 Years,56
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,136
+,"KNOX, OH",Less than 65 Years,42
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,116
+,"JOHNSON, TN",Less than 65 Years,47
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,116
+,"MONROE, OH",Less than 65 Years,37
+,,65 Years or more,68
+,,No value,10 or fewer
+,,Total,105
+,"ESSEX, VA",Less than 65 Years,37
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,108
+,"MIDDLESEX, VA",Less than 65 Years,34
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,108
+,"VAN WERT, OH",Less than 65 Years,78
+,,65 Years or more,130
+,,No value,10 or fewer
+,,Total,208
+,"MARLBORO, SC",Less than 65 Years,37
+,,65 Years or more,65
+,,No value,10 or fewer
+,,Total,102
+,"NEWPORT, RI",Less than 65 Years,19
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,94
+,"GOOCHLAND, VA",Less than 65 Years,40
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,113
+,"FRANKLIN CITY, VA",Less than 65 Years,46
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,112
+,"PAYNE, OK",Less than 65 Years,41
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,104
+,"WALSH, ND",Less than 65 Years,50
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,121
+,"NAVARRO, TX",Less than 65 Years,29
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,103
+,"LANCASTER, VA",Less than 65 Years,16
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,74
+,"PRINCE GEORGE, VA",Less than 65 Years,48
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,102
+,"AUGUSTA, VA",Less than 65 Years,29
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,91
+,"GRAYSON, TX",Less than 65 Years,40
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,80
+,"WILLIAMSBURG CITY, VA",Less than 65 Years,21
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,82
+,"ABBEVILLE, SC",Less than 65 Years,26
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,87
+,"CLAY, SD",Less than 65 Years,37
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,96
+,"PANOLA, TX",Less than 65 Years,37
+,,65 Years or more,69
+,,No value,10 or fewer
+,,Total,106
+,"NORTHUMBERLAND, VA",Less than 65 Years,28
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,94
+,"FULTON, OH",Less than 65 Years,36
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,90
+,"MATHEWS, VA",Less than 65 Years,28
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,88
+,"WALLER, TX",Less than 65 Years,71
+,,65 Years or more,83
+,,No value,10 or fewer
+,,Total,154
+,"WESTMORELAND, VA",Less than 65 Years,29
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,102
+,"LAWRENCE, PA",Less than 65 Years,35
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,98
+,"GRIMES, TX",Less than 65 Years,41
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,112
+,"BLANCO, TX",Less than 65 Years,24
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,70
+,"GREENSVILLE, VA",Less than 65 Years,28
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,79
+,"CAMP, TX",Less than 65 Years,46
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,105
+,"HARDEMAN, TN",Less than 65 Years,107
+,,65 Years or more,126
+,,No value,10 or fewer
+,,Total,233
+,"LOGAN, OH",Less than 65 Years,33
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,81
+,"LUNENBURG, VA",Less than 65 Years,37
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,87
+,"WASHINGTON, OH",Less than 65 Years,34
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,88
+,"MARION, TN",Less than 65 Years,44
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,98
+,"RICHMOND, VA",Less than 65 Years,26
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,96
+,"LANE, OR",Less than 65 Years,35
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,66
+,"BOSQUE, TX",Less than 65 Years,41
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,80
+,"FAYETTE, OH",Less than 65 Years,45
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,84
+,"SCIOTO, OH",Less than 65 Years,22
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,74
+,"AUSTIN, TX",Less than 65 Years,27
+,,65 Years or more,74
+,,No value,10 or fewer
+,,Total,101
+,"UNION, SD",Less than 65 Years,20
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,68
+,"BURLESON, TX",Less than 65 Years,25
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,73
+,"ADAMS, OH",Less than 65 Years,34
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,84
+,"BEAUFORT, SC",Less than 65 Years,32
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,79
+,"MADISON, VA",Less than 65 Years,29
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,71
+,"NELSON, VA",Less than 65 Years,23
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,75
+,"PROVIDENCE, RI",Less than 65 Years,40
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,71
+,"KING AND QUEEN, VA",Less than 65 Years,25
+,,65 Years or more,58
+,,No value,10 or fewer
+,,Total,83
+,"CALHOUN, SC",Less than 65 Years,43
+,,65 Years or more,82
+,,No value,10 or fewer
+,,Total,125
+,"TRAILL, ND",Less than 65 Years,28
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,69
+,"BENTON, TN",Less than 65 Years,91
+,,65 Years or more,113
+,,No value,10 or fewer
+,,Total,204
+,"ANDERSON, TX",Less than 65 Years,32
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,74
+,"FALLS, TX",Less than 65 Years,28
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,62
+,"HANCOCK, OH",Less than 65 Years,25
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,70
+,"JEFFERSON, OH",Less than 65 Years,33
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,99
+,"SUSQUEHANNA, PA",Less than 65 Years,32
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,74
+,"SAN PATRICIO, TX",Less than 65 Years,61
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,65
+,"SUSSEX, VA",Less than 65 Years,28
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,71
+,"HENRY, VA",Less than 65 Years,29
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,65
+,"MCCORMICK, SC",Less than 65 Years,11
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,59
+,"LEE, SC",Less than 65 Years,29
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,73
+,"DAVIDSON, TN",Less than 65 Years,31
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,59
+,"COOKE, TX",Less than 65 Years,32
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,64
+,"TIOGA, PA",Less than 65 Years,15
+,,65 Years or more,61
+,,No value,10 or fewer
+,,Total,76
+,"GUERNSEY, OH",Less than 65 Years,30
+,,65 Years or more,90
+,,No value,10 or fewer
+,,Total,120
+,"MEIGS, OH",Less than 65 Years,28
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,66
+,"UPSHUR, TX",Less than 65 Years,30
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,80
+,"PALO PINTO, TX",Less than 65 Years,18
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,44
+,"CHARLES CITY, VA",Less than 65 Years,17
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,52
+,"PEMBINA, ND",Less than 65 Years,21
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,64
+,"NEWBERRY, SC",Less than 65 Years,15
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,53
+,"EDGEFIELD, SC",Less than 65 Years,34
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,97
+,"MUSKINGUM, OH",Less than 65 Years,27
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,55
+,"TURNER, SD",Less than 65 Years,14
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,51
+,"WAYNE, PA",Less than 65 Years,29
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,70
+,"PERRY, OH",Less than 65 Years,14
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,61
+,"GEORGETOWN, SC",Less than 65 Years,19
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,54
+,"GREGG, TX",Less than 65 Years,13
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,48
+,"ORANGE, VT",Less than 65 Years,26
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,62
+,"YAMHILL, OR",Less than 65 Years,21
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,45
+,"STAFFORD, VA",Less than 65 Years,30
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,54
+,"HOCKING, OH",Less than 65 Years,26
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,59
+,"COLLETON, SC",Less than 65 Years,23
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,71
+,"KNOX, TN",Less than 65 Years,30
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,64
+,"DAY, SD",Less than 65 Years,11
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,41
+,"POLK, OR",Less than 65 Years,31
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,58
+,"LAUDERDALE, TN",Less than 65 Years,39
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,83
+,"SALUDA, SC",Less than 65 Years,25
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,66
+,"ROBERTSON, TX",Less than 65 Years,23
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,65
+,"HANCOCK, TN",Less than 65 Years,27
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,44
+,"WHARTON, TX",Less than 65 Years,29
+,,65 Years or more,60
+,,No value,10 or fewer
+,,Total,89
+,"DAVIS, UT",Less than 65 Years,21
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,46
+,"FALLS CHURCH CITY, VA",Less than 65 Years,11
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,45
+,"BUCKINGHAM, VA",Less than 65 Years,21
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,56
+,"COMAL, TX",Less than 65 Years,18
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,56
+,"CHEROKEE, OK",Less than 65 Years,16
+,,65 Years or more,40
+,,No value,10 or fewer
+,,Total,56
+,"ROBERTS, SD",Less than 65 Years,15
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,46
+,"FRANKLIN, VT",Less than 65 Years,25
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,51
+,"BAMBERG, SC",Less than 65 Years,27
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,66
+,"CHESTER, TN",Less than 65 Years,51
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,142
+,"SURRY, VA",Less than 65 Years,18
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,49
+,"SPOTSYLVANIA, VA",Less than 65 Years,21
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,48
+,"WASHINGTON, OK",Less than 65 Years,18
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,42
+,"HOPEWELL CITY, VA",Less than 65 Years,26
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,50
+,"TRIPP, SD",Less than 65 Years,14
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,47
+,"CAROLINE, VA",Less than 65 Years,25
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,54
+,"CARROLL, OH",Less than 65 Years,25
+,,65 Years or more,50
+,,No value,10 or fewer
+,,Total,75
+,"WALKER, TX",Less than 65 Years,14
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,38
+,"BRULE, SD",Less than 65 Years,19
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,42
+,"PAWNEE, OK",Less than 65 Years,25
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,47
+,"HARNEY, OR",Less than 65 Years,13
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,54
+,"CRAWFORD, PA",Less than 65 Years,20
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,50
+,"TITUS, TX",Less than 65 Years,31
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,58
+,"DANVILLE CITY, VA",Less than 65 Years,15
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,33
+,"NORTON CITY, VA",Less than 65 Years,22
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,53
+,"CROCKETT, TN",Less than 65 Years,41
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,120
+,"HENRY, OH",Less than 65 Years,16
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,43
+,"PAULDING, OH",Less than 65 Years,19
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,49
+,"BASTROP, TX",Less than 65 Years,20
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,34
+,"UTAH, UT",Less than 65 Years,28
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,45
+,"JACKSON, OH",Less than 65 Years,20
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,47
+,"NOTTOWAY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,39
+,"EL PASO, TX",Less than 65 Years,18
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,38
+,"JEFFERSON, TX",Less than 65 Years,38
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,65
+,"MERCER, ND",Less than 65 Years,12
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,34
+,"MORROW, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,33
+,"WICHITA, TX",Less than 65 Years,18
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,30
+,"LINCOLN, OK",Less than 65 Years,31
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,53
+,"MCKENZIE, ND",Less than 65 Years,30
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,37
+,"MORRIS, TX",Less than 65 Years,21
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,41
+,"PITTSBURG, OK",Less than 65 Years,15
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,46
+,"RHEA, TN",Less than 65 Years,16
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,37
+,"OTTAWA, OK",Less than 65 Years,13
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,34
+,"BUCHANAN, VA",Less than 65 Years,18
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,47
+,"PITTSYLVANIA, VA",Less than 65 Years,15
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,47
+,"RICHLAND, ND",Less than 65 Years,18
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,43
+,"WYOMING, PA",Less than 65 Years,20
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,55
+,"LIMESTONE, TX",Less than 65 Years,22
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,43
+,"CAMERON, TX",Less than 65 Years,34
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,55
+,"MEADE, SD",Less than 65 Years,24
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,36
+,"MEDINA, TX",Less than 65 Years,16
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,38
+,"NELSON, ND",Less than 65 Years,11
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,46
+,"LAWRENCE, SD",Less than 65 Years,13
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,30
+,"AMELIA, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,38
+,"MERCER, OH",Less than 65 Years,14
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,36
+,"BARNWELL, SC",Less than 65 Years,23
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,55
+,"VINTON, OH",Less than 65 Years,14
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,36
+,"DELAWARE, OK",Less than 65 Years,15
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,32
+,"POLK, TX",Less than 65 Years,16
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,46
+,"KLAMATH, OR",Less than 65 Years,12
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,40
+,"LOGAN, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"RAPPAHANNOCK, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,33
+,"GUADALUPE, TX",Less than 65 Years,14
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"STAUNTON CITY, VA",Less than 65 Years,17
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,33
+,"WAYNESBORO CITY, VA",Less than 65 Years,27
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,36
+,"FAYETTE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,32
+,"DOUGLAS, OR",Less than 65 Years,12
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,29
+,"SAN SABA, TX",Less than 65 Years,12
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,33
+,"LAKE, TN",Less than 65 Years,22
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,66
+,"JACKSON, OR",Less than 65 Years,14
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,26
+,"CHARLOTTE, VA",Less than 65 Years,16
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,31
+,"COMANCHE, TX",Less than 65 Years,16
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,35
+,"KENDALL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,30
+,"MANASSAS PARK CITY, VA",Less than 65 Years,15
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,43
+,"HUTCHINSON, TX",Less than 65 Years,12
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,30
+,"INDIANA, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,31
+,"POTTAWATOMIE, OK",Less than 65 Years,13
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,36
+,"HARRISON, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,28
+,"HASKELL, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,33
+,"GRUNDY, TN",Less than 65 Years,19
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,31
+,"LEON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,35
+,"LEE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,36
+,"LUBBOCK, TX",Less than 65 Years,17
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,26
+,"COSHOCTON, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,19
+,"PIKE, OH",Less than 65 Years,13
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,33
+,"POLK, TN",Less than 65 Years,21
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,57
+,"RUTLAND, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,34
+,"BARNES, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"BRISTOL, RI",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,26
+,"OSAGE, OK",Less than 65 Years,12
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,27
+,"FULTON, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,26
+,"WINDHAM, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,27
+,"COMANCHE, OK",Less than 65 Years,19
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,40
+,"FANNIN, TX",Less than 65 Years,12
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,25
+,"JIM WELLS, TX",Less than 65 Years,31
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,32
+,"WYTHE, VA",Less than 65 Years,15
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,27
+,"GRAND ISLE, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,26
+,"CUMBERLAND, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,31
+,"HENDERSON, TN",Less than 65 Years,37
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,73
+,"KENT, RI",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"OKFUSKEE, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,24
+,"EASTLAND, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"WILLIAMS, ND",Less than 65 Years,12
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,29
+,"FREESTONE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,23
+,"MONTAGUE, TX",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"TILLAMOOK, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"WILLIAMSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,23
+,"CAVALIER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,18
+,"WEBB, TX",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"LAMOURE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,18
+,"RUTHERFORD, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"HAYWOOD, TN",Less than 65 Years,19
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,52
+,"SUMMIT, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"FALL RIVER, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,16
+,"LAMOILLE, VT",Less than 65 Years,13
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,26
+,"HOPKINS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,27
+,"SOMERVELL, TX",Less than 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"TAYLOR, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"GRADY, OK",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"HENRY, TN",Less than 65 Years,24
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,41
+,"VENANGO, PA",Less than 65 Years,17
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,29
+,"HAMILTON, TX",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"LYMAN, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,22
+,"MCLEAN, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,24
+,"SOMERSET, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MONTGOMERY, TN",Less than 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"RAMSEY, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,20
+,"PIERCE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,20
+,"CUMBERLAND, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,24
+,"GRIGGS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"LYNCHBURG CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,25
+,"MCNAIRY, TN",Less than 65 Years,19
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,58
+,"ANGELINA, TX",Less than 65 Years,13
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,24
+,"SAN JACINTO, TX",Less than 65 Years,15
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,32
+,"BOWIE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CARTER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"CUSTER, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"GREGORY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"MCMINN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"NORTHUMBERLAND, PA",Less than 65 Years,12
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,26
+,"SUMNER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"GALLIA, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,30
+,"MCCLAIN, OK",Less than 65 Years,19
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,27
+,"NACOGDOCHES, TX",Less than 65 Years,16
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,28
+,"CAMBRIA, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MCCULLOCH, TX",Less than 65 Years,11
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,27
+,"MIDLAND, TX",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"TOWNER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"DICKEY, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"HAMBLEN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"STARK, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MARTINSVILLE CITY, VA",Less than 65 Years,11
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"ATASCOSA, TX",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"BEDFORD, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,18
+,"KERR, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"MATAGORDA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,30
+,"SULLIVAN, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"WILSON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"LAKE, OR",Less than 65 Years,12
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,26
+,"PRINCE EDWARD, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"STEPHENS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,21
+,"CASS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,18
+,"RAINS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,20
+,"SIOUX, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BUFFALO, SD",Less than 65 Years,12
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"CALDWELL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CARSON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,25
+,"CENTRE, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"COLORADO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,36
+,"RUNNELS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TOOELE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"ARANSAS, TX",Less than 65 Years,18
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"GRAY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,20
+,"LYCOMING, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"GRANT, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,13
+,"KAY, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MCCOOK, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YOUNG, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,17
+,"CAMPBELL, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"WEBER, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ORANGE, TX",Less than 65 Years,12
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,27
+,"ROANOKE, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"DEUEL, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,19
+,"WARD, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BLOUNT, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"DOUGLAS, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,15
+,"HOUSTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEVIER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"BANDERA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MEIGS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,21
+,"WHEELER, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AMHERST, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,19
+,"BLAND, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,14
+,"CLATSOP, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"DECATUR, TN",Less than 65 Years,14
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,38
+,"RANSOM, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"WASHINGTON, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"BLAIR, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,14
+,"CALEDONIA, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"ECTOR, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LAWRENCE, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"VICTORIA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"BROWN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"KLEBERG, TX",Less than 65 Years,20
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"ADAIR, OK",Less than 65 Years,15
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,25
+,"UNION, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"WASCO, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"COCKE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"HUGHES, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"WARREN, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,15
+,"JACK, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WILSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"BENNINGTON, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,15
+,"CURRY, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,16
+,"HARDIN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"HARRISON, TX",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"MOORE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"YANKTON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BUTTE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,14
+,"DEAF SMITH, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"GILLESPIE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MAURY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"MORGAN, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VAN BUREN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENSON, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,19
+,"HOLMES, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"SEMINOLE, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DONLEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,13
+,"KING GEORGE, VA",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"MOUNTRAIL, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CADDO, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"CODINGTON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"LAKE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"LATIMER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"FRANKLIN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"GARFIELD, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MADISON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,18
+,"TODD, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"FREDERICKSBURG CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTGOMERY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"ROANOKE CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"GARVIN, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"ANDERSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CUSTER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COKE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,15
+,"EDMUNDS, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STARR, TX",Less than 65 Years,21
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"LIVE OAK, TX",Less than 65 Years,16
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"SHELBY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAVERICK, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOBLE, OH",Less than 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,16
+,"TRINITY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,18
+,"MCCURTAIN, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLENDALE, SC",Less than 65 Years,13
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"CLARION, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"HAMPTON, SC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"JASPER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,18
+,"ROLETTE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ORLEANS, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"NOWATA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PATRICK, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"PONTOTOC, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"BRYAN, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAINGER, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOUDON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTER, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLEARFIELD, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYSON, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRIO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUNTINGDON, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CROCKETT, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOSTER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONCHO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"DAVISON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONROE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"ROBERTSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARMSTRONG, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOKINGS, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDIN, TN",Less than 65 Years,11
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,22
+,"JEFFERSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEELE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWISHER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"VAL VERDE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIDDER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMAR, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEPHENS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUVAL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOSEPHINE, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CACHE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUNIATA, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOODY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BECKHAM, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCKEAN, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MIFFLIN, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARROLL, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CASTRO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCHENRY, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALLOWA, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOWARD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JASPER, SC",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINGFISHER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"LEXINGTON CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOBLE, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"APPOMATTOX, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MURRAY, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PARMER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"ROCKBRIDGE, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOTETOURT, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMMONS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEADLE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMPORIA CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILLIAM, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOOD RIVER, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOVE, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UVALDE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHARLES MIX, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAVACA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROANE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SPINK, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ARCHER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DALLAM, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUNN, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSTON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHITA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELK, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUMPHREYS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MELLETTE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SARGENT, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TYLER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARREN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASATCH, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"AURORA, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALLAHAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAIBORNE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLINTON, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CORSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILES, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUGHES, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRION, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAWRENCE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OLIVER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REFUGIO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STERLING, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEDFORD, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHOCTAW, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COFFEE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEKALB, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEWEY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HETTINGER, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIOWA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MINER, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PULASKI, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WELLS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ATOKA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOX ELDER, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DICKSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDDY, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KARNES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NEWTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SNYDER, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODWARD, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BLAINE, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COTTON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DIMMIT, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAMLIN, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANSFORD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OCHILTREE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UINTAH, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OLDHAM, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUSHMATAHA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SALEM, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARBON, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLEMAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GALAX CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCPHERSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENARD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OGLALA LAKOTA, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RED RIVER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TEXAS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HALE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HIGHLAND, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JIM HOGG, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NOLAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REAGAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SABINE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SMITH, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUTTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILBARGER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WILLACY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALLEGHANY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHEATHAM, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FENTRESS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GONZALES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCHLEICHER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALWORTH, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WOODS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COAL, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EDWARDS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARTLEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HUTCHINSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MAJOR, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARION, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCINTOSH, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MONTOUR, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OVERTON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RADFORD, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERIDAN, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ALFALFA, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOTTINEAU, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CHILDRESS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COVINGTON CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DEWEY, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DIVIDE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERKINS, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCURRY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHEELER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ZAVALA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAYLOR, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BON HOMME, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BROOKS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BURKE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLLINGSWORTH, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAND, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARPER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HASKELL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HEMPHILL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JACKSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINGSBURY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PERRY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN AUGUSTINE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SCOTT, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEWART, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BATH, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BREWSTER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CANNON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DUCHESNE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"EMERY, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOREST, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GILES, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HICKMAN, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAMB, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LIPSCOMB, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARSHALL, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MORGAN, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PECOS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REAL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SANPETE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SEVIER, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHACKELFORD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERMAN, OR",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERMAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STANLEY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WARD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ANDREWS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVER, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLAY, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DELTA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ELLIS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GAINES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAAKON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HALL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HAND, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KIMBLE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LA SALLE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MITCHELL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROGER MILLS, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TERRY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TILLMAN, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BENNETT, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BILLINGS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BOWMAN, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BUENA VISTA CITY, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CIMARRON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"DAWSON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FAULK, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOLDEN VALLEY, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HANSON, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDEMAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOUSTON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JUAB, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KINNEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KNOX, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARTIN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MILLARD, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BEAVER, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BRISCOE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMPBELL, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ESSEX, VT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOARD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARMON, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PICKETT, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UNION, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UPTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CAMERON, PA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COTTLE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRAIG, VA",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROSBY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, OK",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JERAULD, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KANE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MACON, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"REEVES, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ROBERTS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ZAPATA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BAILEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BORDEN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARFIELD, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GLASSCOCK, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOLIAD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOCKLEY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HYDE, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SULLY, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TROUSDALE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"YOAKUM, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ZIEBACH, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COCHRAN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CRANE, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CULBERSON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FISHER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLOYD, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARZA, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HARDING, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFF DAVIS, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JONES, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENEDY, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KENT, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LYNN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MCMULLEN, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MOORE, TN",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POTTER, SD",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRESIDIO, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RENVILLE, ND",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STONEWALL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TERRELL, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"THROCKMORTON, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, UT",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WINKLER, TX",Less than 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 65 Years,6156
+,,65 Years or more,11271
+,,No value,10 or fewer
+,,Total,17427
+,Total,Less than 65 Years,139182
+,,65 Years or more,214500
+,,No value,10 or fewer
+,,Total,353682

--- a/data/epic/raw/staging/D02d_Falls_EDvisits_CountiesWA_WY_Year_Age.csv
+++ b/data/epic/raw/staging/D02d_Falls_EDvisits_CountiesWA_WY_Year_Age.csv
@@ -1,0 +1,5170 @@
+﻿Session Title,Falls in WA-WY,,
+Session ID,2748285,,
+Data Model,ED Encounters,,
+Population Base,All ED Encounters,,
+Population Criteria Filters: These criteria are a summary and do not fully reflect the content of the exported session.,"State of Residence (U.S.): Washington, West Virginia, Wisconsin, Wyoming",ED Diagnoses: Fall,
+Session Date Range,1/1/2023 - 7/10/2025 (Based On Arrival Date),,
+Measure,Number of ED Encounters,,
+Export User,Stephanie Perniciaro,,
+Date of Export,8/8/2025,,
+,,,
+,,,
+,,,Number of ED Encounters
+Year,County of Residence,Age at Time of Visit,
+Jan 1 – Dec 31 2023,"MILWAUKEE, WI",Less than 18 Years,643
+,,≥ 18 and < 25 Years,131
+,,≥ 25 and < 35 Years,236
+,,≥ 35 and < 45 Years,267
+,,≥ 45 and < 55 Years,387
+,,≥ 55 and < 65 Years,738
+,,65 Years or more,2611
+,,No value,10 or fewer
+,,Total,5013
+,"KING, WA",Less than 18 Years,238
+,,≥ 18 and < 25 Years,75
+,,≥ 25 and < 35 Years,127
+,,≥ 35 and < 45 Years,148
+,,≥ 45 and < 55 Years,225
+,,≥ 55 and < 65 Years,451
+,,65 Years or more,3141
+,,No value,10 or fewer
+,,Total,4405
+,"DANE, WI",Less than 18 Years,234
+,,≥ 18 and < 25 Years,59
+,,≥ 25 and < 35 Years,80
+,,≥ 35 and < 45 Years,104
+,,≥ 45 and < 55 Years,140
+,,≥ 55 and < 65 Years,333
+,,65 Years or more,1952
+,,No value,10 or fewer
+,,Total,2902
+,"BROWN, WI",Less than 18 Years,207
+,,≥ 18 and < 25 Years,32
+,,≥ 25 and < 35 Years,81
+,,≥ 35 and < 45 Years,91
+,,≥ 45 and < 55 Years,122
+,,≥ 55 and < 65 Years,224
+,,65 Years or more,1105
+,,No value,10 or fewer
+,,Total,1862
+,"CLARK, WA",Less than 18 Years,236
+,,≥ 18 and < 25 Years,42
+,,≥ 25 and < 35 Years,62
+,,≥ 35 and < 45 Years,71
+,,≥ 45 and < 55 Years,115
+,,≥ 55 and < 65 Years,204
+,,65 Years or more,1013
+,,No value,10 or fewer
+,,Total,1743
+,"BERKELEY, WV",Less than 18 Years,159
+,,≥ 18 and < 25 Years,28
+,,≥ 25 and < 35 Years,43
+,,≥ 35 and < 45 Years,75
+,,≥ 45 and < 55 Years,122
+,,≥ 55 and < 65 Years,170
+,,65 Years or more,758
+,,No value,10 or fewer
+,,Total,1355
+,"SHEBOYGAN, WI",Less than 18 Years,117
+,,≥ 18 and < 25 Years,22
+,,≥ 25 and < 35 Years,27
+,,≥ 35 and < 45 Years,78
+,,≥ 45 and < 55 Years,82
+,,≥ 55 and < 65 Years,197
+,,65 Years or more,902
+,,No value,10 or fewer
+,,Total,1425
+,"SNOHOMISH, WA",Less than 18 Years,136
+,,≥ 18 and < 25 Years,35
+,,≥ 25 and < 35 Years,56
+,,≥ 35 and < 45 Years,78
+,,≥ 45 and < 55 Years,90
+,,≥ 55 and < 65 Years,152
+,,65 Years or more,928
+,,No value,10 or fewer
+,,Total,1475
+,"HARRISON, WV",Less than 18 Years,100
+,,≥ 18 and < 25 Years,32
+,,≥ 25 and < 35 Years,37
+,,≥ 35 and < 45 Years,59
+,,≥ 45 and < 55 Years,92
+,,≥ 55 and < 65 Years,152
+,,65 Years or more,848
+,,No value,10 or fewer
+,,Total,1320
+,"RACINE, WI",Less than 18 Years,91
+,,≥ 18 and < 25 Years,21
+,,≥ 25 and < 35 Years,30
+,,≥ 35 and < 45 Years,51
+,,≥ 45 and < 55 Years,63
+,,≥ 55 and < 65 Years,139
+,,65 Years or more,791
+,,No value,10 or fewer
+,,Total,1186
+,"LARAMIE, WY",Less than 18 Years,132
+,,≥ 18 and < 25 Years,43
+,,≥ 25 and < 35 Years,61
+,,≥ 35 and < 45 Years,76
+,,≥ 45 and < 55 Years,103
+,,≥ 55 and < 65 Years,151
+,,65 Years or more,738
+,,No value,10 or fewer
+,,Total,1304
+,"LA CROSSE, WI",Less than 18 Years,103
+,,≥ 18 and < 25 Years,22
+,,≥ 25 and < 35 Years,31
+,,≥ 35 and < 45 Years,31
+,,≥ 45 and < 55 Years,74
+,,≥ 55 and < 65 Years,123
+,,65 Years or more,727
+,,No value,10 or fewer
+,,Total,1111
+,"WAUKESHA, WI",Less than 18 Years,112
+,,≥ 18 and < 25 Years,18
+,,≥ 25 and < 35 Years,30
+,,≥ 35 and < 45 Years,39
+,,≥ 45 and < 55 Years,46
+,,≥ 55 and < 65 Years,103
+,,65 Years or more,808
+,,No value,10 or fewer
+,,Total,1156
+,"WALWORTH, WI",Less than 18 Years,60
+,,≥ 18 and < 25 Years,16
+,,≥ 25 and < 35 Years,24
+,,≥ 35 and < 45 Years,27
+,,≥ 45 and < 55 Years,46
+,,≥ 55 and < 65 Years,130
+,,65 Years or more,741
+,,No value,10 or fewer
+,,Total,1044
+,"ROCK, WI",Less than 18 Years,71
+,,≥ 18 and < 25 Years,15
+,,≥ 25 and < 35 Years,27
+,,≥ 35 and < 45 Years,57
+,,≥ 45 and < 55 Years,79
+,,≥ 55 and < 65 Years,120
+,,65 Years or more,591
+,,No value,10 or fewer
+,,Total,960
+,"MARION, WV",Less than 18 Years,83
+,,≥ 18 and < 25 Years,22
+,,≥ 25 and < 35 Years,30
+,,≥ 35 and < 45 Years,24
+,,≥ 45 and < 55 Years,67
+,,≥ 55 and < 65 Years,128
+,,65 Years or more,563
+,,No value,10 or fewer
+,,Total,917
+,"WOOD, WV",Less than 18 Years,67
+,,≥ 18 and < 25 Years,13
+,,≥ 25 and < 35 Years,32
+,,≥ 35 and < 45 Years,50
+,,≥ 45 and < 55 Years,71
+,,≥ 55 and < 65 Years,139
+,,65 Years or more,625
+,,No value,10 or fewer
+,,Total,997
+,"MERCER, WV",Less than 18 Years,89
+,,≥ 18 and < 25 Years,24
+,,≥ 25 and < 35 Years,38
+,,≥ 35 and < 45 Years,45
+,,≥ 45 and < 55 Years,71
+,,≥ 55 and < 65 Years,108
+,,65 Years or more,475
+,,No value,10 or fewer
+,,Total,850
+,"KENOSHA, WI",Less than 18 Years,48
+,,≥ 18 and < 25 Years,18
+,,≥ 25 and < 35 Years,26
+,,≥ 35 and < 45 Years,39
+,,≥ 45 and < 55 Years,48
+,,≥ 55 and < 65 Years,108
+,,65 Years or more,586
+,,No value,10 or fewer
+,,Total,873
+,"SKAGIT, WA",Less than 18 Years,63
+,,≥ 18 and < 25 Years,14
+,,≥ 25 and < 35 Years,19
+,,≥ 35 and < 45 Years,28
+,,≥ 45 and < 55 Years,30
+,,≥ 55 and < 65 Years,91
+,,65 Years or more,697
+,,No value,10 or fewer
+,,Total,942
+,"MONONGALIA, WV",Less than 18 Years,113
+,,≥ 18 and < 25 Years,29
+,,≥ 25 and < 35 Years,38
+,,≥ 35 and < 45 Years,33
+,,≥ 45 and < 55 Years,69
+,,≥ 55 and < 65 Years,110
+,,65 Years or more,390
+,,No value,10 or fewer
+,,Total,782
+,"WINNEBAGO, WI",Less than 18 Years,31
+,,≥ 18 and < 25 Years,16
+,,≥ 25 and < 35 Years,17
+,,≥ 35 and < 45 Years,43
+,,≥ 45 and < 55 Years,38
+,,≥ 55 and < 65 Years,91
+,,65 Years or more,375
+,,No value,10 or fewer
+,,Total,611
+,"OZAUKEE, WI",Less than 18 Years,32
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,24
+,,≥ 45 and < 55 Years,26
+,,≥ 55 and < 65 Years,49
+,,65 Years or more,470
+,,No value,10 or fewer
+,,Total,613
+,"MANITOWOC, WI",Less than 18 Years,36
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,21
+,,≥ 35 and < 45 Years,19
+,,≥ 45 and < 55 Years,32
+,,≥ 55 and < 65 Years,82
+,,65 Years or more,360
+,,No value,10 or fewer
+,,Total,560
+,"JEFFERSON, WV",Less than 18 Years,45
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,14
+,,≥ 35 and < 45 Years,17
+,,≥ 45 and < 55 Years,48
+,,≥ 55 and < 65 Years,88
+,,65 Years or more,354
+,,No value,10 or fewer
+,,Total,573
+,"JACKSON, WV",Less than 18 Years,77
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,17
+,,≥ 35 and < 45 Years,29
+,,≥ 45 and < 55 Years,54
+,,≥ 55 and < 65 Years,74
+,,65 Years or more,325
+,,No value,10 or fewer
+,,Total,583
+,"MARSHALL, WV",Less than 18 Years,58
+,,≥ 18 and < 25 Years,12
+,,≥ 25 and < 35 Years,25
+,,≥ 35 and < 45 Years,17
+,,≥ 45 and < 55 Years,41
+,,≥ 55 and < 65 Years,70
+,,65 Years or more,354
+,,No value,10 or fewer
+,,Total,577
+,"NICHOLAS, WV",Less than 18 Years,24
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,21
+,,≥ 35 and < 45 Years,29
+,,≥ 45 and < 55 Years,38
+,,≥ 55 and < 65 Years,76
+,,65 Years or more,312
+,,No value,10 or fewer
+,,Total,510
+,"OHIO, WV",Less than 18 Years,32
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,16
+,,≥ 35 and < 45 Years,16
+,,≥ 45 and < 55 Years,26
+,,≥ 55 and < 65 Years,59
+,,65 Years or more,272
+,,No value,10 or fewer
+,,Total,428
+,"KANAWHA, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,92
+,"WASHINGTON, WI",Less than 18 Years,34
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,17
+,,≥ 45 and < 55 Years,20
+,,≥ 55 and < 65 Years,58
+,,65 Years or more,339
+,,No value,10 or fewer
+,,Total,478
+,"UPSHUR, WV",Less than 18 Years,44
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,17
+,,≥ 35 and < 45 Years,22
+,,≥ 45 and < 55 Years,35
+,,≥ 55 and < 65 Years,58
+,,65 Years or more,218
+,,No value,10 or fewer
+,,Total,404
+,"DOUGLAS, WI",Less than 18 Years,29
+,,≥ 18 and < 25 Years,11
+,,≥ 25 and < 35 Years,17
+,,≥ 35 and < 45 Years,18
+,,≥ 45 and < 55 Years,18
+,,≥ 55 and < 65 Years,49
+,,65 Years or more,255
+,,No value,10 or fewer
+,,Total,397
+,"WETZEL, WV",Less than 18 Years,40
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,12
+,,≥ 35 and < 45 Years,13
+,,≥ 45 and < 55 Years,28
+,,≥ 55 and < 65 Years,40
+,,65 Years or more,213
+,,No value,10 or fewer
+,,Total,354
+,"MARINETTE, WI",Less than 18 Years,28
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,15
+,,≥ 35 and < 45 Years,15
+,,≥ 45 and < 55 Years,19
+,,≥ 55 and < 65 Years,50
+,,65 Years or more,240
+,,No value,10 or fewer
+,,Total,374
+,"MINERAL, WV",Less than 18 Years,31
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,11
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,20
+,,≥ 55 and < 65 Years,63
+,,65 Years or more,184
+,,No value,10 or fewer
+,,Total,319
+,"ALBANY, WY",Less than 18 Years,31
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,16
+,,≥ 35 and < 45 Years,17
+,,≥ 45 and < 55 Years,18
+,,≥ 55 and < 65 Years,37
+,,65 Years or more,171
+,,No value,10 or fewer
+,,Total,298
+,"BRAXTON, WV",Less than 18 Years,26
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,20
+,,≥ 55 and < 65 Years,28
+,,65 Years or more,151
+,,No value,10 or fewer
+,,Total,246
+,"TREMPEALEAU, WI",Less than 18 Years,44
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,11
+,,≥ 35 and < 45 Years,13
+,,≥ 45 and < 55 Years,25
+,,≥ 55 and < 65 Years,37
+,,65 Years or more,144
+,,No value,10 or fewer
+,,Total,282
+,"HAMPSHIRE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,77
+,"OCONTO, WI",Less than 18 Years,22
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,18
+,,≥ 55 and < 65 Years,26
+,,65 Years or more,137
+,,No value,10 or fewer
+,,Total,222
+,"JEFFERSON, WI",Less than 18 Years,15
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,19
+,,≥ 45 and < 55 Years,14
+,,≥ 55 and < 65 Years,39
+,,65 Years or more,113
+,,No value,10 or fewer
+,,Total,210
+,"MORGAN, WV",Less than 18 Years,14
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,74
+,"ISLAND, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,26
+,,65 Years or more,122
+,,No value,10 or fewer
+,,Total,165
+,"GRANT, WI",Less than 18 Years,17
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,14
+,,≥ 55 and < 65 Years,24
+,,65 Years or more,153
+,,No value,10 or fewer
+,,Total,219
+,"PRESTON, WV",Less than 18 Years,21
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,11
+,,≥ 45 and < 55 Years,14
+,,≥ 55 and < 65 Years,23
+,,65 Years or more,102
+,,No value,10 or fewer
+,,Total,180
+,"DODGE, WI",Less than 18 Years,14
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,12
+,,≥ 45 and < 55 Years,17
+,,≥ 55 and < 65 Years,18
+,,65 Years or more,85
+,,No value,10 or fewer
+,,Total,155
+,"FOND DU LAC, WI",Less than 18 Years,11
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,13
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,81
+,"PIERCE, WA",Less than 18 Years,11
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,12
+,,≥ 45 and < 55 Years,15
+,,≥ 55 and < 65 Years,28
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,174
+,"ADAMS, WI",Less than 18 Years,13
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,25
+,,65 Years or more,101
+,,No value,10 or fewer
+,,Total,156
+,"VERNON, WI",Less than 18 Years,15
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,11
+,,≥ 55 and < 65 Years,14
+,,65 Years or more,83
+,,No value,10 or fewer
+,,Total,135
+,"COWLITZ, WA",Less than 18 Years,37
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,14
+,,≥ 55 and < 65 Years,22
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,172
+,"OUTAGAMIE, WI",Less than 18 Years,14
+,,≥ 18 and < 25 Years,11
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,21
+,,65 Years or more,59
+,,No value,10 or fewer
+,,Total,128
+,"TAYLOR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,12
+,,≥ 55 and < 65 Years,15
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,133
+,"GRANT, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,60
+,"LEWIS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,11
+,,≥ 45 and < 55 Years,14
+,,≥ 55 and < 65 Years,20
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,137
+,"HARDY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,58
+,"CHELAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,12
+,,65 Years or more,84
+,,No value,10 or fewer
+,,Total,126
+,"MONROE, WI",Less than 18 Years,14
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,11
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,123
+,"COLUMBIA, WI",Less than 18 Years,17
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,66
+,,No value,10 or fewer
+,,Total,116
+,"TYLER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,112
+,"EAU CLAIRE, WI",Less than 18 Years,17
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,12
+,,≥ 55 and < 65 Years,17
+,,65 Years or more,135
+,,No value,10 or fewer
+,,Total,199
+,"KEWAUNEE, WI",Less than 18 Years,19
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,13
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,100
+,"PARK, WY",Less than 18 Years,16
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,85
+,"BARBOUR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,14
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,85
+,"RITCHIE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,45
+,,No value,10 or fewer
+,,Total,71
+,"WEBSTER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,84
+,"CHIPPEWA, WI",Less than 18 Years,15
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,11
+,,≥ 55 and < 65 Years,23
+,,65 Years or more,136
+,,No value,10 or fewer
+,,Total,204
+,"PUTNAM, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"MINGO, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,17
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,82
+,"RANDOLPH, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,15
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,85
+,"CLAY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,64
+,"PEPIN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,77
+,"BROOKE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,37
+,"DODDRIDGE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,14
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,67
+,"BUFFALO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,13
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,77
+,"LINCOLN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,46
+,"DOUGLAS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,48
+,,No value,10 or fewer
+,,Total,71
+,"WHATCOM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,56
+,"MCDOWELL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,58
+,"BURNETT, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,18
+,,No value,10 or fewer
+,,Total,31
+,"FAYETTE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,11
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,65
+,"JUNEAU, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,65
+,"PENDLETON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,41
+,"SPOKANE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,66
+,"HANCOCK, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,29
+,"THURSTON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,62
+,"WIRT, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,54
+,"GREEN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,57
+,"KITSAP, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,52
+,"SHAWANO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,40
+,"PLEASANTS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,39
+,"RALEIGH, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,11
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,53
+,"DOOR, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,56
+,"CALUMET, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,44
+,"CRAWFORD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,37
+,"TUCKER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,29
+,"POLK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,23
+,"SAUK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,31
+,"MASON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,33
+,"GILMER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,28
+,"CABELL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,28
+,"WAUSHARA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,27
+,"BENTON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,28
+,"JACKSON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,33
+,"SAINT CROIX, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,31
+,"IOWA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,34
+,"PIERCE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,28
+,"BAYFIELD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,21
+,"YAKIMA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,27
+,"SUMMERS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,19
+,"MONROE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"GREENBRIER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"RICHLAND, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"MARQUETTE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"ROANE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,20
+,"BOONE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MARATHON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,27
+,"CARBON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,23
+,"SAWYER, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,22
+,"WAUPACA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,24
+,"DUNN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,33
+,"ASHLAND, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,21
+,"CLALLAM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,19
+,"WYOMING, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,18
+,"LINCOLN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAN JUAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,16
+,"CALHOUN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"CAMPBELL, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,23
+,"NATRONA, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"WOOD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,19
+,"GRANT, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"WESTON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GOSHEN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LEWIS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"GREEN LAKE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,15
+,"GRAYS HARBOR, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"WASHBURN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,16
+,"MASON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"VILAS, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WAYNE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"LOGAN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PACIFIC, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"PLATTE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,19
+,"BARRON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"CLARK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,20
+,"KITTITAS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERIDAN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WALLA WALLA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KLICKITAT, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONEIDA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKANOGAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SKAMANIA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TETON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"FREMONT, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"JEFFERSON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWEETWATER, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENOMINEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POCAHONTAS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PORTAGE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"UINTA, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIG HORN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASOTIN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROOK, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITMAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRICE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONVERSE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLORENCE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOREST, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANGLADE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUBLETTE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHAKIE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAHKIAKUM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOT SPRINGS, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NIOBRARA, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FERRY, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEND OREILLE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARFIELD, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,132
+,,≥ 18 and < 25 Years,31
+,,≥ 25 and < 35 Years,36
+,,≥ 35 and < 45 Years,53
+,,≥ 45 and < 55 Years,85
+,,≥ 55 and < 65 Years,150
+,,65 Years or more,702
+,,No value,10 or fewer
+,,Total,1189
+,Total,Less than 18 Years,4462
+,,≥ 18 and < 25 Years,1049
+,,≥ 25 and < 35 Years,1631
+,,≥ 35 and < 45 Years,2151
+,,≥ 45 and < 55 Years,3237
+,,≥ 55 and < 65 Years,6077
+,,65 Years or more,30503
+,,No value,10 or fewer
+,,Total,49110
+Jan 1 – Dec 31 2024,"MILWAUKEE, WI",Less than 18 Years,694
+,,≥ 18 and < 25 Years,130
+,,≥ 25 and < 35 Years,258
+,,≥ 35 and < 45 Years,307
+,,≥ 45 and < 55 Years,448
+,,≥ 55 and < 65 Years,740
+,,65 Years or more,3096
+,,No value,10 or fewer
+,,Total,5673
+,"KING, WA",Less than 18 Years,278
+,,≥ 18 and < 25 Years,71
+,,≥ 25 and < 35 Years,127
+,,≥ 35 and < 45 Years,196
+,,≥ 45 and < 55 Years,233
+,,≥ 55 and < 65 Years,468
+,,65 Years or more,3474
+,,No value,10 or fewer
+,,Total,4847
+,"DANE, WI",Less than 18 Years,221
+,,≥ 18 and < 25 Years,54
+,,≥ 25 and < 35 Years,85
+,,≥ 35 and < 45 Years,140
+,,≥ 45 and < 55 Years,222
+,,≥ 55 and < 65 Years,374
+,,65 Years or more,2244
+,,No value,10 or fewer
+,,Total,3340
+,"BROWN, WI",Less than 18 Years,220
+,,≥ 18 and < 25 Years,29
+,,≥ 25 and < 35 Years,66
+,,≥ 35 and < 45 Years,98
+,,≥ 45 and < 55 Years,145
+,,≥ 55 and < 65 Years,228
+,,65 Years or more,1355
+,,No value,10 or fewer
+,,Total,2141
+,"CLARK, WA",Less than 18 Years,254
+,,≥ 18 and < 25 Years,38
+,,≥ 25 and < 35 Years,64
+,,≥ 35 and < 45 Years,90
+,,≥ 45 and < 55 Years,150
+,,≥ 55 and < 65 Years,199
+,,65 Years or more,1081
+,,No value,10 or fewer
+,,Total,1876
+,"BERKELEY, WV",Less than 18 Years,204
+,,≥ 18 and < 25 Years,36
+,,≥ 25 and < 35 Years,67
+,,≥ 35 and < 45 Years,63
+,,≥ 45 and < 55 Years,132
+,,≥ 55 and < 65 Years,235
+,,65 Years or more,932
+,,No value,10 or fewer
+,,Total,1669
+,"SHEBOYGAN, WI",Less than 18 Years,134
+,,≥ 18 and < 25 Years,24
+,,≥ 25 and < 35 Years,49
+,,≥ 35 and < 45 Years,71
+,,≥ 45 and < 55 Years,96
+,,≥ 55 and < 65 Years,226
+,,65 Years or more,1074
+,,No value,10 or fewer
+,,Total,1674
+,"SNOHOMISH, WA",Less than 18 Years,167
+,,≥ 18 and < 25 Years,26
+,,≥ 25 and < 35 Years,64
+,,≥ 35 and < 45 Years,74
+,,≥ 45 and < 55 Years,97
+,,≥ 55 and < 65 Years,173
+,,65 Years or more,1015
+,,No value,10 or fewer
+,,Total,1616
+,"HARRISON, WV",Less than 18 Years,155
+,,≥ 18 and < 25 Years,32
+,,≥ 25 and < 35 Years,45
+,,≥ 35 and < 45 Years,65
+,,≥ 45 and < 55 Years,114
+,,≥ 55 and < 65 Years,171
+,,65 Years or more,869
+,,No value,10 or fewer
+,,Total,1451
+,"RACINE, WI",Less than 18 Years,94
+,,≥ 18 and < 25 Years,15
+,,≥ 25 and < 35 Years,29
+,,≥ 35 and < 45 Years,47
+,,≥ 45 and < 55 Years,69
+,,≥ 55 and < 65 Years,172
+,,65 Years or more,893
+,,No value,10 or fewer
+,,Total,1319
+,"LARAMIE, WY",Less than 18 Years,151
+,,≥ 18 and < 25 Years,40
+,,≥ 25 and < 35 Years,53
+,,≥ 35 and < 45 Years,50
+,,≥ 45 and < 55 Years,76
+,,≥ 55 and < 65 Years,136
+,,65 Years or more,687
+,,No value,10 or fewer
+,,Total,1193
+,"LA CROSSE, WI",Less than 18 Years,119
+,,≥ 18 and < 25 Years,25
+,,≥ 25 and < 35 Years,42
+,,≥ 35 and < 45 Years,57
+,,≥ 45 and < 55 Years,87
+,,≥ 55 and < 65 Years,138
+,,65 Years or more,829
+,,No value,10 or fewer
+,,Total,1297
+,"WAUKESHA, WI",Less than 18 Years,154
+,,≥ 18 and < 25 Years,19
+,,≥ 25 and < 35 Years,25
+,,≥ 35 and < 45 Years,23
+,,≥ 45 and < 55 Years,39
+,,≥ 55 and < 65 Years,102
+,,65 Years or more,916
+,,No value,10 or fewer
+,,Total,1278
+,"WALWORTH, WI",Less than 18 Years,71
+,,≥ 18 and < 25 Years,19
+,,≥ 25 and < 35 Years,16
+,,≥ 35 and < 45 Years,25
+,,≥ 45 and < 55 Years,27
+,,≥ 55 and < 65 Years,121
+,,65 Years or more,793
+,,No value,10 or fewer
+,,Total,1072
+,"ROCK, WI",Less than 18 Years,63
+,,≥ 18 and < 25 Years,15
+,,≥ 25 and < 35 Years,32
+,,≥ 35 and < 45 Years,51
+,,≥ 45 and < 55 Years,72
+,,≥ 55 and < 65 Years,145
+,,65 Years or more,742
+,,No value,10 or fewer
+,,Total,1120
+,"MARION, WV",Less than 18 Years,114
+,,≥ 18 and < 25 Years,34
+,,≥ 25 and < 35 Years,33
+,,≥ 35 and < 45 Years,35
+,,≥ 45 and < 55 Years,79
+,,≥ 55 and < 65 Years,156
+,,65 Years or more,654
+,,No value,10 or fewer
+,,Total,1105
+,"WOOD, WV",Less than 18 Years,50
+,,≥ 18 and < 25 Years,31
+,,≥ 25 and < 35 Years,24
+,,≥ 35 and < 45 Years,30
+,,≥ 45 and < 55 Years,64
+,,≥ 55 and < 65 Years,128
+,,65 Years or more,697
+,,No value,10 or fewer
+,,Total,1024
+,"MERCER, WV",Less than 18 Years,115
+,,≥ 18 and < 25 Years,39
+,,≥ 25 and < 35 Years,38
+,,≥ 35 and < 45 Years,49
+,,≥ 45 and < 55 Years,118
+,,≥ 55 and < 65 Years,159
+,,65 Years or more,587
+,,No value,10 or fewer
+,,Total,1105
+,"KENOSHA, WI",Less than 18 Years,72
+,,≥ 18 and < 25 Years,11
+,,≥ 25 and < 35 Years,37
+,,≥ 35 and < 45 Years,44
+,,≥ 45 and < 55 Years,64
+,,≥ 55 and < 65 Years,126
+,,65 Years or more,710
+,,No value,10 or fewer
+,,Total,1064
+,"SKAGIT, WA",Less than 18 Years,69
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,20
+,,≥ 35 and < 45 Years,27
+,,≥ 45 and < 55 Years,49
+,,≥ 55 and < 65 Years,98
+,,65 Years or more,733
+,,No value,10 or fewer
+,,Total,1005
+,"MONONGALIA, WV",Less than 18 Years,135
+,,≥ 18 and < 25 Years,33
+,,≥ 25 and < 35 Years,40
+,,≥ 35 and < 45 Years,40
+,,≥ 45 and < 55 Years,61
+,,≥ 55 and < 65 Years,96
+,,65 Years or more,419
+,,No value,10 or fewer
+,,Total,824
+,"WINNEBAGO, WI",Less than 18 Years,68
+,,≥ 18 and < 25 Years,16
+,,≥ 25 and < 35 Years,38
+,,≥ 35 and < 45 Years,27
+,,≥ 45 and < 55 Years,48
+,,≥ 55 and < 65 Years,107
+,,65 Years or more,481
+,,No value,10 or fewer
+,,Total,785
+,"OZAUKEE, WI",Less than 18 Years,51
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,15
+,,≥ 35 and < 45 Years,17
+,,≥ 45 and < 55 Years,23
+,,≥ 55 and < 65 Years,67
+,,65 Years or more,570
+,,No value,10 or fewer
+,,Total,753
+,"MANITOWOC, WI",Less than 18 Years,58
+,,≥ 18 and < 25 Years,11
+,,≥ 25 and < 35 Years,14
+,,≥ 35 and < 45 Years,22
+,,≥ 45 and < 55 Years,28
+,,≥ 55 and < 65 Years,86
+,,65 Years or more,494
+,,No value,10 or fewer
+,,Total,713
+,"JEFFERSON, WV",Less than 18 Years,61
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,11
+,,≥ 35 and < 45 Years,24
+,,≥ 45 and < 55 Years,33
+,,≥ 55 and < 65 Years,89
+,,65 Years or more,413
+,,No value,10 or fewer
+,,Total,638
+,"JACKSON, WV",Less than 18 Years,64
+,,≥ 18 and < 25 Years,15
+,,≥ 25 and < 35 Years,21
+,,≥ 35 and < 45 Years,24
+,,≥ 45 and < 55 Years,43
+,,≥ 55 and < 65 Years,65
+,,65 Years or more,380
+,,No value,10 or fewer
+,,Total,612
+,"MARSHALL, WV",Less than 18 Years,53
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,25
+,,≥ 35 and < 45 Years,26
+,,≥ 45 and < 55 Years,48
+,,≥ 55 and < 65 Years,61
+,,65 Years or more,376
+,,No value,10 or fewer
+,,Total,598
+,"NICHOLAS, WV",Less than 18 Years,25
+,,≥ 18 and < 25 Years,16
+,,≥ 25 and < 35 Years,22
+,,≥ 35 and < 45 Years,22
+,,≥ 45 and < 55 Years,30
+,,≥ 55 and < 65 Years,96
+,,65 Years or more,386
+,,No value,10 or fewer
+,,Total,597
+,"OHIO, WV",Less than 18 Years,38
+,,≥ 18 and < 25 Years,16
+,,≥ 25 and < 35 Years,11
+,,≥ 35 and < 45 Years,24
+,,≥ 45 and < 55 Years,43
+,,≥ 55 and < 65 Years,85
+,,65 Years or more,367
+,,No value,10 or fewer
+,,Total,584
+,"KANAWHA, WV",Less than 18 Years,37
+,,≥ 18 and < 25 Years,17
+,,≥ 25 and < 35 Years,19
+,,≥ 35 and < 45 Years,22
+,,≥ 45 and < 55 Years,44
+,,≥ 55 and < 65 Years,75
+,,65 Years or more,442
+,,No value,10 or fewer
+,,Total,656
+,"WASHINGTON, WI",Less than 18 Years,44
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,19
+,,≥ 35 and < 45 Years,14
+,,≥ 45 and < 55 Years,20
+,,≥ 55 and < 65 Years,44
+,,65 Years or more,354
+,,No value,10 or fewer
+,,Total,503
+,"UPSHUR, WV",Less than 18 Years,51
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,22
+,,≥ 35 and < 45 Years,17
+,,≥ 45 and < 55 Years,38
+,,≥ 55 and < 65 Years,63
+,,65 Years or more,279
+,,No value,10 or fewer
+,,Total,480
+,"DOUGLAS, WI",Less than 18 Years,28
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,14
+,,≥ 35 and < 45 Years,28
+,,≥ 45 and < 55 Years,21
+,,≥ 55 and < 65 Years,52
+,,65 Years or more,276
+,,No value,10 or fewer
+,,Total,425
+,"WETZEL, WV",Less than 18 Years,55
+,,≥ 18 and < 25 Years,11
+,,≥ 25 and < 35 Years,21
+,,≥ 35 and < 45 Years,26
+,,≥ 45 and < 55 Years,24
+,,≥ 55 and < 65 Years,57
+,,65 Years or more,220
+,,No value,10 or fewer
+,,Total,414
+,"MARINETTE, WI",Less than 18 Years,13
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,19
+,,≥ 55 and < 65 Years,56
+,,65 Years or more,229
+,,No value,10 or fewer
+,,Total,338
+,"MINERAL, WV",Less than 18 Years,39
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,16
+,,≥ 45 and < 55 Years,23
+,,≥ 55 and < 65 Years,50
+,,65 Years or more,221
+,,No value,10 or fewer
+,,Total,363
+,"ALBANY, WY",Less than 18 Years,37
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,11
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,16
+,,≥ 55 and < 65 Years,24
+,,65 Years or more,161
+,,No value,10 or fewer
+,,Total,267
+,"BRAXTON, WV",Less than 18 Years,18
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,11
+,,≥ 45 and < 55 Years,17
+,,≥ 55 and < 65 Years,30
+,,65 Years or more,168
+,,No value,10 or fewer
+,,Total,253
+,"TREMPEALEAU, WI",Less than 18 Years,27
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,11
+,,≥ 55 and < 65 Years,25
+,,65 Years or more,150
+,,No value,10 or fewer
+,,Total,238
+,"HAMPSHIRE, WV",Less than 18 Years,40
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,29
+,,≥ 55 and < 65 Years,50
+,,65 Years or more,219
+,,No value,10 or fewer
+,,Total,358
+,"OCONTO, WI",Less than 18 Years,19
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,15
+,,≥ 55 and < 65 Years,24
+,,65 Years or more,143
+,,No value,10 or fewer
+,,Total,218
+,"JEFFERSON, WI",Less than 18 Years,19
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,15
+,,≥ 45 and < 55 Years,18
+,,≥ 55 and < 65 Years,32
+,,65 Years or more,146
+,,No value,10 or fewer
+,,Total,239
+,"MORGAN, WV",Less than 18 Years,38
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,12
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,17
+,,≥ 55 and < 65 Years,33
+,,65 Years or more,200
+,,No value,10 or fewer
+,,Total,315
+,"ISLAND, WA",Less than 18 Years,12
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,23
+,,65 Years or more,171
+,,No value,10 or fewer
+,,Total,225
+,"GRANT, WI",Less than 18 Years,19
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,19
+,,≥ 45 and < 55 Years,13
+,,≥ 55 and < 65 Years,25
+,,65 Years or more,126
+,,No value,10 or fewer
+,,Total,209
+,"PRESTON, WV",Less than 18 Years,43
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,16
+,,≥ 45 and < 55 Years,17
+,,≥ 55 and < 65 Years,25
+,,65 Years or more,107
+,,No value,10 or fewer
+,,Total,222
+,"DODGE, WI",Less than 18 Years,12
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,13
+,,≥ 55 and < 65 Years,18
+,,65 Years or more,113
+,,No value,10 or fewer
+,,Total,178
+,"FOND DU LAC, WI",Less than 18 Years,30
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,23
+,,≥ 45 and < 55 Years,20
+,,≥ 55 and < 65 Years,26
+,,65 Years or more,87
+,,No value,10 or fewer
+,,Total,198
+,"PIERCE, WA",Less than 18 Years,15
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,15
+,,≥ 35 and < 45 Years,13
+,,≥ 45 and < 55 Years,17
+,,≥ 55 and < 65 Years,15
+,,65 Years or more,99
+,,No value,10 or fewer
+,,Total,181
+,"ADAMS, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,13
+,,≥ 55 and < 65 Years,34
+,,65 Years or more,88
+,,No value,10 or fewer
+,,Total,162
+,"VERNON, WI",Less than 18 Years,18
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,11
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,125
+,,No value,10 or fewer
+,,Total,178
+,"COWLITZ, WA",Less than 18 Years,24
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,19
+,,65 Years or more,91
+,,No value,10 or fewer
+,,Total,163
+,"OUTAGAMIE, WI",Less than 18 Years,14
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,16
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,21
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,156
+,"TAYLOR, WV",Less than 18 Years,16
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,14
+,,≥ 55 and < 65 Years,22
+,,65 Years or more,80
+,,No value,10 or fewer
+,,Total,151
+,"GRANT, WV",Less than 18 Years,11
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,15
+,,≥ 55 and < 65 Years,27
+,,65 Years or more,109
+,,No value,10 or fewer
+,,Total,179
+,"LEWIS, WV",Less than 18 Years,13
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,16
+,,65 Years or more,76
+,,No value,10 or fewer
+,,Total,129
+,"HARDY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,26
+,,65 Years or more,117
+,,No value,10 or fewer
+,,Total,169
+,"CHELAN, WA",Less than 18 Years,12
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,81
+,,No value,10 or fewer
+,,Total,116
+,"MONROE, WI",Less than 18 Years,14
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,13
+,,65 Years or more,67
+,,No value,10 or fewer
+,,Total,115
+,"COLUMBIA, WI",Less than 18 Years,11
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,21
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,112
+,"TYLER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,16
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,107
+,"EAU CLAIRE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,55
+,"KEWAUNEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,18
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,87
+,"PARK, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,14
+,,65 Years or more,77
+,,No value,10 or fewer
+,,Total,113
+,"BARBOUR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,13
+,,≥ 55 and < 65 Years,26
+,,65 Years or more,64
+,,No value,10 or fewer
+,,Total,114
+,"RITCHIE, WV",Less than 18 Years,13
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,11
+,,65 Years or more,79
+,,No value,10 or fewer
+,,Total,120
+,"WEBSTER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,11
+,,65 Years or more,78
+,,No value,10 or fewer
+,,Total,116
+,"CHIPPEWA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,33
+,"PUTNAM, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,85
+,,No value,10 or fewer
+,,Total,112
+,"MINGO, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,11
+,,≥ 55 and < 65 Years,16
+,,65 Years or more,57
+,,No value,10 or fewer
+,,Total,93
+,"RANDOLPH, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,11
+,,65 Years or more,52
+,,No value,10 or fewer
+,,Total,87
+,"CLAY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,12
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,93
+,"PEPIN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,76
+,"BROOKE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,53
+,"DODDRIDGE, WV",Less than 18 Years,12
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,75
+,"BUFFALO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,13
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,74
+,"LINCOLN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,54
+,,No value,10 or fewer
+,,Total,84
+,"DOUGLAS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,13
+,,65 Years or more,41
+,,No value,10 or fewer
+,,Total,72
+,"WHATCOM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,14
+,,65 Years or more,36
+,,No value,10 or fewer
+,,Total,83
+,"MCDOWELL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,76
+,"BURNETT, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,73
+,,No value,10 or fewer
+,,Total,106
+,"FAYETTE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,11
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,68
+,"JUNEAU, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,12
+,,65 Years or more,47
+,,No value,10 or fewer
+,,Total,71
+,"PENDLETON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,65
+,"SPOKANE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,12
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,65
+,"HANCOCK, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,26
+,"THURSTON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,48
+,"WIRT, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,38
+,,No value,10 or fewer
+,,Total,62
+,"GREEN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,48
+,"KITSAP, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,52
+,"SHAWANO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,50
+,"PLEASANTS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,34
+,,No value,10 or fewer
+,,Total,52
+,"RALEIGH, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,33
+,,No value,10 or fewer
+,,Total,50
+,"DOOR, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,37
+,"CALUMET, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,51
+,"CRAWFORD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,48
+,"TUCKER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,39
+,"POLK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,32
+,"SAUK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,37
+,"MASON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,31
+,"GILMER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,33
+,"CABELL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,35
+,"WAUSHARA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,38
+,"BENTON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,34
+,"JACKSON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,31
+,"SAINT CROIX, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,27
+,"IOWA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,28
+,"PIERCE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,20
+,"BAYFIELD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,29
+,"YAKIMA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,19
+,,No value,10 or fewer
+,,Total,34
+,"SUMMERS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,32
+,"MONROE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,31
+,"GREENBRIER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,26
+,"RICHLAND, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,26
+,"MARQUETTE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,27
+,"ROANE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"BOONE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,34
+,"MARATHON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,21
+,"CARBON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,23
+,"SAWYER, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,24
+,"WAUPACA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"DUNN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,18
+,"ASHLAND, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CLALLAM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,24
+,"WYOMING, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,20
+,"LINCOLN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,20
+,"SAN JUAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,24
+,"CALHOUN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,18
+,"CAMPBELL, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"NATRONA, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"WOOD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"GRANT, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,19
+,"WESTON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,21
+,"GOSHEN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"LEWIS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GREEN LAKE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,15
+,"GRAYS HARBOR, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,15
+,"WASHBURN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"MASON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VILAS, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,13
+,"WAYNE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,17
+,"LAFAYETTE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,16
+,"PACIFIC, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"PLATTE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARRON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KITTITAS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERIDAN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALLA WALLA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"FRANKLIN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"KLICKITAT, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,15
+,"ONEIDA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKANOGAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SKAMANIA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TETON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREMONT, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWEETWATER, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"MENOMINEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POCAHONTAS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"PORTAGE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UINTA, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIG HORN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"RUSK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASOTIN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROOK, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITMAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRICE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONVERSE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLORENCE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOREST, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANGLADE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUBLETTE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHAKIE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAHKIAKUM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOT SPRINGS, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NIOBRARA, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FERRY, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEND OREILLE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARFIELD, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,132
+,,≥ 18 and < 25 Years,24
+,,≥ 25 and < 35 Years,45
+,,≥ 35 and < 45 Years,48
+,,≥ 45 and < 55 Years,94
+,,≥ 55 and < 65 Years,191
+,,65 Years or more,845
+,,No value,10 or fewer
+,,Total,1379
+,Total,Less than 18 Years,5119
+,,≥ 18 and < 25 Years,1111
+,,≥ 25 and < 35 Years,1826
+,,≥ 35 and < 45 Years,2354
+,,≥ 45 and < 55 Years,3616
+,,≥ 55 and < 65 Years,6730
+,,65 Years or more,35491
+,,No value,10 or fewer
+,,Total,56247
+Jan 1 – Jul 10 2025,"MILWAUKEE, WI",Less than 18 Years,424
+,,≥ 18 and < 25 Years,100
+,,≥ 25 and < 35 Years,127
+,,≥ 35 and < 45 Years,181
+,,≥ 45 and < 55 Years,242
+,,≥ 55 and < 65 Years,417
+,,65 Years or more,1696
+,,No value,10 or fewer
+,,Total,3187
+,"KING, WA",Less than 18 Years,152
+,,≥ 18 and < 25 Years,44
+,,≥ 25 and < 35 Years,77
+,,≥ 35 and < 45 Years,113
+,,≥ 45 and < 55 Years,117
+,,≥ 55 and < 65 Years,279
+,,65 Years or more,2021
+,,No value,10 or fewer
+,,Total,2803
+,"DANE, WI",Less than 18 Years,140
+,,≥ 18 and < 25 Years,31
+,,≥ 25 and < 35 Years,85
+,,≥ 35 and < 45 Years,79
+,,≥ 45 and < 55 Years,137
+,,≥ 55 and < 65 Years,198
+,,65 Years or more,1269
+,,No value,10 or fewer
+,,Total,1939
+,"BROWN, WI",Less than 18 Years,100
+,,≥ 18 and < 25 Years,23
+,,≥ 25 and < 35 Years,47
+,,≥ 35 and < 45 Years,56
+,,≥ 45 and < 55 Years,69
+,,≥ 55 and < 65 Years,134
+,,65 Years or more,728
+,,No value,10 or fewer
+,,Total,1157
+,"CLARK, WA",Less than 18 Years,156
+,,≥ 18 and < 25 Years,21
+,,≥ 25 and < 35 Years,31
+,,≥ 35 and < 45 Years,40
+,,≥ 45 and < 55 Years,43
+,,≥ 55 and < 65 Years,117
+,,65 Years or more,552
+,,No value,10 or fewer
+,,Total,960
+,"BERKELEY, WV",Less than 18 Years,130
+,,≥ 18 and < 25 Years,30
+,,≥ 25 and < 35 Years,48
+,,≥ 35 and < 45 Years,50
+,,≥ 45 and < 55 Years,81
+,,≥ 55 and < 65 Years,141
+,,65 Years or more,584
+,,No value,10 or fewer
+,,Total,1064
+,"SHEBOYGAN, WI",Less than 18 Years,79
+,,≥ 18 and < 25 Years,21
+,,≥ 25 and < 35 Years,37
+,,≥ 35 and < 45 Years,33
+,,≥ 45 and < 55 Years,65
+,,≥ 55 and < 65 Years,126
+,,65 Years or more,620
+,,No value,10 or fewer
+,,Total,981
+,"SNOHOMISH, WA",Less than 18 Years,95
+,,≥ 18 and < 25 Years,13
+,,≥ 25 and < 35 Years,43
+,,≥ 35 and < 45 Years,45
+,,≥ 45 and < 55 Years,62
+,,≥ 55 and < 65 Years,87
+,,65 Years or more,619
+,,No value,10 or fewer
+,,Total,964
+,"HARRISON, WV",Less than 18 Years,64
+,,≥ 18 and < 25 Years,19
+,,≥ 25 and < 35 Years,30
+,,≥ 35 and < 45 Years,30
+,,≥ 45 and < 55 Years,60
+,,≥ 55 and < 65 Years,110
+,,65 Years or more,462
+,,No value,10 or fewer
+,,Total,775
+,"RACINE, WI",Less than 18 Years,75
+,,≥ 18 and < 25 Years,11
+,,≥ 25 and < 35 Years,29
+,,≥ 35 and < 45 Years,48
+,,≥ 45 and < 55 Years,55
+,,≥ 55 and < 65 Years,91
+,,65 Years or more,586
+,,No value,10 or fewer
+,,Total,895
+,"LARAMIE, WY",Less than 18 Years,86
+,,≥ 18 and < 25 Years,18
+,,≥ 25 and < 35 Years,28
+,,≥ 35 and < 45 Years,31
+,,≥ 45 and < 55 Years,34
+,,≥ 55 and < 65 Years,80
+,,65 Years or more,420
+,,No value,10 or fewer
+,,Total,697
+,"LA CROSSE, WI",Less than 18 Years,71
+,,≥ 18 and < 25 Years,25
+,,≥ 25 and < 35 Years,33
+,,≥ 35 and < 45 Years,38
+,,≥ 45 and < 55 Years,45
+,,≥ 55 and < 65 Years,100
+,,65 Years or more,472
+,,No value,10 or fewer
+,,Total,784
+,"WAUKESHA, WI",Less than 18 Years,74
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,12
+,,≥ 35 and < 45 Years,18
+,,≥ 45 and < 55 Years,27
+,,≥ 55 and < 65 Years,61
+,,65 Years or more,468
+,,No value,10 or fewer
+,,Total,667
+,"WALWORTH, WI",Less than 18 Years,37
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,18
+,,≥ 45 and < 55 Years,24
+,,≥ 55 and < 65 Years,85
+,,65 Years or more,449
+,,No value,10 or fewer
+,,Total,628
+,"ROCK, WI",Less than 18 Years,26
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,17
+,,≥ 35 and < 45 Years,21
+,,≥ 45 and < 55 Years,41
+,,≥ 55 and < 65 Years,73
+,,65 Years or more,400
+,,No value,10 or fewer
+,,Total,585
+,"MARION, WV",Less than 18 Years,43
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,26
+,,≥ 35 and < 45 Years,25
+,,≥ 45 and < 55 Years,50
+,,≥ 55 and < 65 Years,64
+,,65 Years or more,407
+,,No value,10 or fewer
+,,Total,624
+,"WOOD, WV",Less than 18 Years,38
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,15
+,,≥ 35 and < 45 Years,24
+,,≥ 45 and < 55 Years,27
+,,≥ 55 and < 65 Years,89
+,,65 Years or more,411
+,,No value,10 or fewer
+,,Total,608
+,"MERCER, WV",Less than 18 Years,78
+,,≥ 18 and < 25 Years,26
+,,≥ 25 and < 35 Years,50
+,,≥ 35 and < 45 Years,43
+,,≥ 45 and < 55 Years,45
+,,≥ 55 and < 65 Years,99
+,,65 Years or more,326
+,,No value,10 or fewer
+,,Total,667
+,"KENOSHA, WI",Less than 18 Years,48
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,16
+,,≥ 35 and < 45 Years,22
+,,≥ 45 and < 55 Years,35
+,,≥ 55 and < 65 Years,75
+,,65 Years or more,415
+,,No value,10 or fewer
+,,Total,620
+,"SKAGIT, WA",Less than 18 Years,38
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,13
+,,≥ 35 and < 45 Years,15
+,,≥ 45 and < 55 Years,33
+,,≥ 55 and < 65 Years,46
+,,65 Years or more,374
+,,No value,10 or fewer
+,,Total,527
+,"MONONGALIA, WV",Less than 18 Years,78
+,,≥ 18 and < 25 Years,18
+,,≥ 25 and < 35 Years,28
+,,≥ 35 and < 45 Years,20
+,,≥ 45 and < 55 Years,30
+,,≥ 55 and < 65 Years,50
+,,65 Years or more,217
+,,No value,10 or fewer
+,,Total,441
+,"WINNEBAGO, WI",Less than 18 Years,36
+,,≥ 18 and < 25 Years,12
+,,≥ 25 and < 35 Years,17
+,,≥ 35 and < 45 Years,25
+,,≥ 45 and < 55 Years,26
+,,≥ 55 and < 65 Years,63
+,,65 Years or more,328
+,,No value,10 or fewer
+,,Total,507
+,"OZAUKEE, WI",Less than 18 Years,33
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,14
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,35
+,,65 Years or more,331
+,,No value,10 or fewer
+,,Total,434
+,"MANITOWOC, WI",Less than 18 Years,33
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,16
+,,≥ 35 and < 45 Years,16
+,,≥ 45 and < 55 Years,13
+,,≥ 55 and < 65 Years,48
+,,65 Years or more,268
+,,No value,10 or fewer
+,,Total,398
+,"JEFFERSON, WV",Less than 18 Years,36
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,14
+,,≥ 45 and < 55 Years,30
+,,≥ 55 and < 65 Years,36
+,,65 Years or more,238
+,,No value,10 or fewer
+,,Total,360
+,"JACKSON, WV",Less than 18 Years,55
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,14
+,,≥ 35 and < 45 Years,19
+,,≥ 45 and < 55 Years,29
+,,≥ 55 and < 65 Years,35
+,,65 Years or more,210
+,,No value,10 or fewer
+,,Total,370
+,"MARSHALL, WV",Less than 18 Years,30
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,11
+,,≥ 35 and < 45 Years,17
+,,≥ 45 and < 55 Years,27
+,,≥ 55 and < 65 Years,50
+,,65 Years or more,204
+,,No value,10 or fewer
+,,Total,343
+,"NICHOLAS, WV",Less than 18 Years,23
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,12
+,,≥ 35 and < 45 Years,19
+,,≥ 45 and < 55 Years,26
+,,≥ 55 and < 65 Years,48
+,,65 Years or more,214
+,,No value,10 or fewer
+,,Total,344
+,"OHIO, WV",Less than 18 Years,27
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,14
+,,≥ 35 and < 45 Years,19
+,,≥ 45 and < 55 Years,21
+,,≥ 55 and < 65 Years,50
+,,65 Years or more,237
+,,No value,10 or fewer
+,,Total,370
+,"KANAWHA, WV",Less than 18 Years,30
+,,≥ 18 and < 25 Years,17
+,,≥ 25 and < 35 Years,34
+,,≥ 35 and < 45 Years,23
+,,≥ 45 and < 55 Years,60
+,,≥ 55 and < 65 Years,78
+,,65 Years or more,356
+,,No value,10 or fewer
+,,Total,598
+,"WASHINGTON, WI",Less than 18 Years,23
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,23
+,,65 Years or more,190
+,,No value,10 or fewer
+,,Total,262
+,"UPSHUR, WV",Less than 18 Years,24
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,13
+,,≥ 35 and < 45 Years,15
+,,≥ 45 and < 55 Years,27
+,,≥ 55 and < 65 Years,43
+,,65 Years or more,148
+,,No value,10 or fewer
+,,Total,274
+,"DOUGLAS, WI",Less than 18 Years,16
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,11
+,,≥ 35 and < 45 Years,12
+,,≥ 45 and < 55 Years,20
+,,≥ 55 and < 65 Years,27
+,,65 Years or more,149
+,,No value,10 or fewer
+,,Total,240
+,"WETZEL, WV",Less than 18 Years,23
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,14
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,17
+,,≥ 55 and < 65 Years,44
+,,65 Years or more,112
+,,No value,10 or fewer
+,,Total,226
+,"MARINETTE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,15
+,,≥ 55 and < 65 Years,26
+,,65 Years or more,177
+,,No value,10 or fewer
+,,Total,237
+,"MINERAL, WV",Less than 18 Years,13
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,15
+,,≥ 55 and < 65 Years,16
+,,65 Years or more,137
+,,No value,10 or fewer
+,,Total,193
+,"ALBANY, WY",Less than 18 Years,20
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,11
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,17
+,,65 Years or more,117
+,,No value,10 or fewer
+,,Total,187
+,"BRAXTON, WV",Less than 18 Years,22
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,11
+,,≥ 45 and < 55 Years,13
+,,≥ 55 and < 65 Years,26
+,,65 Years or more,99
+,,No value,10 or fewer
+,,Total,181
+,"TREMPEALEAU, WI",Less than 18 Years,16
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,14
+,,65 Years or more,93
+,,No value,10 or fewer
+,,Total,140
+,"HAMPSHIRE, WV",Less than 18 Years,22
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,15
+,,≥ 55 and < 65 Years,31
+,,65 Years or more,130
+,,No value,10 or fewer
+,,Total,217
+,"OCONTO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,16
+,,65 Years or more,92
+,,No value,10 or fewer
+,,Total,126
+,"JEFFERSON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,16
+,,65 Years or more,64
+,,No value,10 or fewer
+,,Total,109
+,"MORGAN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,23
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,146
+,"ISLAND, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,114
+,,No value,10 or fewer
+,,Total,138
+,"GRANT, WI",Less than 18 Years,12
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,14
+,,65 Years or more,56
+,,No value,10 or fewer
+,,Total,94
+,"PRESTON, WV",Less than 18 Years,15
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,19
+,,65 Years or more,44
+,,No value,10 or fewer
+,,Total,105
+,"DODGE, WI",Less than 18 Years,11
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,12
+,,65 Years or more,64
+,,No value,10 or fewer
+,,Total,115
+,"FOND DU LAC, WI",Less than 18 Years,23
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,16
+,,65 Years or more,97
+,,No value,10 or fewer
+,,Total,164
+,"PIERCE, WA",Less than 18 Years,13
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,39
+,,No value,10 or fewer
+,,Total,77
+,"ADAMS, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,24
+,,65 Years or more,53
+,,No value,10 or fewer
+,,Total,99
+,"VERNON, WI",Less than 18 Years,13
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,12
+,,65 Years or more,62
+,,No value,10 or fewer
+,,Total,98
+,"COWLITZ, WA",Less than 18 Years,13
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,12
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,74
+,"OUTAGAMIE, WI",Less than 18 Years,12
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,11
+,,65 Years or more,55
+,,No value,10 or fewer
+,,Total,99
+,"TAYLOR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,13
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,87
+,"GRANT, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,13
+,,65 Years or more,63
+,,No value,10 or fewer
+,,Total,92
+,"LEWIS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,65
+,"HARDY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,71
+,,No value,10 or fewer
+,,Total,100
+,"CHELAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,46
+,,No value,10 or fewer
+,,Total,72
+,"MONROE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,53
+,"COLUMBIA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,58
+,"TYLER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,43
+,,No value,10 or fewer
+,,Total,62
+,"EAU CLAIRE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"KEWAUNEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,51
+,,No value,10 or fewer
+,,Total,77
+,"PARK, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,42
+,,No value,10 or fewer
+,,Total,61
+,"BARBOUR, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,48
+,"RITCHIE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,12
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,53
+,"WEBSTER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,44
+,"CHIPPEWA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PUTNAM, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,15
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,112
+,"MINGO, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,32
+,,No value,10 or fewer
+,,Total,55
+,"RANDOLPH, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,51
+,"CLAY, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,31
+,,No value,10 or fewer
+,,Total,50
+,"PEPIN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,43
+,"BROOKE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,75
+,,No value,10 or fewer
+,,Total,105
+,"DODDRIDGE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,37
+,,No value,10 or fewer
+,,Total,53
+,"BUFFALO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,35
+,,No value,10 or fewer
+,,Total,43
+,"LINCOLN, WY",Less than 18 Years,13
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,56
+,"DOUGLAS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,28
+,,No value,10 or fewer
+,,Total,40
+,"WHATCOM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,41
+,"MCDOWELL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,43
+,"BURNETT, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,39
+,"FAYETTE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,41
+,"JUNEAU, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,26
+,,No value,10 or fewer
+,,Total,36
+,"PENDLETON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,49
+,,No value,10 or fewer
+,,Total,60
+,"SPOKANE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,21
+,,No value,10 or fewer
+,,Total,35
+,"HANCOCK, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,13
+,,65 Years or more,70
+,,No value,10 or fewer
+,,Total,100
+,"THURSTON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,24
+,,No value,10 or fewer
+,,Total,37
+,"WIRT, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,28
+,"GREEN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,27
+,,No value,10 or fewer
+,,Total,36
+,"KITSAP, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,20
+,,No value,10 or fewer
+,,Total,29
+,"SHAWANO, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,30
+,,No value,10 or fewer
+,,Total,42
+,"PLEASANTS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,29
+,,No value,10 or fewer
+,,Total,40
+,"RALEIGH, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,28
+,"DOOR, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,22
+,,No value,10 or fewer
+,,Total,30
+,"CALUMET, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,25
+,"CRAWFORD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,23
+,"TUCKER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,23
+,,No value,10 or fewer
+,,Total,30
+,"POLK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,25
+,,No value,10 or fewer
+,,Total,40
+,"SAUK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,27
+,"MASON, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,22
+,"GILMER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,24
+,"CABELL, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,19
+,"WAUSHARA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,17
+,"BENTON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,13
+,,No value,10 or fewer
+,,Total,19
+,"JACKSON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,16
+,"SAINT CROIX, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,22
+,"IOWA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"PIERCE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,17
+,,No value,10 or fewer
+,,Total,23
+,"BAYFIELD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,16
+,,No value,10 or fewer
+,,Total,20
+,"YAKIMA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUMMERS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,16
+,"MONROE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"GREENBRIER, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"RICHLAND, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,16
+,"MARQUETTE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"ROANE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,15
+,,No value,10 or fewer
+,,Total,19
+,"BOONE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,12
+,,No value,10 or fewer
+,,Total,17
+,"MARATHON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CARBON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SAWYER, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAUPACA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"DUNN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASHLAND, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"CLALLAM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WYOMING, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,14
+,,No value,10 or fewer
+,,Total,20
+,"SAN JUAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CALHOUN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,11
+,,No value,10 or fewer
+,,Total,14
+,"CAMPBELL, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NATRONA, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,14
+,"WOOD, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRANT, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,11
+,"WESTON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"GOSHEN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LEWIS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,12
+,"GREEN LAKE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GRAYS HARBOR, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHBURN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MASON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"VILAS, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAYNE, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LAFAYETTE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LOGAN, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PACIFIC, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PLATTE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BARRON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CLARK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KITTITAS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SHERIDAN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WALLA WALLA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FRANKLIN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"KLICKITAT, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ONEIDA, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"OKANOGAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SKAMANIA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TETON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FREMONT, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JEFFERSON, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SWEETWATER, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"MENOMINEE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"POCAHONTAS, WV",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PORTAGE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"UINTA, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"BIG HORN, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"RUSK, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ASOTIN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CROOK, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WHITMAN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PRICE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"STEVENS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"CONVERSE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FLORENCE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FOREST, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LANGLADE, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"SUBLETTE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"TAYLOR, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WASHAKIE, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"WAHKIAKUM, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"IRON, WI",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"LINCOLN, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"HOT SPRINGS, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"JOHNSON, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"COLUMBIA, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"NIOBRARA, WY",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"FERRY, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"PEND OREILLE, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"ADAMS, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,"GARFIELD, WA",Less than 18 Years,10 or fewer
+,,≥ 18 and < 25 Years,10 or fewer
+,,≥ 25 and < 35 Years,10 or fewer
+,,≥ 35 and < 45 Years,10 or fewer
+,,≥ 45 and < 55 Years,10 or fewer
+,,≥ 55 and < 65 Years,10 or fewer
+,,65 Years or more,10 or fewer
+,,No value,10 or fewer
+,,Total,10 or fewer
+,None of the above,Less than 18 Years,70
+,,≥ 18 and < 25 Years,17
+,,≥ 25 and < 35 Years,25
+,,≥ 35 and < 45 Years,34
+,,≥ 45 and < 55 Years,36
+,,≥ 55 and < 65 Years,95
+,,65 Years or more,485
+,,No value,10 or fewer
+,,Total,762
+,Total,Less than 18 Years,2956
+,,≥ 18 and < 25 Years,690
+,,≥ 25 and < 35 Years,1174
+,,≥ 35 and < 45 Years,1425
+,,≥ 45 and < 55 Years,2023
+,,≥ 55 and < 65 Years,3850
+,,65 Years or more,20511
+,,No value,10 or fewer
+,,Total,32629


### PR DESCRIPTION
new files for:

FALLS
ED encounters with ICD10 codes W00*-W19*
by County
by Year
by Age <65, 65+

OPIOID OVERDOSE
ED encounters with OPIOID OVERDOSE grouper (981 diagnoses included)
by County
by Year
by Age <18, 18-45, 45-65, 65+