### PR TITLE
Fixing PAC leak in MMR coverage

### DIFF
--- a/data/bundle_childhood_immunizations/build.R
+++ b/data/bundle_childhood_immunizations/build.R
@@ -44,7 +44,7 @@ nis_insurance <- vroom::vroom('../nis/standard/data_insurance.csv.gz') %>%
 ############################################################
 #Compare Epic Cosmos ( 1dose), NIS (1+ doses),and Epic (1+ dose)
 vaxview <- vroom::vroom('../schoolvaxview/standard/data.csv.gz') %>%
-  filter(grepl('mmr', vax) & time == '2023-09-01') %>%
+  filter(vax == 'mmr' & time == '2023-09-01') %>%
   rename(value_vaxview = value,
          vaxview_survey_type = survey_type) %>%
   dplyr::select(value_vaxview, geography,vaxview_survey_type) %>%

--- a/data/schoolvaxview/ingest.R
+++ b/data/schoolvaxview/ingest.R
@@ -84,7 +84,7 @@ if (!identical(process$raw_state, raw_state)) {
   
 
     vroom::vroom_write(
-      data,
+      vax2,
       "standard/data.csv.gz",
       ","
     )


### PR DESCRIPTION
- Fix schoolvaxview standard output to exclude PAC and exemption rows
- Write filtered vax2 instead of data in ingest.R; use vax == 'mmr' match in build.R