### PR TITLE
Keep payer column in medicaid_quality bundle builds (fixes 27% dup-key rows in youth_wellbeing)

### DIFF
--- a/data/bundle_cancer_screening/build.R
+++ b/data/bundle_cancer_screening/build.R
@@ -9,7 +9,7 @@ medicaid_data <- vroom::vroom('../medicaid_quality/standard/data.csv.gz')
 
 medicaid_cancer <- medicaid_data %>%
   filter(geography_level == 's') %>%
-  dplyr::select(geography, time, age, sex, race_ethnicity,
+  dplyr::select(geography, time, age, sex, race_ethnicity, payer,
                 medicaid_bcs_ad_rate,
                 medicaid_ccs_ad_rate,
                 medicaid_col_ad_rate) %>%
@@ -30,7 +30,7 @@ medicaid_cancer <- medicaid_data %>%
   ) %>%
   filter(!is.na(value),
          geography %in% c(state.name, "District of Columbia")) %>%
-  dplyr::select(geography, year, age, sex, race_ethnicity, outcome_name, source, value)
+  dplyr::select(geography, year, age, sex, race_ethnicity, payer, outcome_name, source, value)
 
 write_parquet(medicaid_cancer, './dist/medicaid_cancer_screening.parquet')
 

--- a/data/bundle_injury_overdose/build.R
+++ b/data/bundle_injury_overdose/build.R
@@ -447,7 +447,7 @@ firearms_by_source_year <- firearms_by_source %>%
 ## Medicaid injury and overdose
 vroom::vroom('../medicaid_quality/standard/data.csv.gz') %>%
   filter(geography_level == 's') %>%
-  dplyr::select(geography, time, age, sex, race_ethnicity,
+  dplyr::select(geography, time, age, sex, race_ethnicity, payer,
                 medicaid_oud_ad_rate,
                 medicaid_iet_ad_rate,
                 medicaid_fua_ad_30d_rate,
@@ -470,7 +470,7 @@ vroom::vroom('../medicaid_quality/standard/data.csv.gz') %>%
   ) %>%
   filter(!is.na(value),
          geography %in% c(state.name, "District of Columbia")) %>%
-  dplyr::select(geography, year, age, sex, race_ethnicity, outcome_name, source, value) %>%
+  dplyr::select(geography, year, age, sex, race_ethnicity, payer, outcome_name, source, value) %>%
   arrow::write_parquet('./dist/medicaid_injury_overdose.parquet')
 
 firearms_by_source_year %>%

--- a/data/bundle_preventative_services/build.R
+++ b/data/bundle_preventative_services/build.R
@@ -9,7 +9,7 @@ medicaid_data <- vroom::vroom('../medicaid_quality/standard/data.csv.gz')
 ## Medicaid preventative services
 medicaid_data %>%
   filter(geography_level == 's') %>%
-  dplyr::select(geography, time, age, sex, race_ethnicity,
+  dplyr::select(geography, time, age, sex, race_ethnicity, payer,
                 medicaid_fva_ad_rate,
                 medicaid_chl_ad_rate,
                 medicaid_ha1c_ad_rate,
@@ -34,7 +34,7 @@ medicaid_data %>%
   ) %>%
   filter(!is.na(value),
          geography %in% c(state.name, "District of Columbia")) %>%
-  dplyr::select(geography, year, age, sex, race_ethnicity, outcome_name, source, value) %>%
+  dplyr::select(geography, year, age, sex, race_ethnicity, payer, outcome_name, source, value) %>%
   arrow::write_parquet('dist/medicaid_preventative_services.parquet')
 
 

--- a/data/bundle_youth_wellbeing/build.R
+++ b/data/bundle_youth_wellbeing/build.R
@@ -9,7 +9,7 @@ medicaid_data <- vroom::vroom('../medicaid_quality/standard/data.csv.gz')
 ## Medicaid youth wellbeing
 medicaid_data %>%
   filter(geography_level == 's') %>%
-  dplyr::select(geography, time, age, sex, race_ethnicity,
+  dplyr::select(geography, time, age, sex, race_ethnicity, payer,
                 medicaid_awc_ch_rate,
                 medicaid_dev_ch_rate,
                 medicaid_wcc_ch_rate,
@@ -42,7 +42,7 @@ medicaid_data %>%
   ) %>%
   filter(!is.na(value),
          geography %in% c(state.name, "District of Columbia")) %>%
-  dplyr::select(geography, year, age, sex, race_ethnicity, outcome_name, source, value) %>%
+  dplyr::select(geography, year, age, sex, race_ethnicity, payer, outcome_name, source, value) %>%
   arrow::write_parquet('dist/medicaid_youth_wellbeing.parquet')
 
 


### PR DESCRIPTION
## Summary

The four `bundle_*/build.R` files that read from `medicaid_quality/standard/data.csv.gz` drop the `payer` column at the first `dplyr::select()`. Since `payer` is part of the source's primary key (set in `medicaid_quality/ingest.R:235` from CMS `population`), this collapses distinct rows.

## Impact

`bundle_youth_wellbeing/dist/medicaid_youth_wellbeing.parquet` currently has **834 of 3037 rows (27.5%)** with duplicate `(geography, year, age, sex, race_ethnicity, outcome_name, source)` keys but **different `value`s** — because child-health metrics are reported for both `payer=Medicaid` and `payer=CHIP`, with no `Total` row.

Example — Alabama, 2014, Adolescent Well-Care Visits:
| geography | year | outcome_name | source | value | (dropped payer) |
|---|---|---|---|---|---|
| Alabama | 2014 | Adolescent Well-Care Visits | Medicaid | 41.5 | Medicaid |
| Alabama | 2014 | Adolescent Well-Care Visits | Medicaid | 31.1 | CHIP |

Downstream consumers can't tell which value is which.

The other three bundles (`cancer_screening`, `preventative_services`, `injury_overdose`) use the same pattern and are **latently affected** — clean today only because adult metrics currently have a single payer value per key.

## Fix

Add `payer` to both `select()` calls in each of the four build scripts (8 lines). Verified: with `payer` retained, output has 0 duplicate keys and no data loss.

Alternative considered: filter to `payer == 'Total'` — not viable, child metrics have no Total row. Filter to `payer == 'Medicaid'` — drops 486 valid CHIP rows.

## Verification

```python
import pandas as pd
df = pd.read_parquet('data/bundle_youth_wellbeing/dist/medicaid_youth_wellbeing.parquet')
key = ['geography','year','age','sex','race_ethnicity','outcome_name','source']
dups = df.groupby(key).filter(lambda g: g['value'].nunique() > 1)
print(f'{len(dups)}/{len(df)} rows in dup-key groups')  # → 834/3037 before, 0 after
```

---
Found while building the [PopHIVE MCP server](https://github.com/DISSC-yale/sp-pophive-mcp) catalog. Happy to adjust the approach if you'd prefer a different output schema.
